### PR TITLE
Fix XY-graph scaling for 128x64x1 GUI

### DIFF
--- a/src/pages/128x64x1/advanced/mixer_setup.c
+++ b/src/pages/128x64x1/advanced/mixer_setup.c
@@ -114,8 +114,8 @@ static void _show_simple()
 
     // The following items are not draw in the logical view;
     GUI_CreateXYGraph(&gui->graph, GRAPH_X, GRAPH_Y, GRAPH_W, GRAPH_H,
-                              CHAN_MIN_VALUE, CHAN_MIN_VALUE * 5 / 4,
-                              CHAN_MAX_VALUE, CHAN_MAX_VALUE * 5 / 4,
+                              CHAN_MIN_VALUE, CHAN_MIN_VALUE * 1251 / 1000,
+                              CHAN_MAX_VALUE, CHAN_MAX_VALUE * 1251 / 1000,
                               0, 0, eval_mixer_cb, curpos_cb, touch_cb,
                               &mp->mixer[0]);
     OBJ_SET_USED(&gui->bar, 0);
@@ -202,8 +202,8 @@ static void _show_complex(int page_change)
     GUI_CreateBarGraph(&gui->bar, LEFT_VIEW_WIDTH +10, LCD_HEIGHT - RIGHT_VIEW_HEIGHT -1, 5, RIGHT_VIEW_HEIGHT,
                               CHAN_MIN_VALUE, CHAN_MAX_VALUE, BAR_VERTICAL, eval_chan_cb, NULL);
     GUI_CreateXYGraph(&gui->graph, GRAPH_X, GRAPH_Y, GRAPH_W, GRAPH_H,
-                                  CHAN_MIN_VALUE, CHAN_MIN_VALUE * 5 / 4,
-                                  CHAN_MAX_VALUE, CHAN_MAX_VALUE * 5 / 4,
+                                  CHAN_MIN_VALUE, CHAN_MIN_VALUE * 1251 / 1000,
+                                  CHAN_MAX_VALUE, CHAN_MAX_VALUE * 1251 / 1000,
                                   0, 0, eval_mixer_cb, curpos_cb, touch_cb, mp->cur_mixer);
     if (page_change) {
         GUI_SetSelected(GUI_ShowScrollableRowOffset(&gui->scrollable, selection));
@@ -349,8 +349,8 @@ static void _show_expo_dr()
                         left_side_num_elements * LINE_SPACE, LINE_SPACE, EXPO_LAST, expo_row_cb, expo_getobj_cb, expo_size_cb, NULL);
     
     GUI_CreateXYGraph(&gui->graph, GRAPH_X, GRAPH_Y, GRAPH_W, GRAPH_H,
-                              CHAN_MIN_VALUE, CHAN_MIN_VALUE * 5 / 4,
-                              CHAN_MAX_VALUE, CHAN_MAX_VALUE * 5 / 4,
+                              CHAN_MIN_VALUE, CHAN_MIN_VALUE * 1251 / 1000,
+                              CHAN_MAX_VALUE, CHAN_MAX_VALUE * 1251 / 1000,
                               0, 0, eval_mixer_cb, curpos_cb, NULL, NULL);
 
     mp->cur_mixer = &mp->mixer[0];

--- a/src/pages/128x64x1/standard/drexp_page.c
+++ b/src/pages/128x64x1/standard/drexp_page.c
@@ -101,8 +101,8 @@ void PAGE_DrExpInit(int page)
     //GUI_SetSelected(GUI_ShowScrollableRowOffset(&gui->scrollable, current_selected));
 
     GUI_CreateXYGraph(&gui->graph, GRAPH_X, GRAPH_Y, GRAPH_W, GRAPH_H,
-                      CHAN_MIN_VALUE, CHAN_MIN_VALUE * 5 / 4, 
-                      CHAN_MAX_VALUE, CHAN_MAX_VALUE * 5 / 4,
+                      CHAN_MIN_VALUE, CHAN_MIN_VALUE * 1251 / 1000,
+                      CHAN_MAX_VALUE, CHAN_MAX_VALUE * 1251 / 1000,
                       0, 0, show_curve_cb, curpos_cb, NULL, NULL);
 
     GUI_Select1stSelectableObj();


### PR DESCRIPTION
With corrected scaling XY-graph has more nice look (straight line) with "Scale=125%".