### PR TITLE
Added a FrskyX protocol option to send RSSI back to receiver via last…

### DIFF
--- a/src/config/model.h
+++ b/src/config/model.h
@@ -21,7 +21,7 @@ const char *MODEL_TEMPLATE;
 #define UNKNOWN_ICON ("media/noicon" IMG_EXT)
 
 //This cannot be computed, and must be manually updated
-#define NUM_PROTO_OPTS 4
+#define NUM_PROTO_OPTS 5
 #define VIRT_NAME_LEN 10 
 
 struct Model {

--- a/src/protocol/frskyx_cc2500.c
+++ b/src/protocol/frskyx_cc2500.c
@@ -42,6 +42,7 @@ static const char * const frskyx_opts[] = {
   _tr_noop("AD2GAIN"),  "0", "2000", "655361", NULL,       // big step 10, little step 1
   _tr_noop("Freq-Fine"),  "-127", "127", NULL,
   _tr_noop("Format"),  "FCC", "EU", NULL,
+  _tr_noop("RSSIChan"),  "None", "LastChan", NULL,
   NULL
 };
 enum {
@@ -49,6 +50,7 @@ enum {
     PROTO_OPTS_AD2GAIN,
     PROTO_OPTS_FREQFINE,
     PROTO_OPTS_FORMAT,
+    PROTO_OPTS_RSSICHAN,
     LAST_PROTO_OPT,
 };
 ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
@@ -217,7 +219,10 @@ static u16 scaleForPXX(u8 chan, u8 failsafe)
     else
         chan_val = Channels[chan];
     
-    chan_val = chan_val * STICK_SCALE / CHAN_MAX_VALUE + 1024;
+    if (Model.proto_opts[PROTO_OPTS_RSSICHAN] && (chan == Model.num_channels - 1) && !failsafe)
+        chan_val = Telemetry.value[TELEM_FRSKY_RSSI] * 21;      // Max RSSI value seems to be 99, scale it to around 2000
+    else
+        chan_val = chan_val * STICK_SCALE / CHAN_MAX_VALUE + 1024;
 
     if (chan_val > 2046)   chan_val = 2046;
     else if (chan_val < 1) chan_val = 1;


### PR DESCRIPTION
… RC channel

Some of the popular FrskyX receivers, such as XSR, X4R, etc, can't send RSSI to FC.  I've added a protocol option to send RSSI back to receiver via the last RC channel.  The RSSI can then be used by FC to display on OSD.  The maximum protocol option has been increased from 4 to 5 due to FrskyX has reached the max.