### PR TITLE
Add support for 6 independent trims set

### DIFF
--- a/src/config/model.c
+++ b/src/config/model.c
@@ -813,7 +813,7 @@ int assign_int(void* ptr, const struct struct_map *map, int map_size)
             return 1;
         }
         if (MATCH_KEY(TRIM_VALUE)) {
-            parse_int_list(value, m->trims[idx].value, 3, S8);
+            parse_int_list(value, m->trims[idx].value, 6, S8);
             return 1;
         }
         printf("%s: Unknown trim setting: %s\n", section, name);
@@ -1185,9 +1185,11 @@ u8 CONFIG_WriteModel(u8 model_num) {
         write_int(fh, &m->trims[idx], _sectrim, MAPSIZE(_sectrim));
         if(WRITE_FULL_MODEL || m->trims[idx].sw)
             fprintf(fh, "%s=%s\n", TRIM_SWITCH, INPUT_SourceNameAbbrevSwitchReal(file, m->trims[idx].sw));
-        if(WRITE_FULL_MODEL || m->trims[idx].value[0] || m->trims[idx].value[1] || m->trims[idx].value[2])
-            fprintf(fh, "%s=%d,%d,%d\n", TRIM_VALUE,
-                    m->trims[idx].value[0], m->trims[idx].value[1], m->trims[idx].value[2]);
+        if(WRITE_FULL_MODEL || m->trims[idx].value[0] || m->trims[idx].value[1] || m->trims[idx].value[2]
+                            || m->trims[idx].value[3] || m->trims[idx].value[4] || m->trims[idx].value[5])
+            fprintf(fh, "%s=%d,%d,%d,%d,%d,%d\n", TRIM_VALUE,
+                               m->trims[idx].value[0], m->trims[idx].value[1], m->trims[idx].value[2],
+                               m->trims[idx].value[3], m->trims[idx].value[4], m->trims[idx].value[5]);
     }
     if (WRITE_FULL_MODEL || m->swash_type) {
         fprintf(fh, "[%s]\n", SECTION_SWASH);

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -401,7 +401,7 @@ s32 MIXER_ApplyLimits(unsigned channel, struct Limit *limit, volatile s32 *_raw,
 s8 *MIXER_GetTrim(unsigned i)
 {
     if (Model.trims[i].sw) {
-        for (int j = 0; j < 3; j++) {
+        for (int j = 0; j < 6; j++) {
             // Assume switch 0/1/2 are in order
             if(raw[Model.trims[i].sw+j] > 0) {
                 return &Model.trims[i].value[j];

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -167,7 +167,7 @@ struct Trim {
     u8 neg;
     u8 step;
     u8 sw;
-    s8 value[3];
+    s8 value[6];
 };
 
 /* Curve functions */


### PR DESCRIPTION
You can use 4-6 contiguous virtual channels to setup 4-6 pos switch, then assign to trims "Switch" the first used virtual channel and you will have 4-6 independent trims set. The virtual channels switch at any state should have only single channel with +100% value, all others -100%. It's intended for for 4-6 flight modes with independent trims settings.