### PR TITLE
Disable datalog for devof4-XMS and devof7-XMS

### DIFF
--- a/src/target/devof4-XMS/Makefile.inc
+++ b/src/target/devof4-XMS/Makefile.inc
@@ -16,4 +16,9 @@ SRC_C   += $(SDIR)/target/devof7/backlight.c\
            $(SDIR)/target/devof7/tx_buttons.c \
            $(SDIR)/target/devof7/crc.c
 
+else
+
+$(TARGET).fs_wrapper: $(LAST_MODEL)
+	rm filesystem/$(FILESYSTEM)/datalog.bin
+
 endif

--- a/src/target/devof4-XMS/target_defs.h
+++ b/src/target/devof4-XMS/target_defs.h
@@ -28,7 +28,7 @@
 #define HAS_TOUCH           0
 #define HAS_RTC             0
 #define HAS_VIBRATINGMOTOR  1
-#define HAS_DATALOG         1
+#define HAS_DATALOG         0
 #define HAS_SCANNER         0
 #define HAS_LAYOUT_EDITOR   0
 #define HAS_EXTRA_SWITCHES  OPTIONAL

--- a/src/target/devof7-XMS/Makefile.inc
+++ b/src/target/devof7-XMS/Makefile.inc
@@ -17,4 +17,9 @@ SRC_C   += $(SDIR)/target/devof7/backlight.c \
            $(SDIR)/target/devof7/lcd.c \
            $(SDIR)/target/devof7/tx_buttons.c
 
+else
+
+$(TARGET).fs_wrapper: $(LAST_MODEL)
+	rm filesystem/$(FILESYSTEM)/datalog.bin
+
 endif

--- a/src/target/devof7-XMS/target_defs.h
+++ b/src/target/devof7-XMS/target_defs.h
@@ -28,7 +28,7 @@
 #define HAS_TOUCH           0
 #define HAS_RTC             0
 #define HAS_VIBRATINGMOTOR  1
-#define HAS_DATALOG         1
+#define HAS_DATALOG         0
 #define HAS_SCANNER         0
 #define HAS_LAYOUT_EDITOR   0
 #define HAS_EXTRA_SWITCHES  OPTIONAL


### PR DESCRIPTION
Because of lack of memory for future updates.