### PR TITLE
 Prevent mux voice from triggering sound before welcome has played.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -97,6 +97,7 @@ int main() {
     audio_queue_time = CLOCK_getms() + 1500;
     num_audio++;
     next_audio++;
+    AUDIO_SetVolume(); // Initial setting of voice volume
 #endif
 
     MUSIC_Play(MUSIC_STARTUP);

--- a/src/main.c
+++ b/src/main.c
@@ -95,8 +95,8 @@ int main() {
     // AUDIO_Init() has already been called by CONFIG_ReadModel()
 #if HAS_EXTENDED_AUDIO
     audio_queue_time = CLOCK_getms() + 1500;
-    num_audio++;
-    next_audio++;
+    num_audio=1;
+    next_audio=1;
     AUDIO_SetVolume(); // Initial setting of voice volume
 #endif
 


### PR DESCRIPTION
I know this is not the perfect solution, as it discards mux voice alert completely on transmitter startup, on the other hand mixers get checked so early after startup there really seems to be no choice to it unless we start digging deeper. 