### PR TITLE
Timer-based PPM protocol

### DIFF
--- a/src/protocol/ppmout.c
+++ b/src/protocol/ppmout.c
@@ -51,7 +51,6 @@ enum {
 };
 ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
 
-volatile u8 state;
 static void build_data_pkt()
 {
     int i;
@@ -82,6 +81,7 @@ static void initialize()
     CLOCK_StopTimer();
     if (PPMin_Mode())
         return;
+
     PWM_Initialize();
     num_channels = Model.num_channels;
     if (Model.proto_opts[CENTER_PW] == 0) {
@@ -91,9 +91,9 @@ static void initialize()
         Model.proto_opts[PERIOD_PW] = 22500;
     }
     
-    state = 0;
     CLOCK_StartTimer(1000, ppmout_cb);
 }
+
 
 const void * PPMOUT_Cmds(enum ProtoCmds cmd)
 {

--- a/src/target/at9/at9_stubs.c
+++ b/src/target/at9/at9_stubs.c
@@ -102,6 +102,7 @@ const char *MCU_GetPinName(char *str, struct mcu_pin *port) {
 
 void PWM_Initialize() {}
 void PWM_Stop() {}
-void PWM_Set(int val) {
-    (void)val;
+void PPM_Enable(unsigned low_time, volatile u16 *pulses) {
+    (void)low_time;
+    (void)pulses;
 }

--- a/src/target/common/devo/Makefile.inc
+++ b/src/target/common/devo/Makefile.inc
@@ -78,7 +78,7 @@ $(TARGET).dfu: $(TARGET).bin
 ###################################
 $(ODIR)/%.bin: $(ODIR)/%.o_ $(PROTO_LINKFILE) $(PROTO_EXTRA_OBJS) $(TARGET).bin
 	@echo " + Building '$@'"
-	$(LD) -o $(@:.bin=.elf) $< $(PROTO_EXTRA_OBJS) -gc-sections -Map=$(@:.bin=.map) \
+	$(LD) -o $(@:.bin=.elf) $< $(PROTO_EXTRA_OBJS) $(LIBOPENCM3) -gc-sections -Map=$(@:.bin=.map) \
 		--cref -T$(PROTO_LINKFILE) --just-symbols=$(SYMBOL_FILE)
 	$(DUMP) -t $(@:.bin=.elf) | grep -q _from_thumb; if [ $$? -eq 0 ]; then echo "ERROR: Bad address found"; false; else true; fi
 	$(CP) -O binary  $(@:.bin=.elf) $@

--- a/src/target/common/devo/ports.h
+++ b/src/target/common/devo/ports.h
@@ -92,8 +92,9 @@ static const struct mcu_pin PROTO_MOSI_PIN  = _SPI_PROTO_MOSI_PIN;
 #endif //_TOUCH_PORT
 
 #ifndef _PWM_PIN
-    #define _PWM_PIN GPIO_USART1_TX    //GPIO9
-    #define _PWM_EXTI EXTI9
+    #define _PWM_PIN                   GPIO_USART1_TX    //GPIO9
+    #define _PWM_EXTI                  EXTI9
+    #define _PWM_TIM_OC                TIM_OC2
 #endif //_PWM_PIN
 
 #ifndef _USART

--- a/src/target/common/devo/protocol/pwm.c
+++ b/src/target/common/devo/protocol/pwm.c
@@ -42,27 +42,31 @@ void PWM_Initialize()
 #endif
 
     rcc_peripheral_enable_clock(&RCC_APB2ENR,
-                                RCC_APB2ENR_TIM1EN | RCC_APB2ENR_IOPAEN | RCC_APB2ENR_AFIOEN);
-
+                                 RCC_APB2ENR_TIM1EN
+                               | RCC_APB2ENR_IOPAEN
+                               | RCC_APB2ENR_AFIOEN);
     timer_reset(TIM1);
 
     // Timer global mode: No divider, Alignment edge, Direction up, auto-preload buffered
-    timer_set_mode(TIM1, TIM_CR1_CKD_CK_INT,
-                   TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
+    timer_set_mode(TIM1, TIM_CR1_CKD_CK_INT, TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
     timer_enable_preload(TIM1);
 
     /* timer updates each microsecond */
     timer_set_prescaler(TIM1, 72 - 1);
-    timer_generate_event(TIM1, TIM_EGR_UG);
 
-    /* Capture compare output setup*/
-    gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
-                  GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, _PWM_PIN);
+    /* compare output setup. compare register must match i/o pin */
     timer_set_oc_mode(TIM1, _PWM_TIM_OC, TIM_OCM_PWM1); // output active while counter below compare
     timer_enable_oc_preload(TIM1, _PWM_TIM_OC);         // must use preload for PWM mode
     timer_set_oc_polarity_low(TIM1, _PWM_TIM_OC);       // notch time is low
+    timer_set_oc_value(TIM1, _PWM_TIM_OC, 0);           // hold output inactive
+    timer_set_period(TIM1, 22500);                      // sane default
+    timer_generate_event(TIM1, TIM_EGR_UG);             // load shadow registers
+    timer_enable_counter(TIM1);
+
     timer_enable_oc_output(TIM1, _PWM_TIM_OC);          // enable OCx to pin
     timer_enable_break_main_output(TIM1);               // master output enable
+    gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,       // connect compare output to pin
+                  GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, _PWM_PIN);
 
     // interrupt on overflow (reload)
     nvic_enable_irq(NVIC_TIM1_UP_IRQ);
@@ -76,6 +80,8 @@ void PWM_Stop()
         return;
 
     timer_disable_counter(TIM1);
+    nvic_disable_irq(NVIC_TIM1_UP_IRQ);
+    timer_disable_oc_output(TIM1, _PWM_TIM_OC);
     rcc_peripheral_disable_clock(&RCC_APB2ENR, RCC_APB2ENR_TIM1EN);
 
 #if _PWM_PIN == GPIO_USART1_TX
@@ -85,12 +91,12 @@ void PWM_Stop()
 
 void PPM_Enable(unsigned low_time, volatile u16 *pulses)
 {
-    timer_set_oc_value(TIM1, _PWM_TIM_OC, low_time);
     pwm = pulses;
     if (*pwm) {
         timer_set_period(TIM1, *pwm++);
-        timer_generate_event(TIM1, TIM_EGR_UG); // Force-load first period
-        timer_enable_counter(TIM1);
+        timer_set_oc_value(TIM1, _PWM_TIM_OC, low_time);
+        timer_generate_event(TIM1, TIM_EGR_UG); // Force-load shadow registers
+
         //Create an interrupt on ARR reload
         timer_clear_flag(TIM1, TIM_SR_UIF);
         timer_enable_irq(TIM1, TIM_DIER_UIE);

--- a/src/target/common/devo/protocol/pwm.c
+++ b/src/target/common/devo/protocol/pwm.c
@@ -44,65 +44,46 @@ void PWM_Initialize()
 #if _PWM_PIN == GPIO_USART1_TX
     UART_Stop();
 #endif
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPAEN);
-    gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
-                  GPIO_CNF_OUTPUT_PUSHPULL, _PWM_PIN);
-    gpio_clear(GPIOA, _PWM_PIN);
-    return;
-#if 0
-    rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB2ENR_TIM1EN);
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPAEN);
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_AFIOEN);
 
-    gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
-                  GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO_TIM1_CH2 | GPIO_TIM1_CH3);
-    nvic_enable_irq(NVIC_TIM1_UP_IRQ);
-    nvic_set_priority(NVIC_TIM1_UP_IRQ, 1);
+    rcc_peripheral_enable_clock(&RCC_APB2ENR,
+                                RCC_APB2ENR_TIM1EN | RCC_APB2ENR_IOPAEN | RCC_APB2ENR_AFIOEN);
 
+//TODO Set timer channel as needed based on _PWM_PIN
     timer_reset(TIM1);
 
-    /* Timer global mode:
-     * - No divider
-     * - Alignment edge
-     * - Direction up
-     */
+    // Timer global mode: No divider, Alignment edge, Direction up, auto-preload buffered
     timer_set_mode(TIM1, TIM_CR1_CKD_CK_INT,
                    TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
+    timer_enable_preload(TIM1);
 
     /* timer updates each microsecond */
     timer_set_prescaler(TIM1, 72 - 1);
-    timer_set_period(TIM1, 32000);
     timer_generate_event(TIM1, TIM_EGR_UG);
 
-    timer_continuous_mode(TIM1);
-    /* ---- */
-    /* Output compare 1 mode and preload */
-    timer_set_oc_mode(TIM1, TIM_OC3, TIM_OCM_PWM1);
-    timer_enable_oc_preload(TIM1, TIM_OC3);
+    /* Capture compare output setup*/
+    gpio_set_mode(GPIOA, GPIO_MODE_OUTPUT_50_MHZ,
+                  GPIO_CNF_OUTPUT_ALTFN_PUSHPULL, GPIO_TIM1_CH2);
+    timer_set_oc_mode(TIM1, TIM_OC2, TIM_OCM_PWM1); // output active while counter below compare
+    timer_enable_oc_preload(TIM1, TIM_OC2);         // must use preload for PWM mode
+    timer_set_oc_polarity_low(TIM1, TIM_OC2);       // notch time is low
+    timer_enable_oc_output(TIM1, TIM_OC2);          // enable OCx to pin
+    timer_enable_break_main_output(TIM1);           // master output enable
 
-    /* Polarity and state */
-    timer_set_oc_polarity_high(TIM1, TIM_OC3);
-    timer_enable_oc_output(TIM1, TIM_OC3);
-
-    /* Capture compare value */
-    timer_set_oc_value(TIM1, TIM_OC3, 16000);
-    timer_set_oc_value(TIM1, TIM_OC3, 16000);
-    /* ---- */
-    /* ARR reload enable */
-    timer_enable_preload(TIM1);
-
-    timer_enable_counter(TIM1);
-#endif
+    // interrupt on overflow (reload)
+    nvic_enable_irq(NVIC_TIM1_UP_IRQ);
+    nvic_set_priority(NVIC_TIM1_UP_IRQ, 1);
 }
+
+
 void PWM_Stop()
 {
     if (PPMin_Mode())
         return;
-#if 0
+
     if (RCC_APB1ENR & RCC_APB2ENR_TIM1EN) {
         rcc_peripheral_disable_clock(&RCC_APB1ENR, RCC_APB2ENR_TIM1EN);
     }
-#endif
+
 #if _PWM_PIN == GPIO_USART1_TX
     UART_Initialize();
 #endif
@@ -118,13 +99,11 @@ void PWM_Set(int val)
 
 void PPM_Enable(unsigned low_time, volatile u16 *pulses)
 {
-    timer_disable_counter(TIM1);
     timer_set_oc_value(TIM1, TIM_OC2, low_time);
     pwm = pulses;
     if (*pwm) {
         timer_set_period(TIM1, *pwm++);
-        //Force-load new period
-        timer_generate_event(TIM1, TIM_EGR_UG);
+        timer_generate_event(TIM1, TIM_EGR_UG); // Force-load first period
         timer_enable_counter(TIM1);
         //Create an interrupt on ARR reload
         timer_clear_flag(TIM1, TIM_SR_UIF);
@@ -132,15 +111,15 @@ void PPM_Enable(unsigned low_time, volatile u16 *pulses)
     }
 }
 
-#if 0
 void tim1_up_isr()
 {
     timer_clear_flag(TIM1, TIM_SR_UIF);
-    if(*pwm)
+
+    if (*pwm)
         timer_set_period(TIM1, *pwm++);
     else
-        timer_disable_counter(TIM1);
+        timer_set_oc_value(TIM1, TIM_OC2, 0); // hold output inactive
 }
-#endif
+
 #endif //DISABLE_PWM
 #pragma long_calls_off

--- a/src/target/common/devo/protocol/pwm.c
+++ b/src/target/common/devo/protocol/pwm.c
@@ -93,7 +93,7 @@ void PPM_Enable(unsigned low_time, volatile u16 *pulses)
 {
     pwm = pulses;
     if (*pwm) {
-        timer_set_period(TIM1, *pwm++);
+        timer_set_period(TIM1, *pwm++ - 1);
         timer_set_oc_value(TIM1, _PWM_TIM_OC, low_time);
         timer_generate_event(TIM1, TIM_EGR_UG); // Force-load shadow registers
 
@@ -108,7 +108,7 @@ void tim1_up_isr()
     timer_clear_flag(TIM1, TIM_SR_UIF);
 
     if (*pwm)
-        timer_set_period(TIM1, *pwm++);
+        timer_set_period(TIM1, *pwm++ - 1);
     else
         timer_set_oc_value(TIM1, _PWM_TIM_OC, 0); // hold output inactive
 }

--- a/src/target/common/devo/protocol/pwm.c
+++ b/src/target/common/devo/protocol/pwm.c
@@ -44,7 +44,6 @@ void PWM_Initialize()
     rcc_peripheral_enable_clock(&RCC_APB2ENR,
                                 RCC_APB2ENR_TIM1EN | RCC_APB2ENR_IOPAEN | RCC_APB2ENR_AFIOEN);
 
-//TODO Set timer channel as needed based on _PWM_PIN
     timer_reset(TIM1);
 
     // Timer global mode: No divider, Alignment edge, Direction up, auto-preload buffered

--- a/src/target/common/devo/protocol/pwm.c
+++ b/src/target/common/devo/protocol/pwm.c
@@ -34,7 +34,6 @@
 #include <errno.h>
 
 
-static volatile u16 *pwm;
 void PWM_Initialize()
 {
 #if _PWM_PIN == GPIO_USART1_TX
@@ -89,6 +88,7 @@ void PWM_Stop()
 #endif
 }
 
+extern volatile u16 *pwm;  // defined in pwm_rom.c
 void PPM_Enable(unsigned low_time, volatile u16 *pulses)
 {
     pwm = pulses;
@@ -101,16 +101,6 @@ void PPM_Enable(unsigned low_time, volatile u16 *pulses)
         timer_clear_flag(TIM1, TIM_SR_UIF);
         timer_enable_irq(TIM1, TIM_DIER_UIE);
     }
-}
-
-void tim1_up_isr()
-{
-    timer_clear_flag(TIM1, TIM_SR_UIF);
-
-    if (*pwm)
-        timer_set_period(TIM1, *pwm++ - 1);
-    else
-        timer_set_oc_value(TIM1, _PWM_TIM_OC, 0); // hold output inactive
 }
 
 #endif //DISABLE_PWM

--- a/src/target/common/devo/pwm_rom.c
+++ b/src/target/common/devo/pwm_rom.c
@@ -1,0 +1,39 @@
+/*
+    This project is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Deviation is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "common.h"
+#ifndef DISABLE_PWM
+
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/timer.h>
+#include <libopencm3/cm3/nvic.h>
+
+#include "../ports.h"
+
+
+volatile u16 *pwm;
+
+void tim1_up_isr()
+{
+    timer_clear_flag(TIM1, TIM_SR_UIF);
+
+    if (*pwm)
+        timer_set_period(TIM1, *pwm++ - 1);
+    else
+        timer_set_oc_value(TIM1, _PWM_TIM_OC, 0); // hold output inactive
+}
+
+#endif

--- a/src/target/common/devo/uart.c
+++ b/src/target/common/devo/uart.c
@@ -78,6 +78,7 @@ void UART_Initialize()
 void UART_Stop()
 {
     usart_disable(_USART);
+    rcc_peripheral_disable_clock(&_USART_RCC_APB_ENR_USART, _USART_RCC_APB_ENR_USART_EN);
 }
 
 void UART_SetDataRate(u32 bps)

--- a/src/target/common/devo/uart.c
+++ b/src/target/common/devo/uart.c
@@ -30,7 +30,6 @@ void UART_Initialize()
     rcc_peripheral_enable_clock(&_USART_RCC_APB_ENR_USART, _USART_RCC_APB_ENR_USART_EN);
 
     /* Enable DMA clock */
-    // TODO ENABLED ALREADY FOR ADC?
     rcc_peripheral_enable_clock(&RCC_AHBENR, _RCC_AHBENR_DMAEN);
 
     /* Setup GPIO pin GPIO_USARTX_TX on USART GPIO port for transmit. */
@@ -43,9 +42,9 @@ void UART_Initialize()
     usart_set_baudrate(_USART, 115200);
     usart_set_databits(_USART, 8);
     usart_set_stopbits(_USART, USART_STOPBITS_1);
-    usart_set_mode(_USART, USART_MODE_TX);
     usart_set_parity(_USART, USART_PARITY_NONE);
     usart_set_flow_control(_USART, USART_FLOWCONTROL_NONE);
+    usart_set_mode(_USART, USART_MODE_TX);
     //usart_set_mode(USART1, USART_MODE_TX_RX);
 
     /* Finally enable the USART. */
@@ -77,6 +76,8 @@ void UART_Initialize()
 
 void UART_Stop()
 {
+    nvic_disable_irq(_USART_NVIC_DMA_CHANNEL_IRQ);
+    usart_set_mode(_USART, 0);
     usart_disable(_USART);
     rcc_peripheral_disable_clock(&_USART_RCC_APB_ENR_USART, _USART_RCC_APB_ENR_USART_EN);
 }

--- a/src/target/devo12/devo12_ports.h
+++ b/src/target/devo12/devo12_ports.h
@@ -42,7 +42,8 @@
 //End Touch pins
 
 //PWM Port
-#define _PWM_PIN GPIO8
-#define _PWM_EXTI EXTI8
+#define _PWM_PIN                   GPIO8
+#define _PWM_EXTI                  EXTI8
+#define _PWM_TIM_OC                TIM_OC1
 //End PWM Port
 #endif //_DEVO12_PORTS_H_

--- a/src/target/x9d/x9d_ports.h
+++ b/src/target/x9d/x9d_ports.h
@@ -15,8 +15,9 @@
 //End Sound port
 
 //PWM Port
-#define _PWM_PIN GPIO8
-#define _PWM_EXTI EXTI8
+#define _PWM_PIN                   GPIO8
+#define _PWM_EXTI                  EXTI8
+#define _PWM_TIM_OC                TIM_OC1
 //End PWM Port
 
 #define _USART USART3

--- a/src/target/x9d/x9d_stubs.c
+++ b/src/target/x9d/x9d_stubs.c
@@ -88,6 +88,7 @@ const char *MCU_GetPinName(char *str, struct mcu_pin *port) { return "None";}
 
 void PWM_Initialize() {}
 void PWM_Stop() {}
-void PWM_Set(int val) {
-    (void)val;
+void PPM_Enable(unsigned low_time, volatile u16 *pulses) {
+    (void)low_time;
+    (void)pulses;
 }


### PR DESCRIPTION
Uses timer to generate ppm output pulses, replacing current method of bit-banging based on clock timer callbacks.  This improves control of the pulse width to reduce jitter.

The implementation is based on the timer code that had been commented-out in pwm.c, which needed fixes for defines and co-operation with usart using the same pin.  The basic logic was correct.  Some usart code is also updated for co-operation.

This has been tested with devo10 and t8sg.  Needs devo12 and modular build testing as those are slightly different.  [Test builds available](https://www.deviationtx.com/downloads-new/category/818-hexfet-ppm-timer).