### PR TITLE
Temporary fix for toggle icon position reset

### DIFF
--- a/src/pages/320x240x16/main_layout.c
+++ b/src/pages/320x240x16/main_layout.c
@@ -126,7 +126,10 @@ void PAGE_MainLayoutExit()
 }
 void PAGE_MainLayoutRestoreDialog(int idx)
 {
-    show_config_menu = idx;
+    //temporary fix for reset toggle icon position after toggle icon selection
+    //show_config_menu = idx;
+    lp->selected_for_move = idx;
+    select_for_move(&gui->elem[lp->selected_for_move]);
 }
 
 void set_selected_for_move(int idx)


### PR DESCRIPTION
Issue: the main layout toggle icon position will reset to x=0 y=32 after toggle icon change/selection.

I can't find the specific reason, so it's temporary fix, all works right but not as it should work.