### PR TITLE
Revert "Fix "text" GUI "Standard" - DR can't be greater 100%"

### DIFF
--- a/src/pages/128x64x1/standard/drexp_page.c
+++ b/src/pages/128x64x1/standard/drexp_page.c
@@ -91,9 +91,8 @@ void PAGE_DrExpInit(int page)
                      2 * LINE_SPACE, count, row_cb, NULL, NULL, NULL);
 
     GUI_CreateXYGraph(&gui->graph, GRAPH_X, GRAPH_Y, GRAPH_W, GRAPH_H,
-                      CHAN_MIN_VALUE, CHAN_MIN_VALUE * 5 / 4, 
-                      CHAN_MAX_VALUE, CHAN_MAX_VALUE * 5 / 4,
-                      0, 0, show_curve_cb, curpos_cb, NULL, NULL);
+            CHAN_MIN_VALUE, CHAN_MIN_VALUE, CHAN_MAX_VALUE, CHAN_MAX_VALUE,
+            0, 0, show_curve_cb, curpos_cb, NULL, NULL);
 
     GUI_Select1stSelectableObj();
 }


### PR DESCRIPTION
You are too fast! This doesn't solve the problem, actually it is worse than before: DR above 100 % can make sense, you now scale the rates differently so when selecting 125 % you actually have 100 %. That is not correct. The problem lies in the XYgraph indeed, which can be seen in the Devo10 emulator which also draws incorrectly above 100%, but at least doesn't crash the whole thing. I suggest reverting the commit.