### PR TITLE
Add selectable and configurable drawn background

### DIFF
--- a/src/config/display.c
+++ b/src/config/display.c
@@ -143,6 +143,14 @@ static const struct struct_map _secbargraph[] =
     {FG_COLOR_ZERO,          OFFSET_COL(Display.bargraph, fg_color_zero)},
     {OUTLINE_COLOR,          OFFSET_COL(Display.bargraph, outline_color)},
 };
+#if (LCD_WIDTH == 480) || (LCD_WIDTH == 320)
+static const struct struct_map _secbackground[] =
+{
+    {"drawn_background",     OFFSET(Display.background, drawn_background)},
+    {"bg_color",             OFFSET_COL(Display.background, bg_color)},
+    {"hd_color",             OFFSET_COL(Display.background, hd_color)},
+};
+#endif
 
 static int ini_handler(void* user, const char* section, const char* name, const char* value)
 {
@@ -218,6 +226,12 @@ static int ini_handler(void* user, const char* section, const char* name, const 
         if(assign_int(&d->xygraph, _secxygraph, MAPSIZE(_secxygraph)))
             return 1;
     }
+#if (LCD_WIDTH == 480) || (LCD_WIDTH == 320)
+    if(MATCH_SECTION("background")) {
+        if(assign_int(&d->background, _secbackground, MAPSIZE(_secbackground)))
+            return 1;
+    }
+#endif
     for (idx = 0; idx < NUM_STR_ELEMS(BARGRAPH_VAL); idx++) {
         if(MATCH_SECTION(BARGRAPH_VAL[idx])) {
             struct disp_bargraph *graph;

--- a/src/config/display.h
+++ b/src/config/display.h
@@ -78,6 +78,14 @@ struct disp_metrics {
     u8 line_space;
 };
 
+#if (LCD_WIDTH == 480) || (LCD_WIDTH == 320)
+struct disp_background {
+    u16 drawn_background;
+    u16 bg_color;
+    u16 hd_color;
+};
+#endif
+
 enum DispFlags {
     BAR_TRANSPARENT   = 0x01,
     TRIM_TRANSPARENT  = 0x02,
@@ -91,6 +99,9 @@ struct display_settings {
     struct disp_listbox listbox;
     struct disp_scrollbar scrollbar;
     struct disp_metrics metrics;
+#if (LCD_WIDTH == 480) || (LCD_WIDTH == 320)
+    struct disp_background background;
+#endif
     struct disp_bargraph bargraph;
     struct disp_xygraph xygraph;
     struct disp_bargraph trim;

--- a/src/fs/320x240x16/media/config.ini
+++ b/src/fs/320x240x16/media/config.ini
@@ -5,6 +5,11 @@
 ;  bat_icon=1
    header_time=1
 
+[background]
+  drawn_background=0
+  bg_color=50A0D8
+  hd_color=707070
+
 [font-default]
   font=15normal
   font_color=000000

--- a/src/gui/320x240x16/_gui.c
+++ b/src/gui/320x240x16/_gui.c
@@ -42,7 +42,18 @@ void _gui_hilite_selected(struct guiObject *obj)
 
 void _gui_draw_background(int x, int y, int w, int h)
 {
-    LCD_DrawWindowedImageFromFile(x, y, "media/devo8" IMG_EXT, w, h, x, y);
+    if(Display.background.drawn_background) {
+        if(y + h < 32) {
+            LCD_FillRect(x, y, w, h, Display.background.hd_color);
+        } else if(y >= 32) {
+            LCD_FillRect(x, y, w, h, Display.background.bg_color);
+        } else {
+            LCD_FillRect(x, y, w, 32 - y, Display.background.hd_color);
+            LCD_FillRect(x, 32, w, h - 32 + y, Display.background.bg_color);
+        }
+    } else {
+        LCD_DrawWindowedImageFromFile(x, y, "media/devo8" IMG_EXT, w, h, x, y);
+    }
 }
 
 // Bug fix: Unlike devo8, devo10's page always has 1 default selected objects. When a dialog, e.g. saftydialog,

--- a/src/gui/480x272x16/_gui.c
+++ b/src/gui/480x272x16/_gui.c
@@ -42,7 +42,18 @@ void _gui_hilite_selected(struct guiObject *obj)
 
 void _gui_draw_background(int x, int y, int w, int h)
 {
-	LCD_DrawWindowedImageFromFile(x, y, "media/devo12" IMG_EXT, w, h, x, y);
+    if(Display.background.drawn_background) {
+        if(y + h < 32) {
+            LCD_FillRect(x, y, w, h, Display.background.hd_color);
+        } else if(y >= 32) {
+            LCD_FillRect(x, y, w, h, Display.background.bg_color);
+        } else {
+            LCD_FillRect(x, y, w, 32 - y, Display.background.hd_color);
+            LCD_FillRect(x, 32, w, h - 32 + y, Display.background.bg_color);
+        }
+    } else {
+        LCD_DrawWindowedImageFromFile(x, y, "media/devo12" IMG_EXT, w, h, x, y);
+    }
 }
 
 // Bug fix: Unlike devo8, devo10's page always has 1 default selected objects. When a dialog, e.g. saftydialog,


### PR DESCRIPTION
You can select to draw background instead a background image for color GUI. This will greatly speed up the drawing of the pages. You can set header color and background color. The settings are in "config.ini" file. By default used background image.

```
[background]
  drawn_background=0
  bg_color=50A0D8
  hd_color=707070

```