### PR TITLE
Add E010 format to MJXq protocol

### DIFF
--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -195,7 +195,8 @@ static void send_packet(u8 bind)
     case FORMAT_E010:
         packet[10] = GET_FLAG(CHANNEL_HEADLESS, 0x01)
                    | GET_FLAG(CHANNEL_RTH, 0x02);
-        if (!bind) packet[14] = 0;
+        if (!bind) 
+            packet[14] = GET_FLAG(CHANNEL_FLIP, 0x04);
         break;
         
     case FORMAT_H26D:

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -412,12 +412,8 @@ static void initialize_txid()
     // Pump zero bytes for LFSR to diverge more
     for (u8 i = 0; i < sizeof(lfsr); ++i) rand32_r(&lfsr, 0);
 
-    if( Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_E010) {
-        txid[0] = 0x90;
-        txid[1] = 0x1c;
-        txid[2] = 0x00;
-    }
-    else if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_WLH08) {
+    if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_WLH08
+      ||Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_E010 ) {
         // txid must be multiple of 8
         txid[0] = (lfsr >> 16) & 0xf8;
         txid[1] = (lfsr >> 8 ) & 0xff;

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -192,17 +192,11 @@ static void send_packet(u8 bind)
 
     packet[14] = 0xc0;  // bind value
     switch (Model.proto_opts[PROTOOPTS_FORMAT]) {
-    case FORMAT_E010:
-        packet[10] = GET_FLAG(CHANNEL_HEADLESS, 0x01)
-                   | GET_FLAG(CHANNEL_RTH, 0x02);
-        if (!bind) 
-            packet[14] = GET_FLAG(CHANNEL_FLIP, 0x04);
-        break;
-        
     case FORMAT_H26D:
         packet[10] = pan_tilt_value();
         // fall through on purpose - no break
     case FORMAT_WLH08:
+    case FORMAT_E010:
         packet[10] += GET_FLAG(CHANNEL_RTH, 0x02)
                     | GET_FLAG(CHANNEL_HEADLESS, 0x01);
         if (!bind) {

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -58,7 +58,7 @@
 #define ADDRESS_LENGTH     5
 
 static const char * const mjxq_opts[] = {
-  _tr_noop("Format"), "WLH08", "X600", "X800", "H26D", NULL,
+  _tr_noop("Format"), "WLH08", "X600", "X800", "H26D", "E010", NULL,
   NULL
 };
 enum {
@@ -70,6 +70,7 @@ enum {
     FORMAT_X600,
     FORMAT_X800,
     FORMAT_H26D,
+    FORMAT_E010,
 };
 ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
 
@@ -191,6 +192,12 @@ static void send_packet(u8 bind)
 
     packet[14] = 0xc0;  // bind value
     switch (Model.proto_opts[PROTOOPTS_FORMAT]) {
+    case FORMAT_E010:
+        packet[10] = GET_FLAG(CHANNEL_HEADLESS, 0x01)
+                   | GET_FLAG(CHANNEL_RTH, 0x02);
+        if (!bind) packet[14] = 0;
+        break;
+        
     case FORMAT_H26D:
         packet[10] = pan_tilt_value();
         // fall through on purpose - no break
@@ -279,7 +286,7 @@ static void mjxq_init()
     memcpy(rx_tx_addr, "\x6d\x6a\x77\x77\x77", sizeof(rx_tx_addr));
     if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_WLH08) {
         memcpy(rf_channels, "\x12\x22\x32\x42", sizeof(rf_channels));
-    } else if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H26D) {
+    } else if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H26D || Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_E010) {
         memcpy(rf_channels, "\x36\x3e\x46\x2e", sizeof(rf_channels));
     } else {
         memcpy(rf_channels, "\x0a\x35\x42\x3d", sizeof(rf_channels));
@@ -309,7 +316,10 @@ static void mjxq_init()
     NRF24L01_WriteReg(NRF24L01_02_EN_RXADDR, 0x01);
     NRF24L01_WriteReg(NRF24L01_04_SETUP_RETR, 0x00); // no retransmits
     NRF24L01_WriteReg(NRF24L01_11_RX_PW_P0, PACKET_SIZE);
-    NRF24L01_SetBitrate(NRF24L01_BR_1M);             // 1Mbps
+    if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_E010)
+        NRF24L01_SetBitrate(NRF24L01_BR_250K);             // 250kbps
+    else
+        NRF24L01_SetBitrate(NRF24L01_BR_1M);             // 1Mbps
     NRF24L01_SetPower(Model.tx_power);
     NRF24L01_Activate(0x73);                          // Activate feature register
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);       // Disable dynamic payload length on all pipes
@@ -350,7 +360,7 @@ static void mjxq_init2()
 {
     if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H26D) {
         memcpy(rf_channels, "\x32\x3e\x42\x4e", sizeof(rf_channels));
-    } else if (Model.proto_opts[PROTOOPTS_FORMAT] != FORMAT_WLH08) {
+    } else if (Model.proto_opts[PROTOOPTS_FORMAT] != FORMAT_WLH08 && Model.proto_opts[PROTOOPTS_FORMAT] != FORMAT_E010) {
         memcpy(rf_channels, mjx_tx_rf_map[Model.fixed_id % (sizeof(mjx_tx_rf_map)/sizeof(mjx_tx_rf_map[0]))].rfchan, sizeof(rf_channels));
     }
 }
@@ -407,7 +417,12 @@ static void initialize_txid()
     // Pump zero bytes for LFSR to diverge more
     for (u8 i = 0; i < sizeof(lfsr); ++i) rand32_r(&lfsr, 0);
 
-    if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_WLH08) {
+    if( Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_E010) {
+        txid[0] = 0x90;
+        txid[1] = 0x1c;
+        txid[2] = 0x00;
+    }
+    else if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_WLH08) {
         // txid must be multiple of 8
         txid[0] = (lfsr >> 16) & 0xf8;
         txid[1] = (lfsr >> 8 ) & 0xff;


### PR DESCRIPTION
Add E010 format to MJXq protocol, compatible with EAchine E010, NuHui NH-010 and probably JJRC H36 mini.

- Channel 6: flip mode
- Channel 9: Headless
- Channel 10: RTH