### PR TITLE
Optimize GUI redraw

### DIFF
--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -12,6 +12,15 @@
 #include "_gui.h"
 
 #define RGB888_to_RGB565(r, g, b) (((r & 0xf8) << 8) | ((g & 0xfc) << 3) | ((b & 0xf8) >>3))
+
+enum FULL_REDRAW {
+    REDRAW_ONLY_DIRTY   = 0x00,
+    REDRAW_IF_NOT_MODAL = 0x01,
+    REDRAW_EVERYTHING   = 0x02,
+};
+
+extern u8 FullRedraw;
+
 enum DialogType {
     dtOk, dtCancel, dtOkCancel, dtNone,
 };
@@ -23,6 +32,7 @@ enum BarGraphDirection {
     TRIM_INVHORIZONTAL,
     TRIM_VERTICAL,
 };
+
 enum TextSelectType {
     TEXTSELECT_224,
     TEXTSELECT_128,

--- a/src/gui/scrollable.c
+++ b/src/gui/scrollable.c
@@ -195,7 +195,13 @@ static int create_scrollable_objs(guiScrollable_t *scrollable, int row, int offs
     scrollable->cur_row = row;
     int rel_row = 0;
     int selectable, num_selectable = 0;
+#if (LCD_WIDTH != 66) && (LCD_WIDTH != 24)
+    u8 redraw_mode = FullRedraw;
     GUI_RemoveScrollableObjs((guiObject_t *)scrollable);
+    FullRedraw = redraw_mode;
+#else
+    GUI_RemoveScrollableObjs((guiObject_t *)scrollable);
+#endif
     guiObject_t *head = objHEAD;
     objHEAD = NULL;
     for(int y = scrollable->header.box.y, bottom = y + scrollable->header.box.height;
@@ -236,6 +242,9 @@ static int create_scrollable_objs(guiScrollable_t *scrollable, int row, int offs
     GUI_SetHidden((guiObject_t *)&scrollable->scrollbar, hidden);
     if (! hidden)
         GUI_SetScrollbar(&scrollable->scrollbar, scroll_pos);
+#if (LCD_WIDTH != 66) && (LCD_WIDTH != 24)
+    OBJ_SET_DIRTY((guiObject_t *)scrollable, 1);
+#endif
     //return new index of selected item
     if (idx >= 0 && idx < num_selectable)
         return idx;

--- a/src/pages/128x64x1/advanced/mixer_limits.c
+++ b/src/pages/128x64x1/advanced/mixer_limits.c
@@ -130,7 +130,7 @@ void revert_cb(guiObject_t *obj, const void *data)
     (void)obj;
     memcpy(&mp->limit, (const void *)&origin_limit, sizeof(origin_limit));
     MIXER_SetLimit(mp->channel, &mp->limit);  // save
-    GUI_DrawScreen();
+    FullRedraw = REDRAW_EVERYTHING;
 }
 
 static unsigned action_cb(u32 button, unsigned flags, void *data)

--- a/src/pages/128x64x1/main_layout.c
+++ b/src/pages/128x64x1/main_layout.c
@@ -83,7 +83,7 @@ void show_layout()
     GUI_CreateLabel(&gui->xlbl, 0,  1, NULL, micro, "X:");
     GUI_CreateLabelBox(&gui->x, 8, 1, 13, 6, &micro, pos_cb, NULL, (void *) 0L);
     GUI_CreateLabel(&gui->ylbl, 22, 1, NULL, micro, "Y:");
-    GUI_CreateLabelBox(&gui->y, 30, 1, 9, 6, &micro, pos_cb, NULL, (void *) 1L);
+    GUI_CreateLabelBox(&gui->y, 30, 1, 10, 6, &micro, pos_cb, NULL, (void *) 1L);
     //gui->y must be the last element!
     GUI_SelectionNotify(notify_cb);
 
@@ -91,6 +91,7 @@ void show_layout()
     if(OBJ_IS_USED(&gui->elem[0]))
         GUI_SetSelected((guiObject_t *)&gui->elem[0]);
 }
+
 void layout_exit()
 {
     GUI_SelectionNotify(NULL);

--- a/src/pages/320x240x16/advanced/mixer_page.c
+++ b/src/pages/320x240x16/advanced/mixer_page.c
@@ -17,6 +17,7 @@
 #include "../pages.h"
 #include "config/model.h"
 #include "../icons.h"
+#include "gui/gui.h"
 
 #include "../../common/advanced/_mixer_page.c"
 
@@ -47,7 +48,9 @@ static void _show_page()
     int i;
     if (mp->firstObj) {
         GUI_RemoveHierObjects(mp->firstObj);
+        FullRedraw = REDRAW_ONLY_DIRTY;
         mp->firstObj = NULL;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
     }
     struct Mixer *mix = MIXER_GetAllMixers();
     for (i = 0; i < ENTRIES_PER_PAGE; i++) {

--- a/src/pages/320x240x16/chantest_page.c
+++ b/src/pages/320x240x16/chantest_page.c
@@ -37,6 +37,8 @@ static int scroll_cb(guiObject_t *parent, u8 pos, s8 direction, void *data)
         newpos = endpos;
     if (newpos != cur_row) {
         GUI_RemoveHierObjects((guiObject_t *)&gui->chan[0]);
+        FullRedraw = REDRAW_ONLY_DIRTY;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
         _show_bar_page(newpos);
     }
     return cur_row;
@@ -96,7 +98,6 @@ static void _show_bar_page(int row)
         GUI_CreateScrollbar(&gui->scrollbar, LCD_WIDTH-16, 32, LCD_HEIGHT-32, num_rows-1, NULL, scroll_cb, NULL);
         GUI_SetScrollbar(&gui->scrollbar, cur_row);
     }
-        
 }
 
 void PAGE_ChantestInit(int page)

--- a/src/pages/320x240x16/main_layout.c
+++ b/src/pages/320x240x16/main_layout.c
@@ -120,19 +120,23 @@ void PAGE_MainLayoutInit(int page)
     GUI_SelectionNotify(notify_cb);
     draw_elements();
 }
+
 void PAGE_MainLayoutEvent()
 {
 }
+
 void PAGE_MainLayoutExit()
 {
     GUI_SelectionNotify(NULL);
     BUTTON_UnregisterCallback(&action);
 }
+
 void PAGE_MainLayoutRestoreDialog(int idx)
 {
     GUI_RemoveAllObjects();
     PAGE_MainLayoutInit(0);
-    lp->selected_for_move = idx;
+    lp->selected_for_move = - 1;
+    select_for_move(&gui->elem[idx]);
     show_config();
 }
 
@@ -144,6 +148,7 @@ void set_selected_for_move(int idx)
     GUI_TextSelectEnable(&gui->x, state);
     GUI_TextSelectEnable(&gui->y, state);
 }
+
 const char *xpos_cb(guiObject_t *obj, int dir, void *data)
 {
     (void)obj;
@@ -158,6 +163,7 @@ const char *xpos_cb(guiObject_t *obj, int dir, void *data)
     sprintf(tempstring, "%d", lp->selected_x);
     return tempstring;
 }
+
 const char *ypos_cb(guiObject_t *obj, int dir, void *data)
 {
     (void)obj;
@@ -312,8 +318,11 @@ void show_config()
     int count = 0;
     int row_idx = 0;
     long type;
-    if (OBJ_IS_USED(&gui->dialog))
+    if (OBJ_IS_USED(&gui->dialog)) {
+        u8 draw_mode = FullRedraw;
         GUI_RemoveObj((guiObject_t *)&gui->dialog);
+        FullRedraw = draw_mode;
+    }
     if(lp->selected_for_move >= 0) {
         type = ELEM_TYPE(pc->elem[lp->selected_for_move]);
         row_idx = elem_abs_to_rel(lp->selected_for_move);

--- a/src/pages/320x240x16/standard/drexp_page.c
+++ b/src/pages/320x240x16/standard/drexp_page.c
@@ -96,7 +96,7 @@ static void _refresh_page() {
     GUI_SetHidden((guiObject_t *)&gui->exp[2], hide3);
     GUI_SetHidden((guiObject_t *)&gui->graph[2], hide3);
 
-    GUI_RedrawAllObjects();
+    FullRedraw = REDRAW_EVERYTHING;
 }
 
 void PAGE_DrExpCurvesEvent()

--- a/src/pages/320x240x16/standard/failsafe_page.c
+++ b/src/pages/320x240x16/standard/failsafe_page.c
@@ -29,8 +29,10 @@ static void show_page(int page)
     struct mixer_page * mp = &pagemem.u.mixer_page;
     if (mp->firstObj) {
         GUI_RemoveHierObjects(mp->firstObj);
-        mp->firstObj = NULL;       
-    }   
+        FullRedraw = REDRAW_ONLY_DIRTY;
+        mp->firstObj = NULL;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
+    }
     for (long i = 0; i < ENTRIES_PER_PAGE; i++) {
         int row = 40 + ((LCD_HEIGHT - 240) / 2) + 24 * i;
         long ch = page  + i;

--- a/src/pages/320x240x16/standard/reverse_page.c
+++ b/src/pages/320x240x16/standard/reverse_page.c
@@ -37,8 +37,10 @@ static void show_page(int page)
     struct mixer_page * mp = &pagemem.u.mixer_page;
     if (mp->firstObj) {
         GUI_RemoveHierObjects(mp->firstObj);
-        mp->firstObj = NULL;       
-    }   
+        FullRedraw = REDRAW_ONLY_DIRTY;
+        mp->firstObj = NULL;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
+    }
     for (long i = 0; i < ENTRIES_PER_PAGE; i++) {
         int row = 40 + ((LCD_HEIGHT - 240) / 2) + 24 * i;
         long ch = page  + i;

--- a/src/pages/320x240x16/standard/subtrim_page.c
+++ b/src/pages/320x240x16/standard/subtrim_page.c
@@ -29,8 +29,10 @@ static void show_page(int page)
     struct mixer_page * mp = &pagemem.u.mixer_page;
     if (mp->firstObj) {
         GUI_RemoveHierObjects(mp->firstObj);
-        mp->firstObj = NULL;       
-    }   
+        FullRedraw = REDRAW_ONLY_DIRTY;
+        mp->firstObj = NULL;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
+    }
     for (long i = 0; i < ENTRIES_PER_PAGE; i++) {
         int row = 40 + ((LCD_HEIGHT - 240) / 2) + 24 * i;
         long ch = page  + i;

--- a/src/pages/320x240x16/standard/traveladj_page.c
+++ b/src/pages/320x240x16/standard/traveladj_page.c
@@ -26,13 +26,16 @@ static struct stdtravel_obj * const gui = &gui_objs.u.stdtravel;
 
 static void show_page(int page)
 {
+    static const int YOFFSET = 56 + ((LCD_HEIGHT - 240) / 2);
     struct mixer_page * mp = &pagemem.u.mixer_page;
     if (mp->firstObj) {
         GUI_RemoveHierObjects(mp->firstObj);
-        mp->firstObj = NULL;       
-    }   
+        FullRedraw = REDRAW_ONLY_DIRTY;
+        mp->firstObj = NULL;
+        GUI_DrawBackground(0, YOFFSET, LCD_WIDTH - 16, LCD_HEIGHT - YOFFSET);
+    }
     for (long i = 0; i < ENTRIES_PER_PAGE; i++) {
-        int row = 56 + ((LCD_HEIGHT - 240) / 2) + 22 * i;
+        int row = YOFFSET + 22 * i;
         long ch = page  + i;
         if (ch >= Model.num_channels)
             break;

--- a/src/pages/320x240x16/timer_page.c
+++ b/src/pages/320x240x16/timer_page.c
@@ -80,7 +80,9 @@ static void _show_page(int page)
 static void _draw_body() {
     if (firstObj) {
         GUI_RemoveHierObjects(firstObj);
+        FullRedraw = REDRAW_ONLY_DIRTY;
         firstObj = NULL;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
     }
     int COL1 = 30;
     int COL2 = 103;

--- a/src/pages/320x240x16/toggle_select.c
+++ b/src/pages/320x240x16/toggle_select.c
@@ -88,6 +88,8 @@ static int scroll_cb(guiObject_t *parent, u8 pos, s8 direction, void *data)
         }
     }
     GUI_RemoveHierObjects((guiObject_t *)&gui->symbolicon[0]);
+    FullRedraw = REDRAW_ONLY_DIRTY;
+    GUI_DrawBackground(0, 79, LCD_WIDTH - 16, LCD_HEIGHT - 79);
     show_icons((long)data, idx);
     return page;
 }

--- a/src/pages/320x240x16/tx_configure.c
+++ b/src/pages/320x240x16/tx_configure.c
@@ -109,7 +109,9 @@ static void _show_page()
 {
     if (firstObj) {
         GUI_RemoveHierObjects(firstObj);
+        FullRedraw = REDRAW_ONLY_DIRTY;
         firstObj = NULL;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
     }
     guiObject_t *obj;
     u8 space = 19;

--- a/src/pages/common/_main_config.c
+++ b/src/pages/common/_main_config.c
@@ -186,6 +186,32 @@ static void dlgbut_cb(struct guiObject *obj, const void *data)
     (void)obj;
     int idx = (long)data;
     u32 i;
+#if (LCD_WIDTH == 320) || (LCD_WIDTH == 480)
+    u16 x, y, w, h;
+    //Close the dialog
+    if (OBJ_IS_USED(&gui->dialog)) {
+        u8 draw_mode = FullRedraw;
+        GUI_RemoveObj((guiObject_t *)&gui->dialog);
+        FullRedraw = draw_mode;
+    }
+    //Erase object
+    GetWidgetLoc(&pc->elem[idx], &x, &y, &w, &h);
+    if (x > 0) {
+        x -= 1;
+        w += 2;
+    }
+    if (y > 0) {
+        y -= 1;
+        h += 2;
+    }
+    if(x + w > LCD_WIDTH) {
+        w = LCD_WIDTH - x;
+    }
+    if(y + h > LCD_HEIGHT) {
+        h = LCD_HEIGHT - y;
+    }
+    GUI_DrawBackground(x, y, w, h);
+#endif
     //Remove object
     int type = ELEM_TYPE(pc->elem[idx]);
     for(i = idx+1; i < NUM_ELEMS; i++) {
@@ -197,7 +223,7 @@ static void dlgbut_cb(struct guiObject *obj, const void *data)
          ELEM_SET_Y(pc->elem[i-1], 0);
     idx = MAINPAGE_FindNextElem(type, 0);
     set_selected_for_move(idx);
-    //close the dialog and reopen with new elements
+    //Open the dialog with new elements
     show_config();
 }
 

--- a/src/pages/common/_main_layout.c
+++ b/src/pages/common/_main_layout.c
@@ -31,8 +31,11 @@ void draw_elements()
     u16 x, y, w, h;
     set_selected_for_move(-1);
     guiObject_t *obj = gui->y.header.next;
-    if (obj)
+    if (obj) {
+        u8 redraw_mode = FullRedraw;
         GUI_RemoveHierObjects(obj);
+        FullRedraw = redraw_mode;
+    }
     for(u32 i = 0; i < NUM_ELEMS; i++) {
         if (! GetWidgetLoc(&pc->elem[i], &x, &y, &w, &h))
             break;
@@ -133,10 +136,27 @@ int guielem_idx(guiObject_t *obj)
 
 void move_elem()
 {
+    u16 x, y, w, h;
     guiObject_t *obj = GUI_GetSelected();
     if ((guiLabel_t *)obj < gui->elem)
         return;
     int idx = guielem_idx(obj);
+    GetWidgetLoc(&pc->elem[idx], &x, &y, &w, &h);
+    if (x > 0) {
+        x -= 1;
+        w += 2;
+    }
+    if (y > 0) {
+        y -= 1;
+        h += 2;
+    }
+    if(x + w > LCD_WIDTH) {
+        w = LCD_WIDTH - x;
+    }
+    if(y + h > LCD_HEIGHT) {
+        h = LCD_HEIGHT - y;
+    }
+    GUI_DrawBackground(x, y, w, h);
     ELEM_SET_X(pc->elem[idx], lp->selected_x);
     ELEM_SET_Y(pc->elem[idx], lp->selected_y);
     draw_elements();
@@ -153,6 +173,8 @@ void notify_cb(guiObject_t *obj)
     GetElementSize(ELEM_TYPE(pc->elem[idx]), &lp->selected_w, &lp->selected_h);
     if (ELEM_TYPE(pc->elem[idx]) == ELEM_MODELICO)
         AdjustIconSize(&lp->selected_x, &lp->selected_y, &lp->selected_h, &lp->selected_w);
+    GUI_Redraw((guiObject_t *)&gui->xlbl);
     GUI_Redraw((guiObject_t *)&gui->x);
+    GUI_Redraw((guiObject_t *)&gui->ylbl);
     GUI_Redraw((guiObject_t *)&gui->y);
 }

--- a/src/pages/common/_model_page.c
+++ b/src/pages/common/_model_page.c
@@ -311,7 +311,7 @@ static void file_press_cb(guiObject_t *obj, void *data)
     if (mp->file_state == 3) {
         CONFIG_ResetModel();
         CONFIG_SaveModelIfNeeded();
-        GUI_RedrawAllObjects();
+        FullRedraw = REDRAW_EVERYTHING;
     } else {
         MODELPage_ShowLoadSave(mp->file_state, PAGE_ModelInit);
     }


### PR DESCRIPTION
* Avoid full page redraw for any scrollable object change. It looks much more naturally if updated the scrollable area only, but not the full page.
* Avoid full page redraw with every item position change at "Main layout edit" page.
* Avoid full page redraw after close any dialog window.
* Optimize redraw objects after close dialog window, redraw underlying objects only.