### PR TITLE
 Fix min/max limit values on LRSSI so alarm can be set on LRSSI. 

### DIFF
--- a/src/telemetry/telem_frsky.c
+++ b/src/telemetry/telem_frsky.c
@@ -154,7 +154,7 @@ s32 _frsky_get_max_value(u8 telem)
 s32 _frsky_get_min_value(u8 telem)
 {
     switch(telem) {
-        case TELEM_FRSKY_LRSSI:     return -150;
+        case TELEM_FRSKY_LRSSI:     return -200;
 #if HAS_EXTENDED_TELEMETRY
         case TELEM_FRSKY_TEMP1:
         case TELEM_FRSKY_TEMP2:     return -30;

--- a/src/telemetry/telem_frsky.c
+++ b/src/telemetry/telem_frsky.c
@@ -125,7 +125,7 @@ s32 _frsky_get_max_value(u8 telem)
         case TELEM_FRSKY_VOLT2:     return 8538; //should be 33 * AD2gain, but ugh
         case TELEM_FRSKY_RSSI:      return 60000;
         case TELEM_FRSKY_LQI:       return 127;
-        case TELEM_FRSKY_LRSSI:     return 255;
+        case TELEM_FRSKY_LRSSI:     return -10;
 #if HAS_EXTENDED_TELEMETRY
         case TELEM_FRSKY_RPM:       return 60000;
         case TELEM_FRSKY_VOLT3:
@@ -154,6 +154,7 @@ s32 _frsky_get_max_value(u8 telem)
 s32 _frsky_get_min_value(u8 telem)
 {
     switch(telem) {
+        case TELEM_FRSKY_LRSSI:     return -150;
 #if HAS_EXTENDED_TELEMETRY
         case TELEM_FRSKY_TEMP1:
         case TELEM_FRSKY_TEMP2:     return -30;


### PR DESCRIPTION
Adjust min/max values to match actual possible range (-7 to -198).  The LRSSI value is an estimate in dBm according to the procedure of section 17.3 of the datasheet.  