### PR TITLE
Fix use of Devo12 "mymedia\toggle3.bmp"

### DIFF
--- a/src/pages/common/_toggle_select.c
+++ b/src/pages/common/_toggle_select.c
@@ -49,7 +49,7 @@ static u32 _get_icon_info()
             FILE *fh;
             fh = fopen(toggle_files[3], "r");
             if(!fh)
-                toggle_files[3] = "mymedia/toggle3 " IMG_EXT;
+                toggle_files[3] = "mymedia/toggle3" IMG_EXT;
             else
                 fclose(fh);
             checked = 1;


### PR DESCRIPTION
The space character after "mymedia/toggle3 " break use of "mymedia/toggle3.bmp".