### PR TITLE
Add fine frequency tuning option to A7105 protocols

### DIFF
--- a/src/protocol/flysky_a7105.c
+++ b/src/protocol/flysky_a7105.c
@@ -46,10 +46,12 @@
 
 static const char * const flysky_opts[] = {
   "WLToys ext.",  _tr_noop("Off"), "V9x9", "V6x6", "V912", "CX20", NULL,
+  "Freq Tune", "-300", "300", "655361", NULL, // big step 10, little step 1
   NULL
 };
 enum {
     PROTOOPTS_WLTOYS = 0,
+    PROTOOPTS_FREQTUNE,
     LAST_PROTO_OPT,
 };
 ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
@@ -129,6 +131,7 @@ static u16 packet_period;
 static u8 hopping_frequency[16];
 static u8 hopping_frequency_no;
 static u8 tx_power;
+static s16 freq_offset;
 
 static int flysky_init()
 {
@@ -348,6 +351,11 @@ static u16 flysky_cb()
             A7105_SetPower(Model.tx_power);
             tx_power = Model.tx_power;
         }
+        // keep frequency tuning updated
+        if(freq_offset != Model.proto_opts[PROTOOPTS_FREQTUNE]) {
+                freq_offset = Model.proto_opts[PROTOOPTS_FREQTUNE];
+                A7105_AdjustLOBaseFreq(freq_offset);
+        }
     }
     hopping_frequency_no++;
     return packet_period;
@@ -409,6 +417,8 @@ static void initialize(u8 bind) {
     
     tx_power = Model.tx_power;
     A7105_SetPower(Model.tx_power);
+    freq_offset = Model.proto_opts[PROTOOPTS_FREQTUNE];
+    A7105_AdjustLOBaseFreq(freq_offset);
     hopping_frequency_no = 0;
     if (bind || ! Model.fixed_id) {
         counter = BIND_COUNT;

--- a/src/protocol/iface_a7105.h
+++ b/src/protocol/iface_a7105.h
@@ -82,6 +82,6 @@ void A7105_WriteID(u32 id);
 void A7105_Strobe(enum A7105_State);
 void A7105_SetPower(int power);
 void A7105_SetTxRxMode(enum TXRX_State);
-
+void A7105_AdjustLOBaseFreq(s16 offset);
 
 #endif

--- a/src/protocol/spi/a7105.c
+++ b/src/protocol/spi/a7105.c
@@ -162,14 +162,14 @@ void A7105_AdjustLOBaseFreq(s16 offset)
 {
     // LO base frequency = 32e6*(bip+(bfp/(2^16)))
     u8 bip;  // LO base frequency integer part
-    u16 bfp; // LO base frequency fractional part
+    u32 bfp; // LO base frequency fractional part
     if(offset < 0) {
         bip = 0x4a; // 2368 MHz
-        bfp = 0xffff + (offset * 2.048f) + 1;
+        bfp = 0xffff+((offset*2048)/1000)+1;
     }
     else {
         bip = 0x4b; // 2400 MHz (default)
-        bfp = offset * 2.048f;
+        bfp = (offset*2048)/1000;
     }
     if(offset == 0)
         bfp = 0x0002; // as per datasheet, not sure why recommanded, but that's a +1kHz drift only ...

--- a/src/protocol/spi/a7105.c
+++ b/src/protocol/spi/a7105.c
@@ -154,5 +154,29 @@ void A7105_Strobe(enum A7105_State state)
     CS_HI();
 }
 
+// fine tune A7105 LO base frequency
+// this is required for some A7105 modules / Rx
+// with inaccurate crystal oscillator
+// arg: offset in +/-kHz
+void A7105_AdjustLOBaseFreq(s16 offset)
+{
+    // LO base frequency = 32e6*(bip+(bfp/(2^16)))
+    u8 bip;  // LO base frequency integer part
+    u16 bfp; // LO base frequency fractional part
+    if(offset < 0) {
+        bip = 0x4a; // 2368 MHz
+        bfp = 0xffff + (offset * 2.048f) + 1;
+    }
+    else {
+        bip = 0x4b; // 2400 MHz (default)
+        bfp = offset * 2.048f;
+    }
+    if(offset == 0)
+        bfp = 0x0002; // as per datasheet, not sure why recommanded, but that's a +1kHz drift only ...
+    A7105_WriteReg( A7105_11_PLL_III, bip);
+    A7105_WriteReg( A7105_12_PLL_IV, (bfp >> 8) & 0xff);
+    A7105_WriteReg( A7105_13_PLL_V, bfp & 0xff);
+}
+
 //#pragma long_calls_off
 #endif


### PR DESCRIPTION
Add fine frequency tuning option to A7105 protocols, same as CC2500 protocols.
This is required for some A7105 modules or Rx with inaccurate crystal oscillators.

Forums thread: https://www.deviationtx.com/forum/6-general-discussions/7376-jumper-t8sg-and-e010s-flysky-afhds-latency

More and more people are having the same issue with 256 kbps xn297 protocols (eg E010), unfortunately there's nothing we can do in software to fine tune the nrf24l01. X-in-1 modules manufacturers should use better accuracy crystals, especially for the nrf24l01 (+/-20ppm because of the xn297 emulation, despite the nrf24 datasheet specifies +/-60ppm,  ...). I'll expose the issue to Jumper.