### PR TITLE
Frskyx timing

### DIFF
--- a/src/protocol/frskyx_cc2500.c
+++ b/src/protocol/frskyx_cc2500.c
@@ -740,9 +740,9 @@ static u16 frskyx_cb() {
       channr = (channr + chanskip) % 47;
       state++;
 #ifndef EMULATOR
-      return 5500;
+      return 5200;
 #else
-      return 55;
+      return 52;
 #endif
     case FRSKY_DATA2:
       CC2500_SetTxRxMode(RX_EN);
@@ -757,9 +757,9 @@ static u16 frskyx_cb() {
       CC2500_Strobe(CC2500_SRX);
       state++;
 #ifndef EMULATOR
-      return 3000;
+      return 3100;
 #else
-      return 30;
+      return 31;
 #endif
     case FRSKY_DATA4:
       len = CC2500_ReadReg(CC2500_3B_RXBYTES | CC2500_READ_BURST) & 0x7F;
@@ -779,9 +779,9 @@ static u16 frskyx_cb() {
       if (seq_tx_send != 8) seq_tx_send = (seq_tx_send + 1) % 4;
       state = FRSKY_DATA1;
 #ifndef EMULATOR
-      return 300;
+      return 500;
 #else
-      return 3;
+      return 5;
 #endif
   }
   return 1;


### PR DESCRIPTION
Timing change fixes issue with telemetry when using LBT option.  Enters receive mode a little sooner and listens a little longer.  This change comes from the DIY-Multimodule project.

Have tested with Frsky XSR receiver.  Both CPPM and SBUS outputs are unaffected.