### PR TITLE
Add CX10D & CX10WD formats to Q303 protocol, from goebish

### DIFF
--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -44,21 +44,17 @@
     #define BIND_COUNT 4
     #define dbgprintf printf
 #else
-    #define BIND_COUNT 2335
+    #define BIND_COUNT 1500
     //printf inside an interrupt handler is really dangerous
     //this shouldn't be enabled even in debug builds without explicitly
     //turning it on
     #define dbgprintf if(0) printf
 #endif
 
-#define PACKET_SIZE  10
-#define Q303_PACKET_PERIOD   1500  // Timeout for callback in uSec
-#define CX35_PACKET_PERIOD   3000
-#define INITIAL_WAIT     500
-#define RF_BIND_CHANNEL 0x02
-#define NUM_RF_CHANNELS    4
+#define INITIAL_WAIT          500
+#define RF_BIND_CHANNEL      0x02
 
-static u8 packet[PACKET_SIZE];
+static u8 packet[11];
 static u8 phase;
 static u16 bind_counter;
 static u32 packet_counter;
@@ -66,8 +62,10 @@ static u8 tx_power;
 static u8 tx_addr[5];
 static u8 current_chan;
 static u8 txid[4];
-static u8 rf_chans[4];
+static u8 rf_chans[16];
 static u16 packet_period;
+static u8 packet_size;
+static u8 num_rf_channels;
 
 enum {
     BIND,
@@ -75,7 +73,7 @@ enum {
 };
 
 static const char * const q303_opts[] = {
-    _tr_noop("Format"), "Q303", "CX35", NULL, 
+    _tr_noop("Format"), "Q303", "CX35", "CX10D", "CX10WD", NULL, 
     NULL
 };
 
@@ -87,6 +85,8 @@ enum {
 enum {
     FORMAT_Q303 = 0,
     FORMAT_CX35,
+    FORMAT_CX10D,
+    FORMAT_CX10WD,
 };
 ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
 
@@ -96,8 +96,8 @@ enum {
     CHANNEL2,       // Elevator
     CHANNEL3,       // Throttle
     CHANNEL4,       // Rudder
-    CHANNEL5,       // Altitude Hold
-    CHANNEL6,       // Flip
+    CHANNEL5,       // Altitude Hold or Take off / Descend
+    CHANNEL6,       // Flip or Vtx channel increment (CX35)
     CHANNEL7,       // Still Camera
     CHANNEL8,       // Video Camera
     CHANNEL9,       // Headless
@@ -106,7 +106,7 @@ enum {
 };
 
 #define CHANNEL_AHOLD    CHANNEL5  // Q303
-#define CHANNEL_ARM      CHANNEL5  // CX35
+#define CHANNEL_ARM      CHANNEL5  // CX35 (2 pos: land/take off), CX10D/WD (3 pos: land/manual/take off)
 #define CHANNEL_FLIP     CHANNEL6
 #define CHANNEL_VTX      CHANNEL6  // CX35
 #define CHANNEL_SNAPSHOT CHANNEL7
@@ -115,20 +115,8 @@ enum {
 #define CHANNEL_RTH      CHANNEL10
 #define CHANNEL_GIMBAL   CHANNEL11
 
-// flags going to packet[8] (Q303)
-#define FLAG_HIGHRATE 0x03
-#define FLAG_AHOLD    0x40
-#define FLAG_RTH      0x80
-
-// flags going to packet[9] (Q303)
-#define FLAG_GIMBAL_DN 0x04
-#define FLAG_GIMBAL_UP 0x20
-#define FLAG_HEADLESS  0x08
-#define FLAG_FLIP      0x80
-#define FLAG_SNAPSHOT  0x10
-#define FLAG_VIDEO     0x01
-
 #define GET_FLAG(ch, mask) (Channels[ch] > 0 ? mask : 0)
+#define GET_FLAG_LOW(ch, mask) (Channels[ch] < 0 ? mask : 0)
 
 // Bit vector from bit position
 #define BV(bit) (1 << bit)
@@ -146,36 +134,76 @@ static u16 scale_channel(u8 ch, u16 destMin, u16 destMax)
     return (range * (chanval - CHAN_MIN_VALUE)) / CHAN_RANGE + destMin;
 }
 
+#define BTN_TAKEOFF  1
+#define BTN_DESCEND  2
+#define BTN_SNAPSHOT 4
+#define BTN_VIDEO    8
+#define BTN_RTH      16
+#define BTN_VTX      32
+
+static u8 cx10wd_getButtons()
+{
+    #define CX10WD_FLAG_LAND    0x20
+    #define CX10D_FLAG_LAND     0x80
+    #define CX10WD_FLAG_TAKEOFF 0x40
+    
+    static u8 btn_state;
+    static u8 command;
+    
+    // startup
+    if(packet_counter < 50) {
+        btn_state = 0;
+        command = 0;
+        packet_counter++;
+    }
+    
+    // auto land
+    else if(GET_FLAG_LOW(CHANNEL_ARM,1) && !(btn_state & BTN_DESCEND)) {
+        btn_state |= BTN_DESCEND;
+        btn_state &= ~BTN_TAKEOFF;
+        switch(Model.proto_opts[PROTOOPTS_FORMAT]) {
+            case FORMAT_CX10WD:
+                command ^= CX10WD_FLAG_LAND;
+                break;
+            case FORMAT_CX10D:
+                command ^= CX10D_FLAG_LAND;
+                break;
+        }
+    }
+    
+    // auto take off
+    else if(GET_FLAG(CHANNEL_ARM,1) && !(btn_state & BTN_TAKEOFF)) {
+        btn_state |= BTN_TAKEOFF;
+        btn_state &= ~BTN_DESCEND;
+        command ^= CX10WD_FLAG_TAKEOFF;
+    }
+    
+    return command;
+}
+
 static u8 cx35_lastButton()
 {
-    #define BTN_TAKEOFF  1
-    #define BTN_DESCEND  2
-    #define BTN_SNAPSHOT 4
-    #define BTN_VIDEO    8
-    #define BTN_RTH      16
-    #define BTN_VTX      32
-
-    #define CMD_RATE     0x09
-    #define CMD_TAKEOFF  0x0e
-    #define CMD_DESCEND  0x0f
-    #define CMD_SNAPSHOT 0x0b
-    #define CMD_VIDEO    0x0c
-    #define CMD_RTH      0x11
-    #define CMD_VTX      0x10
+    #define CX35_CMD_RATE     0x09
+    #define CX35_CMD_TAKEOFF  0x0e
+    #define CX35_CMD_DESCEND  0x0f
+    #define CX35_CMD_SNAPSHOT 0x0b
+    #define CX35_CMD_VIDEO    0x0c
+    #define CX35_CMD_RTH      0x11
+    #define CX35_CMD_VTX      0x10
     
-    static u8 cx35_btn_state;
+    static u8 btn_state;
     static u8 command;
     static u8 vtx_channel;
     // simulate 2 keypress on rate button just after bind
     if(packet_counter < 50) {
-        cx35_btn_state = 0;
+        btn_state = 0;
         vtx_channel = 0;
         packet_counter++;
         command = 0x00; // startup
     }
     else if(packet_counter < 150) {
         packet_counter++;
-        command = CMD_RATE; // 1st keypress
+        command = CX35_CMD_RATE; // 1st keypress
     }
     else if(packet_counter < 250) {
         packet_counter++;
@@ -183,75 +211,75 @@ static u8 cx35_lastButton()
     }
     
     // descend
-    else if(!(GET_FLAG(CHANNEL_ARM, 1)) && !(cx35_btn_state & BTN_DESCEND)) {
-        cx35_btn_state |= BTN_DESCEND;
-        cx35_btn_state &= ~BTN_TAKEOFF;
-        command = CMD_DESCEND;
+    else if(!(GET_FLAG(CHANNEL_ARM, 1)) && !(btn_state & BTN_DESCEND)) {
+        btn_state |= BTN_DESCEND;
+        btn_state &= ~BTN_TAKEOFF;
+        command = CX35_CMD_DESCEND;
     }
         
     // take off
-    else if(GET_FLAG(CHANNEL_ARM,1) && !(cx35_btn_state & BTN_TAKEOFF)) {
-        cx35_btn_state |= BTN_TAKEOFF;
-        cx35_btn_state &= ~BTN_DESCEND;
-        command = CMD_TAKEOFF;
+    else if(GET_FLAG(CHANNEL_ARM,1) && !(btn_state & BTN_TAKEOFF)) {
+        btn_state |= BTN_TAKEOFF;
+        btn_state &= ~BTN_DESCEND;
+        command = CX35_CMD_TAKEOFF;
     }
     
     // RTH
-    else if(GET_FLAG(CHANNEL_RTH,1) && !(cx35_btn_state & BTN_RTH)) {
-        cx35_btn_state |= BTN_RTH;
-        if(command == CMD_RTH)
+    else if(GET_FLAG(CHANNEL_RTH,1) && !(btn_state & BTN_RTH)) {
+        btn_state |= BTN_RTH;
+        if(command == CX35_CMD_RTH)
             command |= 0x20;
         else
-            command = CMD_RTH;
+            command = CX35_CMD_RTH;
     }
-    else if(!(GET_FLAG(CHANNEL_RTH,1)) && (cx35_btn_state & BTN_RTH)) {
-        cx35_btn_state &= ~BTN_RTH;
-        if(command == CMD_RTH)
+    else if(!(GET_FLAG(CHANNEL_RTH,1)) && (btn_state & BTN_RTH)) {
+        btn_state &= ~BTN_RTH;
+        if(command == CX35_CMD_RTH)
             command |= 0x20;
         else
-            command = CMD_RTH;
+            command = CX35_CMD_RTH;
     }
     
     // video
-    else if(GET_FLAG(CHANNEL_VIDEO,1) && !(cx35_btn_state & BTN_VIDEO)) {
-        cx35_btn_state |= BTN_VIDEO;
-        if(command == CMD_VIDEO)
+    else if(GET_FLAG(CHANNEL_VIDEO,1) && !(btn_state & BTN_VIDEO)) {
+        btn_state |= BTN_VIDEO;
+        if(command == CX35_CMD_VIDEO)
             command |= 0x20;
         else
-            command = CMD_VIDEO;
+            command = CX35_CMD_VIDEO;
     }
-    else if(!(GET_FLAG(CHANNEL_VIDEO,1)) && (cx35_btn_state & BTN_VIDEO)) {
-        cx35_btn_state &= ~BTN_VIDEO;
-        if(command == CMD_VIDEO)
+    else if(!(GET_FLAG(CHANNEL_VIDEO,1)) && (btn_state & BTN_VIDEO)) {
+        btn_state &= ~BTN_VIDEO;
+        if(command == CX35_CMD_VIDEO)
             command |= 0x20;
         else
-            command = CMD_VIDEO;
+            command = CX35_CMD_VIDEO;
     }
     
     // snapshot
-    else if(GET_FLAG(CHANNEL_SNAPSHOT,1) && !(cx35_btn_state & BTN_SNAPSHOT)) {
-        cx35_btn_state |= BTN_SNAPSHOT;
-        if(command == CMD_SNAPSHOT)
+    else if(GET_FLAG(CHANNEL_SNAPSHOT,1) && !(btn_state & BTN_SNAPSHOT)) {
+        btn_state |= BTN_SNAPSHOT;
+        if(command == CX35_CMD_SNAPSHOT)
             command |= 0x20;
         else
-            command = CMD_SNAPSHOT;
+            command = CX35_CMD_SNAPSHOT;
     }
         
     // vtx channel
-    else if(GET_FLAG(CHANNEL_VTX,1) && !(cx35_btn_state & BTN_VTX)) {
-        cx35_btn_state |= BTN_VTX;
+    else if(GET_FLAG(CHANNEL_VTX,1) && !(btn_state & BTN_VTX)) {
+        btn_state |= BTN_VTX;
         vtx_channel++;
         //MUSIC_Beep("d2", 100, 100, (vtx_channel & 7) + 1);
-        if(command == CMD_VTX)
+        if(command == CX35_CMD_VTX)
             command |= 0x20;
         else
-            command = CMD_VTX;
+            command = CX35_CMD_VTX;
     }
     
     if(!(GET_FLAG(CHANNEL_SNAPSHOT,1)))
-        cx35_btn_state &= ~BTN_SNAPSHOT;
+        btn_state &= ~BTN_SNAPSHOT;
     if(!(GET_FLAG(CHANNEL_VTX,1)))
-        cx35_btn_state &= ~BTN_VTX;
+        btn_state &= ~BTN_VTX;
     
     return command;
 }
@@ -262,44 +290,70 @@ static void send_packet(u8 bind)
     if(bind) {
         packet[0] = 0xaa;
         memcpy(&packet[1], txid, 4);
-        memset(&packet[5], 0, 5);
+        memset(&packet[5], 0, packet_size-5);
     }
     else {
-        aileron  = scale_channel(CHANNEL1, 1000, 0);
-        elevator = scale_channel(CHANNEL2, 1000, 0);
-        throttle = scale_channel(CHANNEL3, 0, 1000);
-        rudder   = scale_channel(CHANNEL4, 0, 1000);
-        
-        if(Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_CX35)
-            aileron = 1000 - aileron;
-        
         packet[0] = 0x55;
-        packet[1] = aileron >> 2;          // 8 bits
-        packet[2] = (aileron & 0x03) << 6  // 2 bits
-                  | (elevator >> 4);       // 6 bits
-        packet[3] = (elevator & 0x0f) << 4 // 4 bits
-                  | (throttle >> 6);       // 4 bits
-        packet[4] = (throttle & 0x3f) << 2 // 6 bits 
-                  | (rudder >> 8);         // 2 bits
-        packet[5] = rudder & 0xff;         // 8 bits
         
+        // sticks
+        switch(Model.proto_opts[PROTOOPTS_FORMAT]) {
+            case FORMAT_Q303:
+            case FORMAT_CX35:
+                aileron  = scale_channel(CHANNEL1, 1000, 0);
+                elevator = scale_channel(CHANNEL2, 1000, 0);
+                throttle = scale_channel(CHANNEL3, 0, 1000);
+                rudder   = scale_channel(CHANNEL4, 0, 1000);
+                
+                if(Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_CX35)
+                    aileron = 1000 - aileron;
+                
+                packet[1] = aileron >> 2;          // 8 bits
+                packet[2] = (aileron & 0x03) << 6  // 2 bits
+                          | (elevator >> 4);       // 6 bits
+                packet[3] = (elevator & 0x0f) << 4 // 4 bits
+                          | (throttle >> 6);       // 4 bits
+                packet[4] = (throttle & 0x3f) << 2 // 6 bits 
+                          | (rudder >> 8);         // 2 bits
+                packet[5] = rudder & 0xff;         // 8 bits
+                break;
+            
+            case FORMAT_CX10D:
+            case FORMAT_CX10WD:
+                aileron  = scale_channel(CHANNEL1, 1000, 2000);
+                elevator = scale_channel(CHANNEL2, 2000, 1000);
+                throttle = scale_channel(CHANNEL3, 1000, 2000);
+                rudder   = scale_channel(CHANNEL4, 2000, 1000);
+                
+                packet[1] = aileron & 0xff;
+                packet[2] = aileron >> 8;
+                packet[3] = elevator & 0xff;
+                packet[4] = elevator >> 8;
+                packet[5] = throttle & 0xff;
+                packet[6] = throttle >> 8;
+                packet[7] = rudder & 0xff;
+                packet[8] = rudder >> 8;
+                break;
+        }
+        
+        // buttons
         switch(Model.proto_opts[PROTOOPTS_FORMAT]) {
             case FORMAT_Q303:
                 packet[6] = 0x10; // trim(s) ?
                 packet[7] = 0x10; // trim(s) ?
                 packet[8] = 0x03  // high rate (0-3)
-                          | GET_FLAG(CHANNEL_AHOLD, FLAG_AHOLD)
-                          | GET_FLAG(CHANNEL_RTH, FLAG_RTH);
+                          | GET_FLAG(CHANNEL_AHOLD,   0x40)
+                          | GET_FLAG(CHANNEL_RTH,     0x80);
                 packet[9] = 0x40 // always set
-                          | GET_FLAG(CHANNEL_HEADLESS, FLAG_HEADLESS)
-                          | GET_FLAG(CHANNEL_FLIP, FLAG_FLIP)
-                          | GET_FLAG(CHANNEL_SNAPSHOT, FLAG_SNAPSHOT)
-                          | GET_FLAG(CHANNEL_VIDEO, FLAG_VIDEO);
+                          | GET_FLAG(CHANNEL_HEADLESS,0x08)
+                          | GET_FLAG(CHANNEL_FLIP,    0x80)
+                          | GET_FLAG(CHANNEL_SNAPSHOT,0x10)
+                          | GET_FLAG(CHANNEL_VIDEO,   0x01);
                 if(Channels[CHANNEL_GIMBAL] < CHAN_MIN_VALUE / 2)
-                    packet[9] |= FLAG_GIMBAL_DN;
+                    packet[9] |= 0x04; // gimbal down
                 else if(Channels[CHANNEL_GIMBAL] > CHAN_MAX_VALUE / 2)
-                    packet[9] |= FLAG_GIMBAL_UP;
+                    packet[9] |= 0x20; // gimbal up
                 break;
+                
             case FORMAT_CX35:
                 slider = scale_channel(CHANNEL_GIMBAL, 731, 342);
                 packet[6] = slider >> 2;
@@ -308,6 +362,19 @@ static void send_packet(u8 bind)
                 packet[8] = 0x80; // always set
                 packet[9] = cx35_lastButton();
                 break;
+                
+            case FORMAT_CX10D:
+                packet[8] |= GET_FLAG(CHANNEL_FLIP, 0x10);
+                packet[9] = 0x02; // rate (0-2)
+                packet[10]= cx10wd_getButtons(); // auto land / take off management
+                break;
+                
+            case FORMAT_CX10WD:
+                packet[8] |= GET_FLAG(CHANNEL_FLIP, 0x10);
+                packet[9]  = 0x02  // rate (0-2)
+                           | cx10wd_getButtons(); // auto land / take off management
+                packet[10] = 0x00;
+                break;
         }
     }
     
@@ -315,12 +382,12 @@ static void send_packet(u8 bind)
     XN297_Configure(BV(NRF24L01_00_EN_CRC) | BV(NRF24L01_00_CRCO) | BV(NRF24L01_00_PWR_UP));
 
     NRF24L01_WriteReg(NRF24L01_05_RF_CH, bind ? RF_BIND_CHANNEL : rf_chans[current_chan++]);
-    current_chan %= NUM_RF_CHANNELS;
+    current_chan %= num_rf_channels;
 
     NRF24L01_WriteReg(NRF24L01_07_STATUS, 0x70);
     NRF24L01_FlushTx();
 
-    XN297_WritePayload(packet, PACKET_SIZE);
+    XN297_WritePayload(packet, packet_size);
 
     // Check and adjust transmission power. We do this after
     // transmission to not bother with timeout after power
@@ -339,13 +406,17 @@ static void q303_init()
     
     NRF24L01_Initialize();
     NRF24L01_SetTxRxMode(TX_EN);
-    if(Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_CX35) {
-        XN297_SetScrambledMode(XN297_SCRAMBLED);
-        NRF24L01_SetBitrate(NRF24L01_BR_1M);
-    }
-    else { // Q303
-        XN297_SetScrambledMode(XN297_UNSCRAMBLED);
-        NRF24L01_SetBitrate(NRF24L01_BR_250K);
+    switch(Model.proto_opts[PROTOOPTS_FORMAT]) {
+        case FORMAT_CX35:
+        case FORMAT_CX10D:
+        case FORMAT_CX10WD:
+            XN297_SetScrambledMode(XN297_SCRAMBLED);
+            NRF24L01_SetBitrate(NRF24L01_BR_1M);
+            break;
+        case FORMAT_Q303:
+            XN297_SetScrambledMode(XN297_UNSCRAMBLED);
+            NRF24L01_SetBitrate(NRF24L01_BR_250K);
+            break;
     }
     XN297_SetTXAddr(bind_address, 5);
     NRF24L01_FlushTx();
@@ -440,18 +511,33 @@ static void initialize_txid()
 
     for(i=0; i<4; i++)
         txid[i] = (lfsr >> (i*8)) & 0xff;
-    offset = txid[0] & 3;
-    if(Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_CX35) {        
-        // not figured out txid/channels for CX35 yet, use a known pair
-        memcpy(txid, (u8*) "\x24\x37\x46\x89", 4);
-        offset = 0;
-        
-        for(i=0; i<NUM_RF_CHANNELS; i++)
-            rf_chans[i] = 0x14 + i*3 + offset;
-    }
-    else{ // Q303
-        for(i=0; i<NUM_RF_CHANNELS; i++)
-            rf_chans[i] = 0x46 + i*2 + offset;
+    
+    switch(Model.proto_opts[PROTOOPTS_FORMAT]) {
+        case FORMAT_Q303:
+        case FORMAT_CX10WD:
+            offset = txid[0] & 3;
+            for(i=0; i<4; i++)
+                rf_chans[i] = 0x46 + i*2 + offset;
+            break;
+        case FORMAT_CX35:
+        case FORMAT_CX10D:
+            // not thoroughly figured out txid/channels mapping yet
+            // for now 5 msb of txid[0] must be cleared
+            txid[0] &= 7;
+            offset = 6+((txid[0] & 7)*3);
+            rf_chans[0] = 0x14; // works only if txid[0] < 8
+            for(i=1; i<16; i++) {
+                rf_chans[i] = rf_chans[i-1] + offset;
+                if(rf_chans[i] > 0x41)
+                    rf_chans[i] -= 0x33;
+                if(rf_chans[i] < 0x14)
+                    rf_chans[i] += offset;
+            }
+            // cx35 tx uses only 4 of those channels (#0,3,6,9)
+            if(Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_CX35)
+                for(i=0; i<4; i++)
+                    rf_chans[i] = rf_chans[i*3];
+            break;
     }
 }
 
@@ -462,10 +548,28 @@ static void initialize()
     initialize_txid();
     q303_init();
     bind_counter = BIND_COUNT;
-    if(Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_Q303)
-        packet_period = Q303_PACKET_PERIOD;
-    else if(Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_CX35)
-        packet_period = CX35_PACKET_PERIOD;
+    switch(Model.proto_opts[PROTOOPTS_FORMAT]) {
+        case FORMAT_Q303:
+            packet_period = 1500;
+            packet_size = 10;
+            num_rf_channels = 4;
+            break;
+        case FORMAT_CX35:
+            packet_period = 3000;
+            packet_size = 10;
+            num_rf_channels = 4;
+            break;
+        case FORMAT_CX10D:
+            packet_period = 3000;
+            packet_size = 11;
+            num_rf_channels = 16;
+            break;
+        case FORMAT_CX10WD:
+            packet_period = 3000;
+            packet_size = 11;
+            num_rf_channels = 4;
+            break;
+    }
     current_chan = 0;
     PROTOCOL_SetBindState(BIND_COUNT * packet_period / 1000);
     phase = BIND;


### PR DESCRIPTION
Add CX10D & CX10WD formats to Q303 protocol, also add (semi) arbitrary transmitter ID for CX35.

Channel 5: auto land (below 0) / manual (0) / auto take off (above 0)
Channel 6: flip

Forums thread: https://www.deviationtx.com/forum/protocol-development/6448-cx-10d-traces