### PR TITLE
Add 3pos momentary trim switch, from DavidBoone

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -661,6 +661,12 @@ static void _trim_as_switch(unsigned flags, int i, int is_neg)
         } else if (flags & BUTTON_RELEASE) {
             *value = -100;
         }
+    } else if (Model.trims[i].step == TRIM_3POS) {
+        if (flags & BUTTON_PRESS) {
+            *value = is_neg ? -100 : 100;
+        } else if (flags & BUTTON_RELEASE) {
+            *value = 0;
+        }
     } else if (flags & BUTTON_PRESS) {
         if (Model.trims[i].step == TRIM_ONOFF) {
             //On/Off

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -30,7 +30,8 @@ enum {
     TRIM_ONOFF     = 191,
     TRIM_TOGGLE    = 192,
     TRIM_MOMENTARY = 193,
-    TRIM_SWITCH_TYPES = 3,
+    TRIM_3POS      = 194,
+    TRIM_SWITCH_TYPES = 4,
 };
 
 enum Safety {

--- a/src/pages/common/_trim_page.c
+++ b/src/pages/common/_trim_page.c
@@ -105,6 +105,9 @@ static const char *set_trimstep_cb(guiObject_t *obj, int dir, void *data)
     } else if (*value == TRIM_ONOFF) {
         tempstring_cpy(_tr("On/Off"));
         hide_switch = 1;
+    } else if (*value == TRIM_3POS) {
+        tempstring_cpy(_tr("3 Pos"));
+        hide_switch = 1;
     } else if (*value < 100) {
         sprintf(tempstring, "%d.%d", *value / 10, *value % 10);
     } else {
@@ -146,4 +149,3 @@ void PAGE_TrimInit(int page)
 void PAGE_TrimEvent()
 {
 }
-


### PR DESCRIPTION
Adds the ability to use the momentary trim switches as 3 pos switches. ie, normal resting position is centred (0), while pressing the trim one way or the other results in a momentary deflection in one direction (-100) or the other (+100).