### PR TITLE
Update Frsky to fix hub telemetry

### DIFF
--- a/src/protocol/frsky2way_cc2500.c
+++ b/src/protocol/frsky2way_cc2500.c
@@ -165,6 +165,10 @@ static void frsky2way_build_bind_packet()
     packet[17] = 0x01;
 }
 
+#if HAS_EXTENDED_TELEMETRY
+static u8 sequence;
+#endif
+
 static void frsky2way_build_data_packet()
 {
     //11 d7 2d 22 00 01 c9 c9 ca ca 88 88 ca ca c9 ca 88 88
@@ -173,7 +177,11 @@ static void frsky2way_build_data_packet()
     packet[1] = fixed_id & 0xff;
     packet[2] = fixed_id >> 8;
     packet[3] = counter;
+#if HAS_EXTENDED_TELEMETRY
+    packet[4] = sequence;   // acknowledge last hub packet
+#else
     packet[4] = 0x00;
+#endif
     packet[5] = 0x01;
 
     packet[10] = 0;
@@ -305,16 +313,14 @@ static void frsky2way_parse_telem(u8 *pkt, int len)
 
 #if HAS_EXTENDED_TELEMETRY
 
-    static u8 sequence;
-
     if (pkt[0] < 7) return;   // be paranoid about packet length
 
     if (pkt[6] && pkt[6] <= pkt[0]-7) {   // be paranoid about packet length
+        sequence = (sequence + 1) % 32;
         if (pkt[7] != sequence) {
             ts_state = TS_IDLE;
             sequence = pkt[7];    // should be able to recover in middle of sequence
         }
-        sequence = (sequence + 1) % 8;
             
         for(int i=8; i < 8+pkt[6]; i++)
             frsky_parse_telem_stream(pkt[i]);
@@ -451,6 +457,7 @@ static void initialize(int bind)
     fixed_id = get_tx_id();
 #if HAS_EXTENDED_TELEMETRY
     ts_state = TS_IDLE;
+    sequence = 8;
 #endif
     frsky2way_init(bind);
     if (bind) {

--- a/src/protocol/frsky2way_cc2500.c
+++ b/src/protocol/frsky2way_cc2500.c
@@ -276,7 +276,7 @@ static void frsky2way_parse_telem(u8 *pkt, int len)
 // pkt 4 = A2 : 13.4mV per count; 3.0V = 0xE3 on D6FR
 // pkt 5 = RSSI
 // pkt 6 = number of stream bytes
-// pkt 7 = sequence number increments mod 8 with each packet containing stream data
+// pkt 7 = sequence number increments mod 32 when packet containing stream data acknowledged
 // pkt 8-(8+(pkt[6]-1)) = stream data
 // pkt len-2 = downlink RSSI
 // pkt len-1 = crc status (bit7 set indicates good), link quality indicator (bits6-0)

--- a/src/protocol/spi/cc2500.c
+++ b/src/protocol/spi/cc2500.c
@@ -105,8 +105,8 @@ void CC2500_SetTxRxMode(enum TXRX_State mode)
     }
 
     if(mode == TX_EN) {
-        CC2500_WriteReg(R0, 0x2F | 0x40);
         CC2500_WriteReg(R2, 0x2F);
+        CC2500_WriteReg(R0, 0x2F | 0x40);
     } else if (mode == RX_EN) {
         CC2500_WriteReg(R0, 0x2F);
         CC2500_WriteReg(R2, 0x2F | 0x40);


### PR DESCRIPTION
When receiving hub telemetry the receiver expects the sequence number in the telemetry packet to be echoed back in packet[4] of transmitted packets.  Without this acknowledgement the D4R-II receiver only cycles through 0-7 sequence numbers and repeats unacknowledged data.  When the proper response is sent the D4R-II cycles the sequence number 0-31 without repeating data.

The change to CC2500_SetTxRxMode() turns off the LNA before enabling the PA when entering transmit mode.  Wasn't causing a problem; just good practice.
