### PR TITLE
AFHDS-2A LQI output protocol option, from goebish

### DIFF
--- a/src/config/model.h
+++ b/src/config/model.h
@@ -21,7 +21,7 @@ const char *MODEL_TEMPLATE;
 #define UNKNOWN_ICON ("media/noicon" IMG_EXT)
 
 //This cannot be computed, and must be manually updated
-#define NUM_PROTO_OPTS 4
+#define NUM_PROTO_OPTS 5
 #define VIRT_NAME_LEN 10 
 
 struct Model {

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -74,6 +74,7 @@ enum{
 static const char * const afhds2a_opts[] = {
     _tr_noop("Outputs"), "PWM/IBUS", "PPM/IBUS", "PWM/SBUS", "PPM/SBUS", NULL,
     _tr_noop("Servo Hz"), "50", "400", "5", NULL,
+    _tr_noop("LQI output"), "None", "Ch5", "Ch6", "Ch7", "Ch8", "Ch9", "Ch10", "Ch11", "Ch12", NULL,
     "RX ID", "-32768", "32767", "1", NULL, // todo: store that elsewhere
     "RX ID2","-32768", "32767", "1", NULL, // ^^^^^^^^^^^^^^^^^^^^^^^^^^
     NULL
@@ -89,6 +90,7 @@ enum {
 enum {
     PROTOOPTS_OUTPUTS = 0,
     PROTOOPTS_SERVO_HZ,
+    PROTOOPTS_LQI_OUT,
     PROTOOPTS_RXID, // todo: store that elsewhere
     PROTOOPTS_RXID2,// ^^^^^^^^^^^^^^^^^^^^^^^^^^
     LAST_PROTO_OPT,
@@ -202,6 +204,12 @@ static void build_sticks_packet()
             value = 2125;
         packet[9 +  ch*2] = value & 0xff;
         packet[10 + ch*2] = (value >> 8) & 0xff;
+    }
+    // override channel with telemetry LQI
+    if(Model.proto_opts[PROTOOPTS_LQI_OUT] > 0) {
+        u16 val = 1000 + (Telemetry.value[TELEM_FRSKY_LQI] * 10);
+        packet[17+((Model.proto_opts[PROTOOPTS_LQI_OUT]-1)*2)] = val & 0xff;
+        packet[18+((Model.proto_opts[PROTOOPTS_LQI_OUT]-1)*2)] = (val >> 8) & 0xff;
     }
     packet[37] = 0x00;
 }


### PR DESCRIPTION
Add a protocol option to output LQI on an AUX channel, allowing OSDs to display signal quality.

discussion: https://www.deviationtx.com/forum/protocol-development/5251-flysky-afhds-2a-protocol-as-used-i10-i6-it4?start=480#62315