### PR TITLE
#340 fix MIXER_GetChannelDisplayScale/Format

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -215,12 +215,18 @@ s32 MIXER_GetChannel(unsigned channel, enum LimitMask flags)
 
 s16 MIXER_GetChannelDisplayScale(unsigned channel)
 {
-    return Model.limits[channel].displayscale;
+    if (channel < NUM_OUT_CHANNELS)
+        return Model.limits[channel].displayscale;
+    else
+        return DEFAULT_DISPLAY_SCALE;
 }
 
 char* MIXER_GetChannelDisplayFormat(unsigned channel)
 {
-    return Model.limits[channel].displayformat;
+    if (channel < NUM_OUT_CHANNELS)
+        return Model.limits[channel].displayformat;
+    else
+        return DEFAULT_DISPLAY_FORMAT;
 }
 
 #define REZ_SWASH_X(x)  ((x) - (x)/8 - (x)/128 - (x)/512)   //  1024*sin(60) ~= 886


### PR DESCRIPTION
I've fixed `MIXER_GetChannelDisplayScale`/`MIXER_GetChannelDisplayFormat` when used with a virtual channel (discovered in #340). I added a similar check used by [MIXER_ApplyLimits](https://github.com/DeviationTX/deviation/blob/e292f38af3a8188e0d6de0b0e9827cc147a7c5a5/src/mixer.c#L389) and [MIXER_GetLimit](https://github.com/DeviationTX/deviation/blob/e292f38af3a8188e0d6de0b0e9827cc147a7c5a5/src/mixer.c#L659).