### PR TITLE
Add ability to specify display scale/format string

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -125,7 +125,8 @@ PROTO_EXTRA_OBJS := $(addprefix $(ODIR)/, $(notdir $(PROTO_EXTRA_C:.c=.o)))
 SYMBOL_FILE := $(ODIR)/symbolfile
 endif
 
-HGVERSION := $(shell ../utils/get_version.pl ${TARGET})
+HGVERSION ?= $(shell ../utils/get_version.pl ${TARGET})
+HGVERSION := $(HGVERSION)
 
 # Rebuild on hg version change.
 # Based on http://mercurial.selenic.com/wiki/VersioningWithMake

--- a/src/config/model.c
+++ b/src/config/model.c
@@ -93,6 +93,7 @@ static const char MIXER_CURVE_SMOOTH[] = "smooth";
 /* Section: Channel */
 static const char SECTION_CHANNEL[] = "channel";
 
+static const char CHAN_DISPLAY_SCALE[] = "display-scale";
 static const char CHAN_LIMIT_REVERSE[] = "reverse";
 static const char CHAN_LIMIT_SAFETYSW[] = "safetysw";
 static const char CHAN_LIMIT_SAFETYVAL[] = "safetyval";
@@ -546,6 +547,7 @@ static const struct struct_map _seclimit[] = {
     {CHAN_SCALAR,          OFFSET(Model.limits[0], servoscale), 100},
     {CHAN_SCALAR_NEG,      OFFSET(Model.limits[0], servoscale_neg), 0},
     {CHAN_SUBTRIM,         OFFSETS(Model.limits[0], subtrim), 0},
+    {CHAN_DISPLAY_SCALE,   OFFSETS(Model.limits[0], displayscale), DEFAULT_DISPLAY_SCALE},
 };
 static const struct struct_map _sectrim[] = {
     {TRIM_SOURCE, OFFSET_SRC(Model.trims[0], src), 0xFFFF},
@@ -757,6 +759,12 @@ int assign_int(void* ptr, const struct struct_map *map, int map_size)
             } else {
                 m->limits[idx].failsafe = value_int;
                 m->limits[idx].flags |= CH_FAILSAFE_EN;
+            }
+            return 1;
+        }
+        if (MATCH_KEY(CHAN_DISPLAY_SCALE)) {
+            if (value_int) {
+                m->limits[idx].displayscale = value_int;
             }
             return 1;
         }
@@ -1215,6 +1223,8 @@ u8 CONFIG_WriteModel(u8 model_num) {
         }
         if(WRITE_FULL_MODEL || m->limits[idx].min != DEFAULT_SERVO_LIMIT)
             fprintf(fh, "%s=%d\n", CHAN_LIMIT_MIN, -(int)m->limits[idx].min);
+        if(WRITE_FULL_MODEL || m->limits[idx].displayscale != DEFAULT_DISPLAY_SCALE)
+            fprintf(fh, "%s=%d\n", CHAN_DISPLAY_SCALE, m->limits[idx].displayscale);
         if(WRITE_FULL_MODEL || m->templates[idx] != 0)
             fprintf(fh, "%s=%s\n", CHAN_TEMPLATE, CHAN_TEMPLATE_VAL[m->templates[idx]]);
         write_mixer(fh, m, idx);

--- a/src/config/model.c
+++ b/src/config/model.c
@@ -93,6 +93,7 @@ static const char MIXER_CURVE_SMOOTH[] = "smooth";
 /* Section: Channel */
 static const char SECTION_CHANNEL[] = "channel";
 
+static const char CHAN_DISPLAY_FORMAT[] = "display-format";
 static const char CHAN_DISPLAY_SCALE[] = "display-scale";
 static const char CHAN_LIMIT_REVERSE[] = "reverse";
 static const char CHAN_LIMIT_SAFETYSW[] = "safetysw";
@@ -762,6 +763,10 @@ int assign_int(void* ptr, const struct struct_map *map, int map_size)
             }
             return 1;
         }
+        if (MATCH_KEY(CHAN_DISPLAY_FORMAT)) {
+            strcpy(m->limits[idx].displayformat, value);
+            return 1;
+        }
         if (MATCH_KEY(CHAN_DISPLAY_SCALE)) {
             if (value_int) {
                 m->limits[idx].displayscale = value_int;
@@ -1225,6 +1230,8 @@ u8 CONFIG_WriteModel(u8 model_num) {
             fprintf(fh, "%s=%d\n", CHAN_LIMIT_MIN, -(int)m->limits[idx].min);
         if(WRITE_FULL_MODEL || m->limits[idx].displayscale != DEFAULT_DISPLAY_SCALE)
             fprintf(fh, "%s=%d\n", CHAN_DISPLAY_SCALE, m->limits[idx].displayscale);
+        if(WRITE_FULL_MODEL || strcmp(m->limits[idx].displayformat, DEFAULT_DISPLAY_FORMAT) != 0)
+            fprintf(fh, "%s=%s\n", CHAN_DISPLAY_FORMAT, m->limits[idx].displayformat);
         if(WRITE_FULL_MODEL || m->templates[idx] != 0)
             fprintf(fh, "%s=%s\n", CHAN_TEMPLATE, CHAN_TEMPLATE_VAL[m->templates[idx]]);
         write_mixer(fh, m, idx);

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -213,6 +213,11 @@ s32 MIXER_GetChannel(unsigned channel, enum LimitMask flags)
     return MIXER_ApplyLimits(channel, &Model.limits[channel], raw, Channels, flags);
 }
 
+s16 MIXER_GetChannelDisplayScale(unsigned channel)
+{
+    return Model.limits[channel].displayscale;
+}
+
 #define REZ_SWASH_X(x)  ((x) - (x)/8 - (x)/128 - (x)/512)   //  1024*sin(60) ~= 886
 #define REZ_SWASH_Y(x)  (1*(x))   //  1024 => 1024
 s32 MIXER_CreateCyclicOutput(volatile s32 *raw, unsigned cycnum)
@@ -863,6 +868,7 @@ void MIXER_SetDefaultLimit(struct Limit *limit)
     limit->min = DEFAULT_SERVO_LIMIT;
     limit->servoscale = 100;
     limit->servoscale_neg = 0;  //match servoscale
+    limit->displayscale = DEFAULT_DISPLAY_SCALE;
 }
 
 int MIXER_GetSourceVal(int idx, u32 opts)

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -218,6 +218,11 @@ s16 MIXER_GetChannelDisplayScale(unsigned channel)
     return Model.limits[channel].displayscale;
 }
 
+char* MIXER_GetChannelDisplayFormat(unsigned channel)
+{
+    return Model.limits[channel].displayformat;
+}
+
 #define REZ_SWASH_X(x)  ((x) - (x)/8 - (x)/128 - (x)/512)   //  1024*sin(60) ~= 886
 #define REZ_SWASH_Y(x)  (1*(x))   //  1024 => 1024
 s32 MIXER_CreateCyclicOutput(volatile s32 *raw, unsigned cycnum)
@@ -869,6 +874,7 @@ void MIXER_SetDefaultLimit(struct Limit *limit)
     limit->servoscale = 100;
     limit->servoscale_neg = 0;  //match servoscale
     limit->displayscale = DEFAULT_DISPLAY_SCALE;
+    strcpy(limit->displayformat, DEFAULT_DISPLAY_FORMAT);
 }
 
 int MIXER_GetSourceVal(int idx, u32 opts)

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -1,6 +1,7 @@
 #ifndef _MIXER_H_
 #define _MIXER_H_
 
+#define DEFAULT_DISPLAY_SCALE 100
 #define DEFAULT_SERVO_LIMIT 150
 #define SWASH_INV_ELEVATOR_MASK   1
 #define SWASH_INV_AILERON_MASK    2
@@ -163,6 +164,7 @@ struct Limit {
     s8 failsafe;
     u8 speed;     //measured in degrees/100msec
     s16 subtrim;  // need to support value greater than 250
+    s16 displayscale; // display scale factor
 };
 
 struct Trim {
@@ -182,6 +184,7 @@ unsigned CURVE_NumPoints(struct Curve *curve);
 /* Mixer functions */
 volatile s32 *MIXER_GetInputs();
 s32 MIXER_GetChannel(unsigned channel, enum LimitMask flags);
+s16 MIXER_GetChannelDisplayScale(unsigned channel);
 
 int MIXER_GetMixers(int ch, struct Mixer *mixers, int count);
 int MIXER_SetMixers(struct Mixer *mixers, int count);

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -1,6 +1,7 @@
 #ifndef _MIXER_H_
 #define _MIXER_H_
 
+#define DEFAULT_DISPLAY_FORMAT "%3d%%"
 #define DEFAULT_DISPLAY_SCALE 100
 #define DEFAULT_SERVO_LIMIT 150
 #define SWASH_INV_ELEVATOR_MASK   1
@@ -165,6 +166,7 @@ struct Limit {
     u8 speed;     //measured in degrees/100msec
     s16 subtrim;  // need to support value greater than 250
     s16 displayscale; // display scale factor
+    char displayformat[16];
 };
 
 struct Trim {
@@ -185,6 +187,7 @@ unsigned CURVE_NumPoints(struct Curve *curve);
 volatile s32 *MIXER_GetInputs();
 s32 MIXER_GetChannel(unsigned channel, enum LimitMask flags);
 s16 MIXER_GetChannelDisplayScale(unsigned channel);
+char* MIXER_GetChannelDisplayFormat(unsigned channel);
 
 int MIXER_GetMixers(int ch, struct Mixer *mixers, int count);
 int MIXER_SetMixers(struct Mixer *mixers, int count);

--- a/src/pages/common/_main_page.c
+++ b/src/pages/common/_main_page.c
@@ -83,7 +83,11 @@ const char *show_box_cb(guiObject_t *obj, const void *data)
     } else if(idx - NUM_RTC - NUM_TIMERS <= NUM_TELEM) {
         TELEMETRY_GetValueStr(tempstring, idx - NUM_RTC - NUM_TIMERS);
     } else {
-        sprintf(tempstring, "%3d%%", RANGE_TO_PCT(MIXER_GetChannel(idx - (NUM_RTC + NUM_TIMERS + NUM_TELEM + 1), APPLY_SAFETY | APPLY_SCALAR)));
+        unsigned channel = idx - (NUM_RTC + NUM_TIMERS + NUM_TELEM + 1);
+        s16 val_raw = MIXER_GetChannel(channel, APPLY_SAFETY | APPLY_SCALAR);
+        s16 val_scale = MIXER_GetChannelDisplayScale(channel);
+
+        sprintf(tempstring, "%5d", val_raw/val_scale);
     }
     return tempstring;
 }

--- a/src/pages/common/_main_page.c
+++ b/src/pages/common/_main_page.c
@@ -86,8 +86,9 @@ const char *show_box_cb(guiObject_t *obj, const void *data)
         unsigned channel = idx - (NUM_RTC + NUM_TIMERS + NUM_TELEM + 1);
         s16 val_raw = MIXER_GetChannel(channel, APPLY_SAFETY | APPLY_SCALAR);
         s16 val_scale = MIXER_GetChannelDisplayScale(channel);
+        const char* val_format = MIXER_GetChannelDisplayFormat(channel);
 
-        sprintf(tempstring, "%5d", val_raw/val_scale);
+        sprintf(tempstring, val_format, val_raw/val_scale);
     }
     return tempstring;
 }


### PR DESCRIPTION
I wanted to be able to specify channels in ranges other than [-100, 100] %. For example, I may want to map [-100, 100] % to [-1000, 1000] RPM. I've added the ability to specify the scale factor as well as the `sprintf` format string to facilitate this. To override, specify `display-scale=xxx` and/or `display-format=sss` in a particular channel section of `model.ini`. If `display-scale` or `display-format` are not specified, the default format is used. These options are only exposed by manually editting the `model.ini` file. 