### PR TITLE
Add CX10D & CX10WD formats to Q303 protocol

### DIFF
--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -379,7 +379,7 @@ static void send_packet(u8 bind)
             case FORMAT_CX10D:
                 packet[8] |= GET_FLAG(CHANNEL_FLIP, 0x10);
                 packet[9] = 0x02; // rate (0-2)
-                packet[10]= 00; // ???
+                packet[10]= cx10wd_getButtons(); // auto land / take off management
                 break;
                 
             case FORMAT_CX10WD:

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -290,6 +290,7 @@ static void send_packet(u8 bind)
                 break;
             
             case FORMAT_CX10D:
+            case FORMAT_CX10WD:
                 aileron  = scale_channel(CHANNEL1, 1000, 2000);
                 elevator = scale_channel(CHANNEL2, 1000, 2000);
                 throttle = scale_channel(CHANNEL3, 1000, 2000);

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -292,9 +292,9 @@ static void send_packet(u8 bind)
             case FORMAT_CX10D:
             case FORMAT_CX10WD:
                 aileron  = scale_channel(CHANNEL1, 1000, 2000);
-                elevator = scale_channel(CHANNEL2, 1000, 2000);
+                elevator = scale_channel(CHANNEL2, 2000, 1000);
                 throttle = scale_channel(CHANNEL3, 1000, 2000);
-                rudder   = scale_channel(CHANNEL4, 1000, 2000);
+                rudder   = scale_channel(CHANNEL4, 2000, 1000);
                 
                 packet[1] = aileron & 0xff;
                 packet[2] = aileron >> 8;

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -157,6 +157,7 @@ static u16 scale_channel(u8 ch, u16 destMin, u16 destMax)
 static u8 cx10wd_getButtons()
 {
     #define CX10WD_FLAG_LAND    0x20
+    #define CX10D_FLAG_LAND     0x80
     #define CX10WD_FLAG_TAKEOFF 0x40
     
     static u8 btn_state;
@@ -173,7 +174,14 @@ static u8 cx10wd_getButtons()
     else if(GET_FLAG_LOW(CHANNEL_ARM,1) && !(btn_state & BTN_DESCEND)) {
         btn_state |= BTN_DESCEND;
         btn_state &= ~BTN_TAKEOFF;
-        command ^= CX10WD_FLAG_LAND;
+        switch(Model.proto_opts[PROTOOPTS_FORMAT]) {
+            case FORMAT_CX10WD:
+                command ^= CX10WD_FLAG_LAND;
+                break;
+            case FORMAT_CX10D:
+                command ^= CX10D_FLAG_LAND;
+                break;
+        }
     }
     
     // auto take off

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -96,7 +96,7 @@ enum {
     CHANNEL2,       // Elevator
     CHANNEL3,       // Throttle
     CHANNEL4,       // Rudder
-    CHANNEL5,       // Altitude Hold
+    CHANNEL5,       // Altitude Hold or Take off / Descend
     CHANNEL6,       // Flip
     CHANNEL7,       // Still Camera
     CHANNEL8,       // Video Camera
@@ -106,7 +106,7 @@ enum {
 };
 
 #define CHANNEL_AHOLD    CHANNEL5  // Q303
-#define CHANNEL_ARM      CHANNEL5  // CX35
+#define CHANNEL_ARM      CHANNEL5  // CX35, CX10WD
 #define CHANNEL_FLIP     CHANNEL6
 #define CHANNEL_VTX      CHANNEL6  // CX35
 #define CHANNEL_SNAPSHOT CHANNEL7
@@ -342,8 +342,10 @@ static void send_packet(u8 bind)
                 break;
                 
             case FORMAT_CX10WD:
-                packet[9] = 0x60; // high rate ? (0x00-0x40-0x60)
-                packet[10] = 0;
+                packet[8] |= GET_FLAG(CHANNEL_FLIP, 0x10);
+                packet[9]  = GET_FLAG(CHANNEL_ARM, 0x60)
+                           | 0x02; // rate (0-2)
+                packet[10] = 0x00;
                 break;
         }
     }

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -300,14 +300,14 @@ static void send_packet(u8 bind)
                 throttle = scale_channel(CHANNEL3, 1000, 2000);
                 rudder   = scale_channel(CHANNEL4, 1000, 2000);
                 
-                packet[1] = aileron >> 8;
-                packet[2] = aileron & 0xff;
-                packet[3] = elevator >> 8;
-                packet[4] = elevator & 0xff;
-                packet[5] = throttle >> 8;
-                packet[6] = throttle & 0xff;
-                packet[7] = rudder >> 8;
-                packet[8] = rudder & 0xff;    
+                packet[1] = aileron & 0xff;
+                packet[2] = aileron >> 8;
+                packet[3] = elevator & 0xff;
+                packet[4] = elevator >> 8;
+                packet[5] = throttle & 0xff;
+                packet[6] = throttle >> 8;
+                packet[7] = rudder & 0xff;
+                packet[8] = rudder >> 8;
                 break;
         }
         


### PR DESCRIPTION
Add CX10D & CX10WD formats to Q303 protocol, also add (semi) arbitrary transmitter ID for CX35.

Channel 5: auto land (below 0) / manual (0) / auto take off (above 0)
Channel 6: flip

Forums thread: https://www.deviationtx.com/forum/protocol-development/6448-cx-10d-traces 
