### PR TITLE
Fix AFHDS 2A channel scaling & tx power not in sync

### DIFF
--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -49,6 +49,7 @@ static s32 packet_count;
 static u8 bind_reply;
 static u8 state;
 static u8 channel;
+static u8 tx_power;
 
 static const u8 AFHDS2A_regs[] = {
     -1  , 0x42 | (1<<5), 0x00, 0x25, 0x00,   -1,   -1, 0x00, 0x00, 0x00, 0x00, 0x01, 0x3c, 0x05, 0x00, 0x50, // 00 - 0f
@@ -178,8 +179,10 @@ static int afhds2a_init()
     A7105_WriteReg(0x25, 0x0A);
 
     A7105_SetTxRxMode(TX_EN);
+    
     A7105_SetPower(Model.tx_power);
-
+    tx_power = Model.tx_power;
+    
     A7105_Strobe(A7105_STANDBY);
     A7105_SetTxRxMode(TX_EN);
     return 1;
@@ -540,6 +543,11 @@ static u16 afhds2a_cb()
                 packet_type = PACKET_FAILSAFE;
             else
                 packet_type = PACKET_STICKS; // todo : check for settings changes
+            // keep transmit power in sync
+            if(tx_power != Model.tx_power) {
+                A7105_SetPower(Model.tx_power);
+                tx_power = Model.tx_power;
+            }
             // got some data from RX ?
             // we've no way to know if RX fifo has been filled
             // as we can't poll GIO1 or GIO2 to check WTR

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -197,7 +197,7 @@ static void build_sticks_packet()
             packet[10 + ch*2] = 0x05;
             continue;
         }
-        s32 value = (s32)Channels[ch] * 0x1f1 / CHAN_MAX_VALUE + 0x5d9;
+        s32 value = (s32)Channels[ch] * 500 / CHAN_MAX_VALUE + 1500;
         if (value < 875)
             value = 875;
         else if (value > 2125)


### PR DESCRIPTION
AFHDS 2A channel scaling was slightly off, as reported here:
https://www.deviationtx.com/forum/protocol-development/5251-flysky-afhds-2a-protocol-as-used-i10-i6-it4?start=540#64452

edit: also fixes this issue
https://www.deviationtx.com/forum/6-general-discussions/7357-devo-7e-problem-changing-output-power-afhds-2a