### PR TITLE
AFHDS 2A telemetry update

### DIFF
--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -338,10 +338,8 @@ static void update_telemetry()
                 Telemetry.value[TELEM_FRSKY_RSSI] = packet[index+2];
                 TELEMETRY_SetUpdated(TELEM_FRSKY_RSSI);
                 break;
-            case 0xff:
-                return;
             default:
-                // unknown sensor ID
+                // unknown sensor ID or end of list
                 break;
             }
     }

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -313,7 +313,7 @@ static void update_telemetry()
                 break;
 #if HAS_EXTENDED_TELEMETRY
             case SENSOR_TEMPERATURE:
-                Telemetry.value[TELEM_FRSKY_TEMP1] = 400 + packet[index+3]<<8 | packet[index+2];
+                Telemetry.value[TELEM_FRSKY_TEMP1] = 400 + (packet[index+3]<<8 | packet[index+2]);
                 TELEMETRY_SetUpdated(TELEM_FRSKY_TEMP1);
                 break;
             case SENSOR_CELL_VOLTAGE:

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -269,7 +269,9 @@ static void build_packet(u8 type)
 // telemetry sensors ID
 enum{
     SENSOR_VOLTAGE      = 0x00,
+    SENSOR_TEMPERATURE  = 0x01,
     SENSOR_RPM          = 0x02,
+    SENSOR_CELL_VOLTAGE = 0x03,
     SENSOR_RX_ERR_RATE  = 0xfe,
     SENSOR_RX_RSSI      = 0xfc,
     SENSOR_RX_NOISE     = 0xfb,
@@ -282,7 +284,10 @@ static void update_telemetry()
     // max 7 sensors per packet
     
     u8 voltage_index = 0;
-    
+#if HAS_EXTENDED_TELEMETRY
+    u8 cell_index = 0;
+#endif
+
     for(u8 sensor=0; sensor<7; sensor++) {
         u8 index = 9+(4*sensor);
         switch(packet[index]) {
@@ -307,6 +312,17 @@ static void update_telemetry()
 #endif
                 break;
 #if HAS_EXTENDED_TELEMETRY
+            case SENSOR_TEMPERATURE:
+                Telemetry.value[TELEM_FRSKY_TEMP1] = 400 + packet[index+3]<<8 | packet[index+2];
+                TELEMETRY_SetUpdated(TELEM_FRSKY_TEMP1);
+                break;
+            case SENSOR_CELL_VOLTAGE:
+                if(cell_index < 6) {
+                    Telemetry.value[TELEM_FRSKY_CELL1 + cell_index] = packet[index+3]<<8 | packet[index+2];
+                    TELEMETRY_SetUpdated(TELEM_FRSKY_CELL1 + cell_index);
+                }
+                cell_index++;
+                break;
             case SENSOR_RPM:
                 Telemetry.value[TELEM_FRSKY_RPM] = packet[index+3]<<8 | packet[index+2];
                 TELEMETRY_SetUpdated(TELEM_FRSKY_RPM);

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -313,7 +313,7 @@ static void update_telemetry()
                 break;
 #if HAS_EXTENDED_TELEMETRY
             case SENSOR_TEMPERATURE:
-                Telemetry.value[TELEM_FRSKY_TEMP1] = 400 + (packet[index+3]<<8 | packet[index+2]);
+                Telemetry.value[TELEM_FRSKY_TEMP1] = (packet[index+3]<<8 | packet[index+2]) - 400;
                 TELEMETRY_SetUpdated(TELEM_FRSKY_TEMP1);
                 break;
             case SENSOR_CELL_VOLTAGE:

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -291,7 +291,7 @@ static void update_telemetry()
                 // packet[index+2];
                 break;
             case SENSOR_RX_RSSI:
-                Telemetry.value[TELEM_FRSKY_RSSI] = -packet[index+2];
+                Telemetry.value[TELEM_FRSKY_RSSI] = packet[index+2];
                 TELEMETRY_SetUpdated(TELEM_FRSKY_RSSI);
                 break;
             case 0xff:

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -268,7 +268,8 @@ static void build_packet(u8 type)
 
 // telemetry sensors ID
 enum{
-    SENSOR_VOLTAGE   = 0x00,
+    SENSOR_VOLTAGE      = 0x00,
+    SENSOR_RPM          = 0x02,
     SENSOR_RX_ERR_RATE  = 0xfe,
     SENSOR_RX_RSSI      = 0xfc,
     SENSOR_RX_NOISE     = 0xfb,
@@ -302,6 +303,12 @@ static void update_telemetry()
                 }
 #endif
                 break;
+#if HAS_EXTENDED_TELEMETRY
+            case SENSOR_RPM:
+                Telemetry.value[TELEM_FRSKY_RPM] = packet[index+3]<<8 | packet[index+2];
+                TELEMETRY_SetUpdated(TELEM_FRSKY_RPM);
+                break;
+#endif
             case SENSOR_RX_ERR_RATE:
                 Telemetry.value[TELEM_FRSKY_LQI] = 100 - packet[index+2];
                 TELEMETRY_SetUpdated(TELEM_FRSKY_LQI);

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -281,22 +281,25 @@ static void update_telemetry()
     // AA | TXID | RXID | sensor id | sensor # | value 16 bit big endian | sensor id ......
     // max 7 sensors per packet
     
+    u8 voltage_index = 0;
+    
     for(u8 sensor=0; sensor<7; sensor++) {
         u8 index = 9+(4*sensor);
         switch(packet[index]) {
             case SENSOR_VOLTAGE:
+                voltage_index++;
                 if(packet[index+1] == 0) // Rx voltage
                 {
                     Telemetry.value[TELEM_FRSKY_VOLT1] = packet[index+3]<<8 | packet[index+2];
                     TELEMETRY_SetUpdated(TELEM_FRSKY_VOLT1);
                 }
-                else if(packet[index+1] == 1) // external voltage sensor #1
+                else if(voltage_index == 2) // external voltage sensor #1
                 {
                     Telemetry.value[TELEM_FRSKY_VOLT2] = packet[index+3]<<8 | packet[index+2];
                     TELEMETRY_SetUpdated(TELEM_FRSKY_VOLT2);
                 }
 #if HAS_EXTENDED_TELEMETRY
-                else if(packet[index+1] == 2) // external voltage sensor #2
+                else if(voltage_index == 3) // external voltage sensor #2
                 {
                     Telemetry.value[TELEM_FRSKY_VOLT3] = packet[index+3]<<8 | packet[index+2];
                     TELEMETRY_SetUpdated(TELEM_FRSKY_VOLT3);

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -286,6 +286,7 @@ static void update_telemetry()
     u8 voltage_index = 0;
 #if HAS_EXTENDED_TELEMETRY
     u8 cell_index = 0;
+    u16 cell_total = 0;
 #endif
 
     for(u8 sensor=0; sensor<7; sensor++) {
@@ -320,6 +321,7 @@ static void update_telemetry()
                 if(cell_index < 6) {
                     Telemetry.value[TELEM_FRSKY_CELL1 + cell_index] = packet[index+3]<<8 | packet[index+2];
                     TELEMETRY_SetUpdated(TELEM_FRSKY_CELL1 + cell_index);
+                    cell_total += packet[index+3]<<8 | packet[index+2];
                 }
                 cell_index++;
                 break;
@@ -343,6 +345,12 @@ static void update_telemetry()
                 break;
             }
     }
+#if HAS_EXTENDED_TELEMETRY
+    if(cell_index > 0) {
+        Telemetry.value[TELEM_FRSKY_ALL_CELL] = cell_total;
+        TELEMETRY_SetUpdated(TELEM_FRSKY_ALL_CELL);
+    }
+#endif 
 }
 
 static void build_bind_packet()

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -268,7 +268,7 @@ static void build_packet(u8 type)
 
 // telemetry sensors ID
 enum{
-    SENSOR_RX_VOLTAGE   = 0x00,
+    SENSOR_VOLTAGE   = 0x00,
     SENSOR_RX_ERR_RATE  = 0xfe,
     SENSOR_RX_RSSI      = 0xfc,
     SENSOR_RX_NOISE     = 0xfb,
@@ -283,12 +283,28 @@ static void update_telemetry()
     for(u8 sensor=0; sensor<7; sensor++) {
         u8 index = 9+(4*sensor);
         switch(packet[index]) {
-            case SENSOR_RX_VOLTAGE:
-                Telemetry.value[TELEM_FRSKY_VOLT1] = packet[index+3]<<8 | packet[index+2];
-                TELEMETRY_SetUpdated(TELEM_FRSKY_VOLT1);
+            case SENSOR_VOLTAGE:
+                if(packet[index+1] == 0) // Rx voltage
+                {
+                    Telemetry.value[TELEM_FRSKY_VOLT1] = packet[index+3]<<8 | packet[index+2];
+                    TELEMETRY_SetUpdated(TELEM_FRSKY_VOLT1);
+                }
+                else if(packet[index+1] == 1) // external voltage sensor #1
+                {
+                    Telemetry.value[TELEM_FRSKY_VOLT2] = packet[index+3]<<8 | packet[index+2];
+                    TELEMETRY_SetUpdated(TELEM_FRSKY_VOLT2);
+                }
+#if HAS_EXTENDED_TELEMETRY
+                else if(packet[index+1] == 2) // external voltage sensor #2
+                {
+                    Telemetry.value[TELEM_FRSKY_VOLT3] = packet[index+3]<<8 | packet[index+2];
+                    TELEMETRY_SetUpdated(TELEM_FRSKY_VOLT3);
+                }
+#endif
                 break;
             case SENSOR_RX_ERR_RATE:
-                // packet[index+2];
+                Telemetry.value[TELEM_FRSKY_LQI] = 100 - packet[index+2];
+                TELEMETRY_SetUpdated(TELEM_FRSKY_LQI);
                 break;
             case SENSOR_RX_RSSI:
                 Telemetry.value[TELEM_FRSKY_RSSI] = packet[index+2];


### PR DESCRIPTION
Telemetry update for Flysky/Turnigy AFHDS 2A protocol

- RSSI now reported as a positive number, allowing to set an alarm (min = 60, the lower the better)
- Report Link Quality as LQI (max = 100, the higher the better), probably a better indicator than RSSI
- External IBUS voltage sensors support, only 1 for 7e (modular build), 2 for other platforms, VOLT2 & VOLT3
- External IBUS RPM sensor support, only 1 sensor supported (not available on 7e)
- Built in external voltage sensor support (IA6C, X6B RXs...), not available on 7e
- External IBUS temperature sensor support, not tested, not available on 7e
