### PR TITLE
Fix "text" GUI "Standard" - "Curves" pages

### DIFF
--- a/src/pages/128x64x1/standard/common_standard.c
+++ b/src/pages/128x64x1/standard/common_standard.c
@@ -13,10 +13,27 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef OVERRIDE_PLACEMENT
 #include "common.h"
 #include "gui/gui.h"
 #include "config/model.h"
 #include "../pages.h"
+
+enum {
+    //"Reverse", "Subtrim" and "Fail-safe" pages
+    LABEL_X        = 63,
+    LABEL_W        = 60,
+    //"Throttle curve" and "Pitch curve" pages XY-graph points
+    #define LINE_Y LINE_SPACE
+    WIDTH1         = 5,
+    WIDTH2         = 32,
+    WIDTH2_ADD     = 2,
+    LINE_H         = 9,
+    LINE_H_OFFS    = 1,
+    M_LABEL_X      = 20,
+    M_LEBEL_Y_OFFS = 0,
+};
+#endif //OVERRIDE_PLACEMENT
 
 #if HAS_STANDARD_GUI
 #include "standard.h"
@@ -24,17 +41,16 @@
 
 static struct stdchan_obj * const gui = &gui_objs.u.stdchan;
 
+//"Reverse", "Subtrim" and "Fail-safe" pages
 static int row_cb(int absrow, int relrow, int y, void *data)
 {
     struct page_defs *page_defs = (struct page_defs *)data;
     (void)data;
-    u8 w = 60;
-    u8 x = 63;
 
     GUI_CreateLabelBox(&gui->name[relrow], 0, y,
             0, LINE_HEIGHT, &DEFAULT_FONT, STDMIX_channelname_cb, NULL, (void *)(long)absrow);
-    GUI_CreateTextSelectPlate(&gui->value[relrow], x, y,
-            w, LINE_HEIGHT, &DEFAULT_FONT, page_defs->tgl, page_defs->value, (void *)(long)absrow);
+    GUI_CreateTextSelectPlate(&gui->value[relrow], LABEL_X, y,
+            LABEL_W, LINE_HEIGHT, &DEFAULT_FONT, page_defs->tgl, page_defs->value, (void *)(long)absrow);
     return 1;
 }
 
@@ -48,56 +64,57 @@ void STANDARD_Init(const struct page_defs *page_defs)
     GUI_SetSelected(GUI_ShowScrollableRowOffset(&gui->scrollable, 0));
 }
 
+//"Throttle curve" and "Pitch curve" pages XY-graph points
 void STANDARD_DrawCurvePoints(guiLabel_t vallbl[], guiTextSelect_t val[],
         u8 selectable_bitmap,
         void (*press_cb)(guiObject_t *obj, void *data),
         const char *(*set_pointval_cb)(guiObject_t *obj, int value, void *data))
 {
-    u8 y = LINE_SPACE;
-    u8 w1 = 5;
-    u8 w2 = 32;
+    u8 y  = LINE_Y;
+    u8 w1 = WIDTH1;
+    u8 w2 = WIDTH2;
     u8 x = 0;
-    u8 height = 9;
+    u8 height = LINE_H;
     GUI_CreateLabelBox(&vallbl[0], x, y,  w1, height, &TINY_FONT, NULL, NULL, "L");
     x += w1;
     GUI_CreateTextSelectPlate(&val[0], x, y, w2, height, &TINY_FONT, NULL, set_pointval_cb, (void *)(long)0);
-    x += w2 + 2;
+    x += w2 + WIDTH2_ADD;
     GUI_CreateLabelBox(&vallbl[8], x, y,  w1, height, &TINY_FONT, NULL, NULL, "H");
     x += w1;
     GUI_CreateTextSelectPlate(&val[8], x, y, w2, height, &TINY_FONT, NULL, set_pointval_cb, (void *)(long)8);
 
-    y += height +1;
-    x = 20;
+    y += height + LINE_H_OFFS + M_LEBEL_Y_OFFS;
+    x = M_LABEL_X;
     GUI_CreateLabelBox(&vallbl[4], x, y,  w1, height, &TINY_FONT, NULL, NULL, "M");
     x += w1;
     GUI_CreateTextSelectPlate(&val[4], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)4);
 
-    y += height +1;
+    y += height + LINE_H_OFFS + M_LEBEL_Y_OFFS;
     x = 0;
     GUI_CreateLabelBox(&vallbl[1], x, y,  w1, height, &TINY_FONT, NULL, NULL, "2");
     x += w1;
     GUI_CreateTextSelectPlate(&val[1], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)1);
-    x += w2 + 2;
+    x += w2 + WIDTH2_ADD;
     GUI_CreateLabelBox(&vallbl[2], x, y,  w1, height, &TINY_FONT, NULL, NULL, "3");
     x += w1;
     GUI_CreateTextSelectPlate(&val[2], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)2);
 
-    y += height +1;
+    y += height + LINE_H_OFFS;
     x = 0;
     GUI_CreateLabelBox(&vallbl[3], x, y,  w1, height, &TINY_FONT, NULL, NULL, "4");
     x += w1;
     GUI_CreateTextSelectPlate(&val[3], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)3);
-    x += w2 + 2;
+    x += w2 + WIDTH2_ADD;
     GUI_CreateLabelBox(&vallbl[5], x, y,  w1, height, &TINY_FONT, NULL, NULL, "6");
     x += w1;
     GUI_CreateTextSelectPlate(&val[5], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)5);
 
-    y += height +1;
+    y += height + LINE_H_OFFS;
     x = 0;
     GUI_CreateLabelBox(&vallbl[6], x, y,  w1, height, &TINY_FONT, NULL, NULL, "7");
     x += w1;
     GUI_CreateTextSelectPlate(&val[6], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)6);
-    x += w2 + 2;
+    x += w2 + WIDTH2_ADD;
     GUI_CreateLabelBox(&vallbl[7], x, y,  w1, height, &TINY_FONT, NULL, NULL, "8");
     x += w1;
     GUI_CreateTextSelectPlate(&val[7], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)7);
@@ -105,7 +122,7 @@ void STANDARD_DrawCurvePoints(guiLabel_t vallbl[], guiTextSelect_t val[],
     //update_textsel_state();
     for (u8 i = 1; i < 8; i++) {
         GUI_TextSelectEnablePress(&val[i], 1);
-        if (selectable_bitmap >> (i-1) & 0x01) {
+        if (selectable_bitmap >> (i - 1) & 0x01) {
             GUI_TextSelectEnable(&val[i], 1);
         } else {
             GUI_TextSelectEnable(&val[i], 0);

--- a/src/pages/128x64x1/standard/curves_page.c
+++ b/src/pages/128x64x1/standard/curves_page.c
@@ -13,6 +13,7 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef OVERRIDE_PLACEMENT
 #include "common.h"
 #include "../pages.h"
 #include "gui/gui.h"
@@ -20,6 +21,20 @@
 #include "mixer.h"
 #include "mixer_standard.h"
 #include "standard.h"
+
+enum {
+    MESSAGE_Y    = 10,
+    HEADER1_X    = 32,
+    HEADER1_W    = 59,
+    HEADER2_X    = 92,
+    HEADER2_W    = 36,
+    SCROLL_W     = 76,
+    GRAPH_X      = 77,
+    #define GRAPH_Y HEADER_HEIGHT
+    GRAPH_W      = 50,
+    GRAPH_H      = 50,
+};
+#endif //OVERRIDE_PLACEMENT
 
 #if HAS_STANDARD_GUI
 #include "../../common/standard/_curves_page.c"
@@ -45,7 +60,7 @@ static void update_textsel_state()
         if(! state && i > 0 && i < 8) {
             u8 selectable_bitmap = selectable_bitmaps[curve_mode * 4 + pit_mode];
             GUI_TextSelectEnablePress(&gui->val[i], 1);
-            if (selectable_bitmap >> (i-1) & 0x01) {
+            if (selectable_bitmap >> (i - 1) & 0x01) {
                 GUI_TextSelectEnable(&gui->val[i], 1);
             } else {
                 GUI_TextSelectEnable(&gui->val[i], 0);
@@ -59,9 +74,9 @@ static void press_cb(guiObject_t *obj, void *data)
 {
     u8 point_num = (long)data;
     u8 *selectable_bitmap = &selectable_bitmaps[curve_mode * 4 + pit_mode];
-    if (*selectable_bitmap >> (point_num-1) & 0x01) {
+    if (*selectable_bitmap >> (point_num - 1) & 0x01) {
         GUI_TextSelectEnable((guiTextSelect_t *)obj, 0);
-        *selectable_bitmap &= ~(1 << (point_num-1));
+        *selectable_bitmap &= ~(1 << (point_num - 1));
         auto_generate_cb(NULL, NULL);
     } else {
         GUI_TextSelectEnable((guiTextSelect_t *)obj, 1);
@@ -88,7 +103,7 @@ static void show_page(CurvesMode _curve_mode, int page)
     }
     expected = INPUT_NumSwitchPos(mapped_std_channels.switches[SWITCHFUNC_FLYMODE]) + pit_hold_state;
     if (count != expected) {
-        GUI_CreateLabelBox(&gui->msg, 0, 10, 0, LINE_HEIGHT, &DEFAULT_FONT, NULL, NULL, "Invalid model ini!");// must be invalid model ini
+        GUI_CreateLabelBox(&gui->msg, 0, MESSAGE_Y, 0, LINE_HEIGHT, &DEFAULT_FONT, NULL, NULL, "Invalid model ini!");// must be invalid model ini
         return;
     }
 
@@ -96,15 +111,15 @@ static void show_page(CurvesMode _curve_mode, int page)
     PAGE_ShowHeader(_tr("Mode"));
     
     // FIXME: need a special value for header button/textsels
-    GUI_CreateTextSelectPlate(&gui->mode, 32, 0, 59, HEADER_WIDGET_HEIGHT, &DEFAULT_FONT, NULL, set_mode_cb, (void *)(long)curve_mode);
-    GUI_CreateTextSelectPlate(&gui->hold, 92, 0, 36, HEADER_WIDGET_HEIGHT, &DEFAULT_FONT, NULL, set_holdstate_cb, NULL);
+    GUI_CreateTextSelectPlate(&gui->mode, HEADER1_X, 0, HEADER1_W, HEADER_WIDGET_HEIGHT, &DEFAULT_FONT, NULL, set_mode_cb, (void *)(long)curve_mode);
+    GUI_CreateTextSelectPlate(&gui->hold, HEADER2_X, 0, HEADER2_W, HEADER_WIDGET_HEIGHT, &DEFAULT_FONT, NULL, set_holdstate_cb, NULL);
     if (pit_mode != PITTHROMODE_HOLD)
         GUI_SetHidden((guiObject_t *)&gui->hold, 1);
 
     STANDARD_DrawCurvePoints(gui->vallbl, gui->val,
         selectable_bitmaps[curve_mode * 4 + pit_mode], press_cb, set_pointval_cb);
 
-    GUI_CreateXYGraph(&gui->graph, 77, HEADER_HEIGHT, 50, 50,
+    GUI_CreateXYGraph(&gui->graph, GRAPH_X, GRAPH_Y, GRAPH_W, GRAPH_H,
                       CHAN_MIN_VALUE, CHAN_MIN_VALUE,
                       CHAN_MAX_VALUE, CHAN_MAX_VALUE,
                       0, 0, //CHAN_MAX_VALUE / 4, CHAN_MAX_VALUE / 4,

--- a/src/pages/128x64x1/standard/drexp_page.c
+++ b/src/pages/128x64x1/standard/drexp_page.c
@@ -13,6 +13,7 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef OVERRIDE_PLACEMENT
 #include "common.h"
 #include "../pages.h"
 #include "gui/gui.h"
@@ -20,6 +21,20 @@
 #include "mixer.h"
 #include "mixer_standard.h"
 #include "standard.h"
+
+enum {
+    LABEL2_WIDTH = 30,
+    LABEL3_X     = 31,
+    LABEL3_WIDTH = 36,
+    MESSAGE_Y    = 10,
+    HEADER_W     = 60,
+    SCROLL_W     = 76,
+    GRAPH_X      = 77,
+    #define GRAPH_Y HEADER_HEIGHT
+    GRAPH_W      = 50,
+    GRAPH_H      = 50,
+};
+#endif //OVERRIDE_PLACEMENT
 
 #if HAS_STANDARD_GUI
 #include "../../common/standard/_drexp_page.c"
@@ -42,16 +57,15 @@ void update_graph(int graph)
 static int row_cb(int absrow, int relrow, int y, void *data)
 {
     (void)data;
-    u8 w1 = 30;
-    u8 w2 = 36;
 
     GUI_CreateLabelBox(&gui->label[relrow], 0, y,
         0, LINE_HEIGHT, &DEFAULT_FONT, NULL, NULL, STDMIX_ModeName(absrow - PITTHROMODE_NORMAL));
     y += LINE_SPACE;
     GUI_CreateTextSelectPlate(&gui->value1[relrow], 0, y,
-        w1, LINE_HEIGHT, &TINY_FONT, NULL, set_dr_cb, (void *)(long)(absrow - PITTHROMODE_NORMAL));
-    GUI_CreateTextSelectPlate(&gui->value2[relrow], w1+1, y,
-        w2, LINE_HEIGHT, &TINY_FONT, NULL, set_exp_cb, (void *)(long)(absrow - PITTHROMODE_NORMAL));
+        LABEL2_WIDTH, LINE_HEIGHT, &TINY_FONT, NULL, set_dr_cb, (void *)(long)(absrow - PITTHROMODE_NORMAL));
+    GUI_CreateTextSelectPlate(&gui->value2[relrow], LABEL3_X, y,
+        LABEL3_WIDTH, LINE_HEIGHT, &TINY_FONT, NULL, set_exp_cb, (void *)(long)(absrow - PITTHROMODE_NORMAL));
+    
     return 2;
 }
 
@@ -63,17 +77,17 @@ void PAGE_DrExpInit(int page)
     PAGE_ShowHeader("");
     memset(mp, 0, sizeof(*mp));
     int count = get_mixers();
-    int expected = INPUT_NumSwitchPos(mapped_std_channels.switches[SWITCHFUNC_DREXP_AIL+drexp_type]);
+    int expected = INPUT_NumSwitchPos(mapped_std_channels.switches[SWITCHFUNC_DREXP_AIL + drexp_type]);
     if (count != expected) {
-        GUI_CreateLabelBox(&gui->u.msg, 0, 10, 0, LINE_HEIGHT, &DEFAULT_FONT, NULL, NULL, "Invalid model ini!");// must be invalid model ini
+        GUI_CreateLabelBox(&gui->u.msg, 0, MESSAGE_Y, 0, LINE_HEIGHT, &DEFAULT_FONT, NULL, NULL, "Invalid model ini!"); // must be invalid model ini
         return;
     }
-    GUI_CreateTextSelectPlate(&gui->u.type, 0, 0, 60, HEADER_WIDGET_HEIGHT,
+    GUI_CreateTextSelectPlate(&gui->u.type, 0, 0, HEADER_W, HEADER_WIDGET_HEIGHT,
                      &DEFAULT_FONT, NULL, set_type_cb, (void *)NULL);
-    GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, 76, LCD_HEIGHT - HEADER_HEIGHT,
+    GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, SCROLL_W, LCD_HEIGHT - HEADER_HEIGHT,
                      2 * LINE_SPACE, count, row_cb, NULL, NULL, NULL);
 
-    GUI_CreateXYGraph(&gui->graph, 77, HEADER_HEIGHT, 50, 50,
+    GUI_CreateXYGraph(&gui->graph, GRAPH_X, GRAPH_Y, GRAPH_W, GRAPH_H,
             CHAN_MIN_VALUE, CHAN_MIN_VALUE, CHAN_MAX_VALUE, CHAN_MAX_VALUE,
             0, 0, show_curve_cb, curpos_cb, NULL, NULL);
 
@@ -94,4 +108,5 @@ void PAGE_DrExpCurvesEvent()
         }
     }
 }
+
 #endif //HAS_STANDARD_GUI

--- a/src/pages/text/standard/common_standard.c
+++ b/src/pages/text/standard/common_standard.c
@@ -18,116 +18,19 @@
 #include "config/model.h"
 #include "../pages.h"
 
-#if HAS_STANDARD_GUI
-#include "standard.h"
-#include "../../common/standard/_common_standard.c"
-
-static struct stdchan_obj * const gui = &gui_objs.u.stdchan;
-
-static unsigned _action_cb(u32 button, unsigned flags, void *data);
-
-static int row_cb(int absrow, int relrow, int y, void *data)
-{
-    struct page_defs *page_defs = (struct page_defs *)data;
-    (void)data;
-    u8 w = 10*ITEM_SPACE;
-    u8 x = 10*ITEM_SPACE;
-
-    GUI_CreateLabelBox(&gui->name[relrow], 0, y,
-            0, ITEM_HEIGHT, &DEFAULT_FONT, STDMIX_channelname_cb, NULL, (void *)(long)absrow);
-    GUI_CreateTextSelectPlate(&gui->value[relrow], x, y,
-            w, ITEM_HEIGHT, &DEFAULT_FONT, page_defs->tgl, page_defs->value, (void *)(long)absrow);
-    return 1;
-}
-
-void STANDARD_Init(const struct page_defs *page_defs)
-{
-    PAGE_SetActionCB(_action_cb);
-    PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
-    PAGE_ShowHeader(_tr(page_defs->title));
-    GUI_CreateScrollable(&gui->scrollable, 0, ITEM_HEIGHT + 1, LCD_WIDTH, LCD_HEIGHT - ITEM_HEIGHT -1,
-                     ITEM_SPACE, Model.num_channels, row_cb, NULL, NULL, (void *)page_defs);
-    GUI_SetSelected(GUI_ShowScrollableRowOffset(&gui->scrollable, 0));
-}
-
-static unsigned _action_cb(u32 button, unsigned flags, void *data)
-{
-    (void)data;
-    if ((flags & BUTTON_PRESS) || (flags & BUTTON_LONGPRESS)) {
-        if (CHAN_ButtonIsPressed(button, BUT_EXIT)) {
-            PAGE_ChangeByID(PAGEID_MENU, PREVIOUS_ITEM);
-        }
-        else {
-            // only one callback can handle a button press, so we don't handle BUT_ENTER here, let it handled by press cb
-            return 0;
-        }
-    }
-    return 1;
-}
-
-void STANDARD_DrawCurvePoints(guiLabel_t vallbl[], guiTextSelect_t val[],
-        u8 selectable_bitmap,
-        void (*press_cb)(guiObject_t *obj, void *data),
-        const char *(*set_pointval_cb)(guiObject_t *obj, int value, void *data))
-{
-    u8 y = ITEM_SPACE;
-    u8 w1 = 5;
-    u8 w2 = 32;
-    u8 x = 0;
-    u8 height = 9;
-    GUI_CreateLabelBox(&vallbl[0], x, y,  w1, height, &TINY_FONT, NULL, NULL, "L");
-    x += w1;
-    GUI_CreateTextSelectPlate(&val[0], x, y, w2, height, &TINY_FONT, NULL, set_pointval_cb, (void *)(long)0);
-    x += w2 + 2;
-    GUI_CreateLabelBox(&vallbl[8], x, y,  w1, height, &TINY_FONT, NULL, NULL, "H");
-    x += w1;
-    GUI_CreateTextSelectPlate(&val[8], x, y, w2, height, &TINY_FONT, NULL, set_pointval_cb, (void *)(long)8);
-
-    y += height;
-    x = 20;
-    GUI_CreateLabelBox(&vallbl[4], x, y + 3,  w1, height, &TINY_FONT, NULL, NULL, "M");
-    x += w1;
-    GUI_CreateTextSelectPlate(&val[4], x, y +3, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)4);
-
-    y += ITEM_SPACE;
-    x = 0;
-    GUI_CreateLabelBox(&vallbl[1], x, y,  w1, height, &TINY_FONT, NULL, NULL, "2");
-    x += w1;
-    GUI_CreateTextSelectPlate(&val[1], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)1);
-    x += w2 + 2;
-    GUI_CreateLabelBox(&vallbl[2], x, y,  w1, height, &TINY_FONT, NULL, NULL, "3");
-    x += w1;
-    GUI_CreateTextSelectPlate(&val[2], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)2);
-
-    y += height +1;
-    x = 0;
-    GUI_CreateLabelBox(&vallbl[3], x, y,  w1, height, &TINY_FONT, NULL, NULL, "4");
-    x += w1;
-    GUI_CreateTextSelectPlate(&val[3], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)3);
-    x += w2 + 2;
-    GUI_CreateLabelBox(&vallbl[5], x, y,  w1, height, &TINY_FONT, NULL, NULL, "6");
-    x += w1;
-    GUI_CreateTextSelectPlate(&val[5], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)5);
-
-    y += height +1;
-    x = 0;
-    GUI_CreateLabelBox(&vallbl[6], x, y,  w1, height, &TINY_FONT, NULL, NULL, "7");
-    x += w1;
-    GUI_CreateTextSelectPlate(&val[6], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)6);
-    x += w2 + 2;
-    GUI_CreateLabelBox(&vallbl[7], x, y,  w1, height, &TINY_FONT, NULL, NULL, "8");
-    x += w1;
-    GUI_CreateTextSelectPlate(&val[7], x, y, w2, height, &TINY_FONT, press_cb, set_pointval_cb, (void *)(long)7);
-
-    //update_textsel_state();
-    for (u8 i = 1; i < 8; i++) {
-        GUI_TextSelectEnablePress(&val[i], 1);
-        if (selectable_bitmap >> (i-1) & 0x01) {
-            GUI_TextSelectEnable(&val[i], 1);
-        } else {
-            GUI_TextSelectEnable(&val[i], 0);
-        }
-    }
-}
-#endif //HAS_STANDARD_GUI
+#define OVERRIDE_PLACEMENT
+enum {
+    //"Reverse", "Subtrim" and "Fail-safe" pages
+    LABEL_X        = 10*ITEM_SPACE,
+    LABEL_W        = 10*ITEM_SPACE,
+    //"Throttle curve" and "Pitch curve" pages XY-graph points
+    LINE_Y         = 2*LINE_HEIGHT,
+    WIDTH1         = 3*ITEM_SPACE,
+    WIDTH2         = 5*ITEM_SPACE,
+    WIDTH2_ADD     = 3*ITEM_SPACE,
+    LINE_H         = LINE_HEIGHT,
+    LINE_H_OFFS    = 0,
+    M_LABEL_X      = 5*ITEM_SPACE,
+    M_LEBEL_Y_OFFS = LINE_HEIGHT,
+};
+#include "../../128x64x1/standard/common_standard.c"

--- a/src/pages/text/standard/curves_page.c
+++ b/src/pages/text/standard/curves_page.c
@@ -21,112 +21,16 @@
 #include "mixer_standard.h"
 #include "standard.h"
 
-#if HAS_STANDARD_GUI
-#include "../../common/standard/_curves_page.c"
-
-static unsigned _action_cb(u32 button, unsigned flags, void *data);
-static void show_page(CurvesMode curves_mode, int page);
-
-void PAGE_ThroCurvesInit(int page)
-{
-    show_page(CURVESMODE_THROTTLE, page);
-}
-
-void PAGE_PitCurvesInit(int page)
-{
-    show_page(CURVESMODE_PITCH, page);
-}
-
-static void update_textsel_state()
-{
-    int state = pit_mode == PITTHROMODE_HOLD && pit_hold_state == 0;
-    for (u8 i = 0; i < 9; i++) {
-        GUI_SetHidden((guiObject_t *)&gui->vallbl[i], state);
-        GUI_SetHidden((guiObject_t *)&gui->val[i], state);
-        if(! state && i > 0 && i < 8) {
-            u8 selectable_bitmap = selectable_bitmaps[curve_mode * 4 + pit_mode];
-            GUI_TextSelectEnablePress(&gui->val[i], 1);
-            if (selectable_bitmap >> (i-1) & 0x01) {
-                GUI_TextSelectEnable(&gui->val[i], 1);
-            } else {
-                GUI_TextSelectEnable(&gui->val[i], 0);
-            }
-        }
-    }
-    GUI_SetHidden((guiObject_t *)&gui->graph, state);
-}
-
-static void press_cb(guiObject_t *obj, void *data)
-{
-    u8 point_num = (long)data;
-    u8 *selectable_bitmap = &selectable_bitmaps[curve_mode * 4 + pit_mode];
-    if (*selectable_bitmap >> (point_num-1) & 0x01) {
-        GUI_TextSelectEnable((guiTextSelect_t *)obj, 0);
-        *selectable_bitmap &= ~(1 << (point_num-1));
-        auto_generate_cb(NULL, NULL);
-    } else {
-        GUI_TextSelectEnable((guiTextSelect_t *)obj, 1);
-        *selectable_bitmap |= 1 << (point_num-1);
-    }
-}
-
-
-static void show_page(CurvesMode _curve_mode, int page)
-{
-    (void)page;
-    PAGE_SetActionCB(_action_cb);
-    PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
-    memset(mp, 0, sizeof(*mp));
-    curve_mode = _curve_mode;
-    int count;
-    int expected;
-    if (curve_mode == CURVESMODE_PITCH) {
-        count = STDMIX_GetMixers(mp->mixer_ptr, mapped_std_channels.pitch, 4);
-        get_hold_state();
-    } else {
-        count = STDMIX_GetMixers(mp->mixer_ptr, mapped_std_channels.throttle, 4);
-        pit_hold_state = 0;
-    }
-    expected = INPUT_NumSwitchPos(mapped_std_channels.switches[SWITCHFUNC_FLYMODE]) + pit_hold_state;
-    if (count != expected) {
-        GUI_CreateLabelBox(&gui->msg, 0, 10, 0, ITEM_HEIGHT, &DEFAULT_FONT, NULL, NULL, "Invalid model ini!");// must be invalid model ini
-        return;
-    }
-
-    set_cur_mixer();
-    PAGE_ShowHeader(_tr("Mode"));
-    GUI_CreateTextSelectPlate(&gui->mode, 35, 0, 55, ITEM_HEIGHT, &DEFAULT_FONT, NULL, set_mode_cb, (void *)(long)curve_mode);
-    GUI_CreateTextSelectPlate(&gui->hold, 92, 0, 36, ITEM_HEIGHT, &DEFAULT_FONT, NULL, set_holdstate_cb, NULL);
-    if (pit_mode != PITTHROMODE_HOLD)
-        GUI_SetHidden((guiObject_t *)&gui->hold, 1);
-
-    STANDARD_DrawCurvePoints(gui->vallbl, gui->val,
-        selectable_bitmaps[curve_mode * 4 + pit_mode], press_cb, set_pointval_cb);
-
-    GUI_CreateXYGraph(&gui->graph, 77, ITEM_SPACE, 50, 50,
-                      CHAN_MIN_VALUE, CHAN_MIN_VALUE,
-                      CHAN_MAX_VALUE, CHAN_MAX_VALUE,
-                      0, 0, //CHAN_MAX_VALUE / 4, CHAN_MAX_VALUE / 4,
-                      show_curve_cb, curpos_cb, NULL, NULL);
-
-    update_textsel_state();
-    GUI_Select1stSelectableObj();
-}
-
-static unsigned _action_cb(u32 button, unsigned flags, void *data)
-{
-    (void)data;
-    //u8 total_items = 2;
-    if ((flags & BUTTON_PRESS) || (flags & BUTTON_LONGPRESS)) {
-        if (CHAN_ButtonIsPressed(button, BUT_EXIT)) {
-            PAGE_ChangeByID(PAGEID_MENU, PREVIOUS_ITEM);
-        }
-        else {
-            // only one callback can handle a button press, so we don't handle BUT_ENTER here, let it handled by press cb
-            return 0;
-        }
-    }
-    return 1;
-}
-#endif //HAS_STANDARD_GUI
+#define OVERRIDE_PLACEMENT
+enum {
+    MESSAGE_Y    = 1*LINE_HEIGHT,
+    HEADER1_X    = 7*ITEM_SPACE,
+    HEADER1_W    = 10*ITEM_SPACE,
+    HEADER2_X    = 19*ITEM_SPACE,
+    HEADER2_W    = 4*ITEM_SPACE,
+    GRAPH_X      = 46,
+    GRAPH_Y      = 5,
+    GRAPH_W      = 6,
+    GRAPH_H      = 4,
+};
+#include "../../128x64x1/standard/curves_page.c"

--- a/src/pages/text/standard/drexp_page.c
+++ b/src/pages/text/standard/drexp_page.c
@@ -21,98 +21,17 @@
 #include "mixer_standard.h"
 #include "standard.h"
 
-#if HAS_STANDARD_GUI
-#include "../../common/standard/_drexp_page.c"
-
-static unsigned _action_cb(u32 button, unsigned flags, void *data);
-
-guiObject_t *scroll_bar;
-static const int RIGHT_VIEW_HEIGHT = 60;
-static const int RIGHT_VIEW_ID  = 1;
-
+#define OVERRIDE_PLACEMENT
 enum {
-    ITEM_NORMAL,
-    ITEM_IDLE1,
-    ITEM_IDLE2,
-    ITEM_LAST,
+    LABEL2_WIDTH = 5*ITEM_SPACE,
+    LABEL3_X     = 8*ITEM_SPACE,
+    LABEL3_WIDTH = 5*ITEM_SPACE,
+    MESSAGE_Y    = 1*LINE_HEIGHT,
+    HEADER_W     = 8*ITEM_SPACE,
+    SCROLL_W     = 22*ITEM_SPACE,
+    GRAPH_X      = 46,
+    GRAPH_Y      = 5,
+    GRAPH_W      = 6,
+    GRAPH_H      = 4,
 };
-
-void update_graph(int graph)
-{
-    (void)graph;
-    GUI_Redraw(&gui->graph);
-}
-
-static int row_cb(int absrow, int relrow, int y, void *data)
-{
-    (void)data;
-    u8 w1 = 30;
-    u8 w2 = 36;
-    GUI_CreateLabelBox(&gui->label[relrow], 0, y,
-        0, ITEM_HEIGHT, &DEFAULT_FONT, NULL, NULL, STDMIX_ModeName(absrow - PITTHROMODE_NORMAL));
-    y += ITEM_SPACE;
-    GUI_CreateTextSelectPlate(&gui->value1[relrow], 0, y,
-        w1, ITEM_HEIGHT, &TINY_FONT, NULL, set_dr_cb, (void *)(long)(absrow - PITTHROMODE_NORMAL));
-    GUI_CreateTextSelectPlate(&gui->value2[relrow], w1+1, y,
-        w2, ITEM_HEIGHT, &DEFAULT_FONT, NULL, set_exp_cb, (void *)(long)(absrow - PITTHROMODE_NORMAL));
-    return 2;
-}
-
-void PAGE_DrExpInit(int page)
-{
-    (void)page;
-    PAGE_SetActionCB(_action_cb);
-    PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
-    memset(mp, 0, sizeof(*mp));
-    int count = get_mixers();
-    int expected = INPUT_NumSwitchPos(mapped_std_channels.switches[SWITCHFUNC_DREXP_AIL+drexp_type]);
-    if (count != expected) {
-        GUI_CreateLabelBox(&gui->u.msg, 0, 10, 0, ITEM_HEIGHT, &DEFAULT_FONT, NULL, NULL, "Invalid model ini!");// must be invalid model ini
-        return;
-    }
-    GUI_CreateTextSelectPlate(&gui->u.type, 0, 0,
-        60, ITEM_HEIGHT, &DEFAULT_FONT, NULL, set_type_cb, (void *)NULL);
-    GUI_CreateScrollable(&gui->scrollable, 0, ITEM_SPACE, 76, LCD_HEIGHT - ITEM_SPACE,
-                     2 *ITEM_SPACE, count, row_cb, NULL, NULL, NULL);
-
-    u16 ymax = CHAN_MAX_VALUE/100 * MAX_SCALAR;
-    s16 ymin = -ymax;
-    GUI_CreateXYGraph(&gui->graph, 77, 2, 50, RIGHT_VIEW_HEIGHT,
-            CHAN_MIN_VALUE, ymin, CHAN_MAX_VALUE, ymax,
-            0, 0, show_curve_cb, curpos_cb, NULL, NULL);
-
-    GUI_Select1stSelectableObj();
-}
-
-static void _refresh_page()
-{
-    PAGE_RemoveAllObjects();
-    PAGE_DrExpInit(0);
-}
-
-static unsigned _action_cb(u32 button, unsigned flags, void *data)
-{
-    (void)data;
-    //u8 total_items = 2;
-    if ((flags & BUTTON_PRESS) || (flags & BUTTON_LONGPRESS)) {
-        if (CHAN_ButtonIsPressed(button, BUT_EXIT)) {
-            PAGE_ChangeByID(PAGEID_MENU, PREVIOUS_ITEM);
-        }
-        else {
-            // only one callback can handle a button press, so we don't handle BUT_ENTER here, let it handled by press cb
-            return 0;
-        }
-    }
-    return 1;
-}
-
-void PAGE_DrExpCurvesEvent()
-{
-    if (OBJ_IS_USED(&gui->graph)) {
-        if(MIXER_GetCachedInputs(mp->raw, CHAN_MAX_VALUE / 100)) { // +/-1%
-            GUI_Redraw(&gui->graph);
-        }
-    }
-}
-#endif //HAS_STANDARD_GUI
+#include "../../128x64x1/standard/drexp_page.c"


### PR DESCRIPTION
I can't find the reason why "D/R & Expo" page crashed with "text" GUI, so I send it as is. At least it is not worse then before.