### PR TITLE
Cc2500revsal

### DIFF
--- a/src/config/hardware.c
+++ b/src/config/hardware.c
@@ -31,6 +31,7 @@ const char HAPTIC_ENABLE[] = "enable-haptic";
 static const char SECTION_MODULES[] = "modules";
 static const char MODULE_ENABLE_PIN[] = "enable";
 static const char MODULE_HAS_PA[] = "has_pa";
+static const char MODULE_SWAP_CONTROL[] = "swap_control";
 const char * const MODULE_NAME[TX_MODULE_LAST] = {
       [CYRF6936] = "CYRF6936",
       [A7105]    = "A7105",

--- a/src/config/hardware.c
+++ b/src/config/hardware.c
@@ -100,6 +100,15 @@ static int ini_handler(void* user, const char* section, const char* name, const 
                return 1;
             }
         }
+        if(MATCH_START(name, MODULE_SWAP_CONTROL)) {
+            int pin = get_module_index(name+sizeof(MODULE_SWAP_CONTROL));
+            if(pin >= 0) {
+               int v = value_int ? 1 : 0;
+               Transmitter.module_swap_control = (Transmitter.module_swap_control & ~(1 << pin)) | (v << pin);
+               return 1;
+            }
+        }
+ 
     }
     return 0;
 }

--- a/src/config/hardware.c
+++ b/src/config/hardware.c
@@ -109,7 +109,6 @@ static int ini_handler(void* user, const char* section, const char* name, const 
                return 1;
             }
         }
- 
     }
     return 0;
 }

--- a/src/config/tx.h
+++ b/src/config/tx.h
@@ -72,6 +72,7 @@ struct Transmitter {
     struct TouchCalibration touch;
     struct AutoDimmer auto_dimmer;
     struct CountDownTimerSettings countdown_timer_settings;
+    u8 module_swap_control;
 };
 
 extern struct Transmitter Transmitter;

--- a/src/protocol/spi/cc2500.c
+++ b/src/protocol/spi/cc2500.c
@@ -96,15 +96,22 @@ void CC2500_WriteData(u8 *dpbuffer, u8 len)
 
 void CC2500_SetTxRxMode(enum TXRX_State mode)
 {
+    int R0 = CC2500_02_IOCFG0;
+    int R2 = CC2500_00_IOCFG2;
+    if (Transmitter.module_swap_control && (1 << CC2500)) {
+      R0 = CC2500_00_IOCFG2;
+      R2 = CC2500_02_IOCFG0;
+    }
+
     if(mode == TX_EN) {
-        CC2500_WriteReg(CC2500_02_IOCFG0, 0x2F | 0x40);
-        CC2500_WriteReg(CC2500_00_IOCFG2, 0x2F);
+        CC2500_WriteReg(R0, 0x2F | 0x40);
+        CC2500_WriteReg(R2, 0x2F);
     } else if (mode == RX_EN) {
-        CC2500_WriteReg(CC2500_02_IOCFG0, 0x2F);
-        CC2500_WriteReg(CC2500_00_IOCFG2, 0x2F | 0x40);
+        CC2500_WriteReg(R0, 0x2F);
+        CC2500_WriteReg(R2, 0x2F | 0x40);
     } else {
-        CC2500_WriteReg(CC2500_02_IOCFG0, 0x2F);
-        CC2500_WriteReg(CC2500_00_IOCFG2, 0x2F);
+        CC2500_WriteReg(R0, 0x2F);
+        CC2500_WriteReg(R2, 0x2F);
     }
 }
 


### PR DESCRIPTION
This is for CC2500 RF modules with GDO0 connected to RX_EN of PA/LNA and GD02 to TX_EN i.e. inverted, onboard. I have 2 of those from ebay. And another deviationtx member hit the same issue found this useful too.   To correct the inversion, add a line containing "swap_control-cc2500 = 1" into hardware.ini.  Without the fix, connection dropped a few feet away even with TX set to maximum output.