### PR TITLE
Fix change model icon

### DIFF
--- a/src/pages/common/model_page.h
+++ b/src/pages/common/model_page.h
@@ -16,7 +16,7 @@ struct model_page {
     u8 last_mixermode;
     u8 last_txpower;
 /*Load save */
-    u16 total_items;
+    u8 total_items;
     u8 menu_type;
     enum ModelType modeltype;
 };


### PR DESCRIPTION
With "u16 total_items" devo10 emulator crashed if I try to change default model icon. With "u8 total_items" it is OK.

It was changed from "u8" to "u16" with "Pull Request #128: Increase maximum number of model files from 100 to 255"