### PR TITLE
Fix initialize telemetry and set telemetry type for Frsky

### DIFF
--- a/src/protocol/frsky2way_cc2500.c
+++ b/src/protocol/frsky2way_cc2500.c
@@ -460,6 +460,10 @@ static void initialize(int bind)
     sequence = 8;
 #endif
     frsky2way_init(bind);
+
+    memset(&Telemetry, 0, sizeof(Telemetry));
+    TELEMETRY_SetType(TELEM_FRSKY);
+
     if (bind) {
         PROTOCOL_SetBindState(0xFFFFFFFF);
         state = FRSKY_BIND;

--- a/src/protocol/frskyx_cc2500.c
+++ b/src/protocol/frskyx_cc2500.c
@@ -849,6 +849,9 @@ static void initialize(int bind)
     frskyX_init(); 
     CC2500_SetTxRxMode(TX_EN);  // enable PA 
 
+    memset(&Telemetry, 0, sizeof(Telemetry));
+    TELEMETRY_SetType(TELEM_FRSKY);
+
     if (bind) {
         PROTOCOL_SetBindState(0xFFFFFFFF);
         state = FRSKY_BIND;


### PR DESCRIPTION
Properly initialize telemetry and set telemetry type by protocol, not by modelXX.ini file