### PR TITLE
cflie_nrf24l01 protocol support for CPPM CRTP commander type

### DIFF
--- a/doc/CFlie_NRF24L01.txt
+++ b/doc/CFlie_NRF24L01.txt
@@ -1,0 +1,54 @@
+Crazyflie/Crazyflie 2.0 Protocol (uses NRF24L01) 2017 April 1
+
+# Description #
+This protocol is for supporting the Crazyflie and Crazyflie 2.0 nanocopter.
+Comprehensive details about this copter can be found on the crazyflie wiki and/or forum:
+wiki: http://wiki.bitcraze.io
+forum: http://forum.bitcraze.io
+
+More specific info on DeviationTx support for the Crazyflie can be found on
+the wiki here: http://wiki.bitcraze.io/misc:hacks:deviation
+
+# Binding #
+Binding is done automatically via a fixed three digit model ID. 
+The first digit specifies the data rate:
+0 = 250kbps
+1 = 1Mbps
+2 = 2Mbps
+
+The next two digits specify the channel number.
+
+Example: 280 = 2Mbps, channel 80.
+Example: 000 = 250kbps, channel 0.
+
+# Data Packets #
+Data packets conform to the CRTP protocol outlined in the wiki
+http://wiki.bitcraze.io/projects:crazyflie:crtp
+
+This deviation protocol supports two types of commander packets, selectible in
+the protocol options menu.
+- RPYT = ordinary RPYT packets sent to CRTP port 3
+  (http://wiki.bitcraze.io/projects:crazyflie:crtp:commander)
+- CPPM = CPPM emulation mode sent to the generic setpoint port
+  (http://wiki.bitcraze.io/projects:crazyflie:crtp:setpointgeneric)
+
+# Channels #
+Channel mapping depends on which CRTP mode is selected in the protocol
+settings.
+
+RPYT: Devo channels 0-3 are used for RPYT (AERT) and reordered (and sign
+inverted as necessary) to match what the Crazyflie expects. Channel 4 is
+optional and is used to rotate 45degrees to switch between '+' mode and 'x'
+mode. This rotation is done in the protocol firmware itself. Channel 4 is not
+transmitted to the Crazyflie.
+
+CPPM: Up to 12 channels supported. All channels are remapped from their Devo
+defaults to an emulated PWM value (1000-2000, where 1500 is the midpoint) and
+none are sign inverted. Channels 0-3 are used for RPYT (AERT) and channels
+4-11 are reserved for auxiliary functions as defined in the Crazyflie
+firmware.
+
+# Logging/Telemetry #
+This protocol supports basic logging and telemetry -- currently voltage and
+RSSI. Protocol is configured to use the DSM telemetry variables and UI in
+DeviationTx.


### PR DESCRIPTION
Adding support for a new packet type for the Crazyflie 2.0 -- CPPM emulation via the NRF radio. Allows for flexible channel support and re-mapping. Eliminates need to hardcode max angle/rates in the deviation protocol code.