### PR TITLE
Update UART_ API to support serial protocol development

### DIFF
--- a/src/target.h
+++ b/src/target.h
@@ -178,10 +178,21 @@ void VIBRATINGMOTOR_Start();
 void VIBRATINGMOTOR_Stop();
 
 /* UART & Debug */
+typedef enum {
+    UART_STOPBITS_1,
+    UART_STOPBITS_1_5,
+    UART_STOPBITS_2,
+} uart_stopbits;
+typedef enum {
+    UART_PARITY_EVEN,
+    UART_PARITY_ODD,
+    UART_PARITY_NONE,
+} uart_parity;
 void UART_Initialize();
 void UART_Stop();
 u8 UART_Send(u8 *data, u16 len);
 void UART_SetDataRate(u32 bps);
+void UART_SetFormat(int bits, uart_parity parity, uart_stopbits stopbits);
 
 /* USB*/
 void USB_Enable(unsigned type, unsigned use_interrupt);

--- a/src/target/common/devo/uart.c
+++ b/src/target/common/devo/uart.c
@@ -84,16 +84,39 @@ void UART_Stop()
 
 void UART_SetDataRate(u32 bps)
 {
-    switch (bps) {
-    case   9600:
-    case  57600:
-    case 115200:
-      break;
-    default:
-      bps = 115200;
-    }
+    if (bps > 2000000) bps = 2000000;
 
     usart_set_baudrate(_USART, bps);
+}
+
+void UART_SetFormat(int bits, uart_parity parity, uart_stopbits stopbits)
+{
+    // STM counts parity bit as part of databits length
+    // so bits and parity settings are interdependent.
+    if (bits == 8) {
+        if (parity == UART_PARITY_NONE) {
+            usart_set_databits(_USART, 8);
+            usart_set_parity(_USART, USART_PARITY_NONE);
+        } else {
+            usart_set_databits(_USART, 9);
+            if (parity == UART_PARITY_EVEN)
+                usart_set_parity(_USART, USART_PARITY_EVEN);
+            else
+                usart_set_parity(_USART, USART_PARITY_ODD);
+        }
+    } else if (bits == 7 && parity != UART_PARITY_NONE) {
+        usart_set_databits(_USART, 8);
+        if (parity == UART_PARITY_EVEN)
+            usart_set_parity(_USART, USART_PARITY_EVEN);
+        else
+            usart_set_parity(_USART, USART_PARITY_ODD);
+    }
+
+    switch (stopbits) {
+    case UART_STOPBITS_1:   usart_set_stopbits(_USART, USART_STOPBITS_1); break;
+    case UART_STOPBITS_1_5: usart_set_stopbits(_USART, USART_STOPBITS_1_5); break;
+    case UART_STOPBITS_2:   usart_set_stopbits(_USART, USART_STOPBITS_2); break;
+    }
 }
 
 static volatile u8 busy;


### PR DESCRIPTION
Support for SBUS requires non-standard data rate and parity and stop bit changes.  Other serial protocols need similar control.