### PR TITLE
Fix XY-graph placeholder overlay "Splash" page for Devo F12E

### DIFF
--- a/src/target/devof12e/tw8816.c
+++ b/src/target/devof12e/tw8816.c
@@ -155,6 +155,9 @@ void TW8816_Init()
     window = 0;
     //for(int i = 0; i < 24; i++)
     //    TW8816_DisplayCharacter(i, 'A' + i, 7);
+    
+    //Hide XY Graph placeholder
+    TW8816_UnmapWindow(0);
 }
 
 void TW8816_Reset()


### PR DESCRIPTION
At boot time empty XY-graph placeholder overlay "Splash" and "Safety Warning" pages and cut off portion of image.