### PR TITLE
Fix startup sound volume with drawn background

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -97,6 +97,10 @@ int main() {
     audio_queue_time = CLOCK_getms() + 1500;
     num_audio=1;
     next_audio=1;
+#if (LCD_WIDTH == 480) || (LCD_WIDTH == 320)
+    if(Display.background.drawn_background)
+        while(CLOCK_getms() < audio_queue_time - 1200);
+#endif
     AUDIO_SetVolume(); // Initial setting of voice volume
 #endif
 


### PR DESCRIPTION
With drawn background added delay 0.3sec in order to extended sound device be ready to set volume.