### PR TITLE
Restore inverse highlighting on 128x64 screens

### DIFF
--- a/src/gui/320x240x16/_label.c
+++ b/src/gui/320x240x16/_label.c
@@ -41,9 +41,14 @@ void GUI_DrawLabelHelper(u16 obj_x, u16 obj_y, u16 obj_w, u16 obj_h, const char 
     }
     else if (desc->style == LABEL_FILL) {
         LCD_FillRect(obj_x, obj_y, obj_w, obj_h, desc->fill_color);
-    } else {
+    }
+    else if (desc->style == LABEL_INVERTED || is_selected) {
+        LCD_FillRect(obj_x, obj_y, obj_w, obj_h, 0xffff);
+    }
+    else {
         GUI_DrawBackground(obj_x, obj_y, obj_w, obj_h);
     }
+
     if (desc->fill_color != desc->outline_color) {
         LCD_DrawRect(obj_x, obj_y, obj_w, obj_h, desc->outline_color);
         obj_x+=2; obj_w-=4;

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -46,6 +46,7 @@ enum LabelType {
     LABEL_CENTER,
     LABEL_FILL,
     LABEL_TRANSPARENT,
+    LABEL_INVERTED,
     LABEL_LEFT,
     LABEL_RIGHT,
     LABEL_BOX,
@@ -53,7 +54,7 @@ enum LabelType {
     LABEL_SQUAREBOX,
     LABEL_BRACKET,
     LABEL_UNDERLINE,
-    LABEL_INVERTED,
+
 #endif
 
 };


### PR DESCRIPTION
Commit 8bdf8668 removed code that indicates selected box by inverting background.  This change restores the highlighting.

Other cosmetic changes on the Devo7e and 10 were also introduced with 8bdf but are not affected by this PR.
- Labels in page heading (top row) are centered instead of left-justified
- Top row underline missing on mixer list and mixer channel pages.
Maybe others...