### PR TITLE
Fix Frsky volt3 telemetry display, from hexfet

### DIFF
--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -105,20 +105,22 @@ typedef enum {
 
 typedef enum {
     TELEM_FRSKY_RSSI = 1,
-    TELEM_FRSKY_VOLT1,
-    TELEM_FRSKY_VOLT2,
+    TELEM_FRSKY_VOLT1,  // VOLTx enums must be consecutive for
+    TELEM_FRSKY_VOLT2,  // use in telemetry/telem_frsky.c
+#if HAS_EXTENDED_TELEMETRY
+    TELEM_FRSKY_VOLT3,
+#endif
     TELEM_FRSKY_LQI,
     TELEM_FRSKY_LRSSI,
 #if HAS_EXTENDED_TELEMETRY
-    TELEM_FRSKY_VOLT3,
     TELEM_FRSKY_VOLTA,
-    TELEM_FRSKY_TEMP1,
-    TELEM_FRSKY_TEMP2,
+    TELEM_FRSKY_TEMP1,  // TEMPx enums must be consecutive for
+    TELEM_FRSKY_TEMP2,  // use in telemetry/telem_frsky.c
     TELEM_FRSKY_RPM,
     TELEM_FRSKY_MIN_CELL,
     TELEM_FRSKY_ALL_CELL,
-    TELEM_FRSKY_CELL1,
-    TELEM_FRSKY_CELL2,
+    TELEM_FRSKY_CELL1,  // CELLx enums must be consecutive for
+    TELEM_FRSKY_CELL2,  // in telemetry/telem_frsky.c
     TELEM_FRSKY_CELL3,
     TELEM_FRSKY_CELL4,
     TELEM_FRSKY_CELL5,

--- a/src/telemetry/telem_frsky.c
+++ b/src/telemetry/telem_frsky.c
@@ -57,12 +57,16 @@ const char * _frsky_short_name(char *str, u8 telem)
     switch(telem) {
         case 0: strcpy(str, _tr("None")); break;
         case TELEM_FRSKY_VOLT1:
-        case TELEM_FRSKY_VOLT2: sprintf(str, "%s%d", _tr("Volt"), telem - TELEM_FRSKY_VOLT1 + 1); break;
+        case TELEM_FRSKY_VOLT2:
+#if HAS_EXTENDED_TELEMETRY
+        case TELEM_FRSKY_VOLT3:
+#endif
+            sprintf(str, "%s%d", _tr("Volt"), telem - TELEM_FRSKY_VOLT1 + 1);
+            break;
         case TELEM_FRSKY_RSSI:  strcpy(str, _tr("RSSI")); break;
         case TELEM_FRSKY_LRSSI: strcpy(str, _tr("LRSSI")); break;
         case TELEM_FRSKY_LQI:   strcpy(str, _tr("LQI")); break;
 #if HAS_EXTENDED_TELEMETRY
-        case TELEM_FRSKY_VOLT3: sprintf(str, "%s%d", _tr("Volt"), telem - TELEM_FRSKY_VOLT1 + 1); break;
         case TELEM_FRSKY_VOLTA: sprintf(str, "%s%c", _tr("Volt"), (_tr("Amps"))[0]); break;
         case TELEM_FRSKY_MIN_CELL: strcpy(str, _tr("MinCell")); break;
         case TELEM_FRSKY_ALL_CELL: strcpy(str, _tr("AllCell")); break;


### PR DESCRIPTION
The Volt3 value was incorrectly labeled Volt5/TelemV5 when configuring alerts and main page boxes. Changed to display correctly. Added comments where enums must be in order for correct display.

This will break model files that have configured an alert or display box for Volt5/TelemV5, but the effect is just to set the alert/box content to None. Doubtful anyone has tried to display this since Volt3 is not normally in the Frsky telemetry stream.