### PR TITLE
Disable 4IN1_FLASH support for T8SG

### DIFF
--- a/src/target/t8sg/target_defs.h
+++ b/src/target/t8sg/target_defs.h
@@ -24,7 +24,7 @@
 #define HAS_EXTRA_POTS      OPTIONAL
 #define HAS_MULTIMOD_SUPPORT 1
 #define HAS_VIDEO           0
-#define HAS_4IN1_FLASH      1
+#define HAS_4IN1_FLASH      0
 #define HAS_EXTENDED_AUDIO  1
 #define HAS_AUDIO_UART5     1
 #define HAS_MUSIC_CONFIG    1


### PR DESCRIPTION
It has not sense for transmitter with integrated 4in1 module. Probably we can disable 4IN1_FLASH support for all transmitters with plenty flash memory.