### PR TITLE
Fix display of text in startup warnings

### DIFF
--- a/src/pages/128x64x1/dialogs.c
+++ b/src/pages/128x64x1/dialogs.c
@@ -121,10 +121,9 @@ void PAGE_ShowWarning(const char *title, const char *str)
     (void)title;
     if (dialog)
         return;
-    if (str != tempstring)
-        tempstring_cpy(str);
+    snprintf(dlg_string, sizeof(dlg_string), "%s", str);
     dialog = GUI_CreateDialog(&gui->dialog, DIALOG3_X, DIALOG3_Y,
-                 DIALOG3_WIDTH, DIALOG3_HEIGHT, NULL, NULL, lowbatt_ok_cb, dtOk, tempstring);
+                 DIALOG3_WIDTH, DIALOG3_HEIGHT, NULL, NULL, lowbatt_ok_cb, dtOk, dlg_string);
 }
 
 

--- a/src/pages/320x240x16/dialogs.c
+++ b/src/pages/320x240x16/dialogs.c
@@ -100,10 +100,9 @@ void PAGE_ShowWarning(const char *title, const char *str)
 {   
     if (dialog)
         return;
-    if(str != tempstring)
-        sprintf(tempstring, "%s", str);
+    snprintf(dlg_string, sizeof(dlg_string), "%s", str);
     dialogcrc = 0;
-    dialog = GUI_CreateDialog(&gui->dialog, 10 + DLG_XOFFSET, 42 + DLG_YOFFSET, 300, 188, title, NULL, lowbatt_ok_cb, dtOk, tempstring);
+    dialog = GUI_CreateDialog(&gui->dialog, 10 + DLG_XOFFSET, 42 + DLG_YOFFSET, 300, 188, title, NULL, lowbatt_ok_cb, dtOk, dlg_string);
 }
 
 void PAGE_ShowLowBattDialog()

--- a/src/pages/common/_dialogs.c
+++ b/src/pages/common/_dialogs.c
@@ -15,6 +15,7 @@
 
 
 static guiObject_t *dialog = NULL;
+static char dlg_string[LCD_DEPTH == 1 ? 64 : 256];
 
 /******************/
 /*  Safety Dialog */


### PR DESCRIPTION
We can't use "tempstring" for early warnings (such as "Missing modules"), since "tempstring" used by draw screen and will be overwritten before warning will draw.