### PR TITLE
Optimize GUI redraw

### DIFF
--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -28,15 +28,10 @@ static void (*select_notify)(guiObject_t *obj) = NULL;
 
 static struct guiObject *objACTIVE = NULL;
 
-enum FULL_REDRAW {
-    REDRAW_ONLY_DIRTY   = 0x00,
-    REDRAW_IF_NOT_MODAL = 0x01,
-    REDRAW_EVERYTHING   = 0x02,
-};
-
 static buttonAction_t button_action;
 static buttonAction_t button_modalaction;
-static u8 FullRedraw;
+u8 FullRedraw;
+
 #if HAS_TOUCH
 static u8 change_selection_on_touch = 1;
 static u8 in_touch = 0;
@@ -184,7 +179,11 @@ void GUI_RemoveObj(struct guiObject *obj)
             prev = prev->next;
         }
     }
-    FullRedraw = objHEAD ? REDRAW_IF_NOT_MODAL : REDRAW_EVERYTHING;
+    if(obj->Type == Dialog) {
+        FullRedraw = REDRAW_ONLY_DIRTY;
+    } else {
+        FullRedraw = objHEAD ? REDRAW_IF_NOT_MODAL : REDRAW_EVERYTHING;
+    }
 }
 
 void GUI_RemoveHierObjects(struct guiObject *obj)
@@ -226,24 +225,6 @@ void GUI_DrawBackground(u16 x, u16 y, u16 w, u16 h)
         _gui_draw_background(x, y, w, h);
 }
 
-void GUI_DrawScreen(void)
-{
-#ifdef DEBUG_DRAW
-    printf("DrawScreen\n");
-#endif
-    /*
-     * First we need to draw the main background
-     *  */
-    GUI_DrawBackground(0, 0, LCD_WIDTH, LCD_HEIGHT);
-    /*
-     * Then we need to draw any supporting GUI
-     */
-    FullRedraw = REDRAW_IF_NOT_MODAL;
-    GUI_DrawObjects();
-    FullRedraw = REDRAW_ONLY_DIRTY;
-    LCD_ForceUpdate();
-}
-
 struct guiObject *GUI_IsModal(void)
 {
     struct guiObject *obj = objHEAD;
@@ -264,7 +245,44 @@ void _GUI_Redraw(struct guiObject *obj)
 
 void GUI_RedrawAllObjects()
 {
-    FullRedraw = REDRAW_EVERYTHING;
+    struct guiObject *obj = objHEAD;
+    while(obj) {
+        if(! OBJ_IS_HIDDEN(obj)) {
+            if (obj->Type == Scrollable && ((guiScrollable_t *)obj)->head) {
+                //Redraw scrollable contents
+                guiObject_t *head = objHEAD;
+                objHEAD = ((guiScrollable_t *)obj)->head;
+                GUI_RedrawAllObjects();
+                objHEAD = head;
+            }
+            OBJ_SET_DIRTY(obj, 1);
+        } else {
+            OBJ_SET_DIRTY(obj, 0);
+        }
+        obj = obj->next;
+    }
+}
+
+void _GUI_RedrawUnderlyingObjects(u16 x, u16 y, u16 w, u16 h)
+{
+    struct guiObject *obj = objHEAD;
+    while(obj) {
+        if(! OBJ_IS_HIDDEN(obj) &&
+          (! ((obj->box.x + obj->box.width < x) ||
+              (obj->box.x > x + w) ||
+              (obj->box.y + obj->box.height < y) ||
+              (obj->box.y > y + h)) || obj->Type == Label)) {
+            if (obj->Type == Scrollable && ((guiScrollable_t *)obj)->head) {
+                //Redraw scrollable contents
+                guiObject_t *head = objHEAD;
+                objHEAD = ((guiScrollable_t *)obj)->head;
+                GUI_RedrawAllObjects();
+                objHEAD = head;
+            }
+            OBJ_SET_DIRTY(obj, 1);
+        }
+        obj = obj->next;
+    }
 }
 
 void GUI_HideObjects(struct guiObject *headObj, struct guiObject *modalObj)
@@ -283,9 +301,11 @@ void GUI_HideObjects(struct guiObject *headObj, struct guiObject *modalObj)
 
 void _GUI_RefreshScreen(struct guiObject *headObj)
 {
+    static u8 dlg_active = 0;
+    static u16 x, y, w, h;
     struct guiObject *modalObj = GUI_IsModal();
-
     struct guiObject *obj;
+
     if (FullRedraw) {
 #ifdef DEBUG_DRAW
         printf("Full Redraw requested: %d\n", FullRedraw);
@@ -294,9 +314,36 @@ void _GUI_RefreshScreen(struct guiObject *headObj)
             //Handle Dialog redraw as an incremental
             FullRedraw = REDRAW_ONLY_DIRTY;
         } else {
-            GUI_DrawScreen();
+            dlg_active = 0;
+            //First we need to draw the main background
+            GUI_DrawBackground(0, 0, LCD_WIDTH, LCD_HEIGHT);
+            //Then we need to draw any supporting GUI
+            FullRedraw = REDRAW_IF_NOT_MODAL;
+            struct guiObject *obj = objHEAD;
+            while(obj) {
+                if(! OBJ_IS_HIDDEN(obj)) {
+                    if(obj->Type == Dialog) {
+                        dlg_active = 1;
+                        x = obj->box.x;
+                        y = obj->box.y;
+                        w = obj->box.width;
+                        h = obj->box.height;
+                    }
+                    GUI_DrawObject(obj);
+                } else {
+                    OBJ_SET_DIRTY(obj, 0);
+                }
+                obj = obj->next;
+            }
+            FullRedraw = REDRAW_ONLY_DIRTY;
             return;
         }
+    }
+    if(dlg_active && (objDIALOG == NULL)) {
+        dlg_active = 0;
+        GUI_DrawBackground(x, y, w, h);
+        //GUI_RedrawAllObjects();
+        _GUI_RedrawUnderlyingObjects(x, y, w, h);
     }
     GUI_HideObjects(headObj, modalObj);
     //Only start drawing from headObj(scrollable) or 1st modal if either is set
@@ -304,11 +351,31 @@ void _GUI_RefreshScreen(struct guiObject *headObj)
     while(obj) {
         if(! OBJ_IS_HIDDEN(obj)) {
             if (obj->Type == Scrollable && ((guiScrollable_t *)obj)->head) {
+                #if (LCD_WIDTH != 66) && (LCD_WIDTH != 24)
+                //If scrollable changed first we need to draw the scrollable background
+                if(OBJ_IS_DIRTY(obj)) {
+                    #if (LCD_DEPTH == 16)
+                    if(! ((((guiObject_t *)((guiScrollable_t *)obj)->head)->Type == Label) &&
+                          (((guiLabel_t *)((guiScrollable_t *)obj)->head)->desc.style == LABEL_LISTBOX))) {
+                        GUI_DrawBackground(obj->box.x, obj->box.y, obj->box.width, obj->box.height);
+                    }
+                    #else
+                        GUI_DrawBackground(obj->box.x, obj->box.y, obj->box.width, obj->box.height);
+                    #endif
+                    OBJ_SET_DIRTY(obj, 0);
+                }
+                #endif
                 //Redraw scrollable contents
                 _GUI_RefreshScreen(((guiScrollable_t *)obj)->head);
             } else if(OBJ_IS_DIRTY(obj)) {
                 if(OBJ_IS_TRANSPARENT(obj) || OBJ_IS_HIDDEN(obj)) {
                     GUI_DrawBackground(obj->box.x, obj->box.y, obj->box.width, obj->box.height);
+                } else if(obj->Type == Dialog) {
+                    dlg_active = 1;
+                    x = obj->box.x;
+                    y = obj->box.y;
+                    w = obj->box.width;
+                    h = obj->box.height;
                 }
                 GUI_DrawObject(obj);
             }
@@ -318,6 +385,16 @@ void _GUI_RefreshScreen(struct guiObject *headObj)
 }
 
 void GUI_RefreshScreen() {
+    _GUI_RefreshScreen(NULL);
+    LCD_ForceUpdate();
+}
+
+void GUI_DrawScreen(void)
+{
+#ifdef DEBUG_DRAW
+    printf("DrawScreen\n");
+#endif
+    FullRedraw = REDRAW_EVERYTHING;
     _GUI_RefreshScreen(NULL);
     LCD_ForceUpdate();
 }

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -12,6 +12,15 @@
 #include "_gui.h"
 
 #define RGB888_to_RGB565(r, g, b) (((r & 0xf8) << 8) | ((g & 0xfc) << 3) | ((b & 0xf8) >>3))
+
+enum FULL_REDRAW {
+    REDRAW_ONLY_DIRTY   = 0x00,
+    REDRAW_IF_NOT_MODAL = 0x01,
+    REDRAW_EVERYTHING   = 0x02,
+};
+
+extern u8 FullRedraw;
+
 enum DialogType {
     dtOk, dtCancel, dtOkCancel, dtNone,
 };
@@ -23,6 +32,7 @@ enum BarGraphDirection {
     TRIM_INVHORIZONTAL,
     TRIM_VERTICAL,
 };
+
 enum TextSelectType {
     TEXTSELECT_224,
     TEXTSELECT_128,

--- a/src/gui/scrollable.c
+++ b/src/gui/scrollable.c
@@ -109,7 +109,6 @@ static int get_selectable_idx(guiScrollable_t *scrollable, guiObject_t *obj)
     return -1;
 }
 
-
 static guiObject_t *get_selectable_obj(guiScrollable_t *scrollable, int row, int col)
 {
     guiObject_t *head = scrollable->head;
@@ -199,7 +198,6 @@ static guiObject_t *set_selected_abs_row_col(guiScrollable_t *scrollable, int ro
     create_scrollable_objs(scrollable, row);
     return get_selectable_obj(scrollable, row, col);
 }
-
 
 static guiObject_t * set_selectable_idx(guiScrollable_t *scrollable, int idx)
 {
@@ -298,8 +296,13 @@ static void create_scrollable_objs(guiScrollable_t *scrollable, int row)
     scrollable->cur_row = row;
     int rel_row = 0;
     int selectable_rows = 0;
+#if (LCD_WIDTH != 66) && (LCD_WIDTH != 24)
+    u8 redraw_mode = FullRedraw;
     GUI_RemoveScrollableObjs((guiObject_t *)scrollable);
-
+    FullRedraw = redraw_mode;
+#else
+    GUI_RemoveScrollableObjs((guiObject_t *)scrollable);
+#endif
     guiObject_t *head = objHEAD;
     objHEAD = NULL;
     for(int y = scrollable->header.box.y, bottom = y + scrollable->header.box.height;
@@ -333,6 +336,9 @@ static void create_scrollable_objs(guiScrollable_t *scrollable, int row)
     GUI_SetHidden((guiObject_t *)&scrollable->scrollbar, hidden);
     if (! hidden)
         GUI_SetScrollbar(&scrollable->scrollbar, scroll_pos);
+#if (LCD_WIDTH != 66) && (LCD_WIDTH != 24)
+    OBJ_SET_DIRTY((guiObject_t *)scrollable, 1);
+#endif
 }
 
 #if HAS_TOUCH
@@ -426,6 +432,7 @@ guiObject_t *GUI_GetScrollableObj(guiScrollable_t *scrollable, int row, int col)
         return NULL;
     return scrollable->getobj_cb(relrow, col, scrollable->cb_data);
 }
+
 guiObject_t *GUI_ShowScrollableRowCol(guiScrollable_t *scrollable, int absrow, int col)
 {
     return set_selected_abs_row_col(scrollable, absrow, col);
@@ -440,6 +447,7 @@ guiObject_t *GUI_ShowScrollableRowOffset(guiScrollable_t *scrollable, int row_id
     int idx = row_idx & 0xff;
     return set_selectable_idx(scrollable, idx);
 }
+
 int GUI_ScrollableGetObjRowOffset(guiScrollable_t *scrollable, guiObject_t *obj)
 {
     int idx = get_selectable_idx(scrollable, obj);
@@ -449,10 +457,12 @@ int GUI_ScrollableGetObjRowOffset(guiScrollable_t *scrollable, guiObject_t *obj)
     //printf("Saving position:%04x\n", idx);
     return idx;
 }
+
 int GUI_ScrollableCurrentRow(guiScrollable_t *scrollable)
 {
     return scrollable->cur_row;
 }
+
 int GUI_ScrollableVisibleRows(guiScrollable_t *scrollable)
 {
     return scrollable->visible_rows;

--- a/src/pages/128x64x1/main_layout.c
+++ b/src/pages/128x64x1/main_layout.c
@@ -83,7 +83,7 @@ void PAGE_LayoutEditInit(int page)
     GUI_CreateLabel(&gui->xlbl, 0,  1, NULL, micro, "X:");
     GUI_CreateLabelBox(&gui->x, 8, 1, 13, 6, &micro, pos_cb, NULL, (void *) 0L);
     GUI_CreateLabel(&gui->ylbl, 22, 1, NULL, micro, "Y:");
-    GUI_CreateLabelBox(&gui->y, 30, 1, 9, 6, &micro, pos_cb, NULL, (void *) 1L);
+    GUI_CreateLabelBox(&gui->y, 30, 1, 10, 6, &micro, pos_cb, NULL, (void *) 1L);
     //gui->y must be the last element!
     GUI_SelectionNotify(notify_cb);
 

--- a/src/pages/320x240x16/main_layout.c
+++ b/src/pages/320x240x16/main_layout.c
@@ -115,7 +115,8 @@ void PAGE_MainLayoutInit(int page)
     GUI_SelectionNotify(notify_cb);
     draw_elements();
     if (show_config_menu) {
-        lp->selected_for_move = show_config_menu;
+        lp->selected_for_move = -1;
+        select_for_move(&gui->elem[show_config_menu]);
         show_config();
         show_config_menu = 0;
     }
@@ -312,8 +313,11 @@ void show_config()
     int count = 0;
     int row_idx = 0;
     long type;
-    if (OBJ_IS_USED(&gui->dialog))
+    if (OBJ_IS_USED(&gui->dialog)) {
+        u8 draw_mode = FullRedraw;
         GUI_RemoveObj((guiObject_t *)&gui->dialog);
+        FullRedraw = draw_mode;
+    }
     if(lp->selected_for_move >= 0) {
         type = ELEM_TYPE(pc->elem[lp->selected_for_move]);
         row_idx = elem_abs_to_rel(lp->selected_for_move);

--- a/src/pages/320x240x16/standard/drexp_page.c
+++ b/src/pages/320x240x16/standard/drexp_page.c
@@ -95,7 +95,7 @@ static void _refresh_page() {
     GUI_SetHidden((guiObject_t *)&gui->exp[2], hide3);
     GUI_SetHidden((guiObject_t *)&gui->graph[2], hide3);
 
-    GUI_RedrawAllObjects();
+    FullRedraw = REDRAW_EVERYTHING;
 }
 
 void PAGE_DrExpCurvesEvent()

--- a/src/pages/320x240x16/standard/failsafe_page.c
+++ b/src/pages/320x240x16/standard/failsafe_page.c
@@ -36,7 +36,9 @@ static void show_page(int page)
     struct mixer_page * mp = &pagemem.u.mixer_page;
     if (mp->firstObj) {
         GUI_RemoveHierObjects(mp->firstObj);
-        mp->firstObj = NULL;       
+        FullRedraw = REDRAW_ONLY_DIRTY;
+        mp->firstObj = NULL;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
     }
     for (long i = 0; i < ENTRIES_PER_PAGE; i++) {
         int row = ROW1 + ROW_HEIGHT * i;
@@ -50,6 +52,7 @@ static void show_page(int page)
         GUI_CreateTextSelect(&gui->value[i], COL2, row, TEXTSELECT_128, toggle_failsafe_cb, set_failsafe_cb, (void *)ch);
     }
 }
+
 void PAGE_FailSafeInit(int page)
 {
     (void)page;

--- a/src/pages/320x240x16/standard/reverse_page.c
+++ b/src/pages/320x240x16/standard/reverse_page.c
@@ -32,6 +32,7 @@ static void toggle_reverse_cb(guiObject_t *obj, void *data)
         return;
     Model.limits[ch].flags ^= CH_REVERSE;
 }
+
 static void show_page(int page)
 {
     enum {
@@ -44,8 +45,10 @@ static void show_page(int page)
     struct mixer_page * mp = &pagemem.u.mixer_page;
     if (mp->firstObj) {
         GUI_RemoveHierObjects(mp->firstObj);
-        mp->firstObj = NULL;       
-    }   
+        FullRedraw = REDRAW_ONLY_DIRTY;
+        mp->firstObj = NULL;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
+    }
     for (long i = 0; i < ENTRIES_PER_PAGE; i++) {
         int row = ROW1 + ROW_HEIGHT * i;
         long ch = page  + i;

--- a/src/pages/320x240x16/standard/subtrim_page.c
+++ b/src/pages/320x240x16/standard/subtrim_page.c
@@ -36,8 +36,10 @@ static void show_page(int page)
     struct mixer_page * mp = &pagemem.u.mixer_page;
     if (mp->firstObj) {
         GUI_RemoveHierObjects(mp->firstObj);
-        mp->firstObj = NULL;       
-    }   
+        FullRedraw = REDRAW_ONLY_DIRTY;
+        mp->firstObj = NULL;
+        GUI_DrawBackground(0, 32, LCD_WIDTH - 16, LCD_HEIGHT - 32);
+    }
     for (long i = 0; i < ENTRIES_PER_PAGE; i++) {
         int row = ROW1 + ROW_HEIGHT * i;
         long ch = page  + i;
@@ -50,6 +52,7 @@ static void show_page(int page)
         GUI_CreateTextSelect(&gui->value[i], COL2, row, TEXTSELECT_128, NULL, subtrim_cb, (void *)(ch));
     }
 }
+
 void PAGE_SubtrimInit(int page)
 {
     (void)page;

--- a/src/pages/320x240x16/standard/traveladj_page.c
+++ b/src/pages/320x240x16/standard/traveladj_page.c
@@ -37,8 +37,10 @@ static void show_page(int page)
     struct mixer_page * mp = &pagemem.u.mixer_page;
     if (mp->firstObj) {
         GUI_RemoveHierObjects(mp->firstObj);
-        mp->firstObj = NULL;       
-    }   
+        FullRedraw = REDRAW_ONLY_DIRTY;
+        mp->firstObj = NULL;
+        GUI_DrawBackground(0, ROW1, LCD_WIDTH - 16, LCD_HEIGHT - ROW1);
+    }
     for (long i = 0; i < ENTRIES_PER_PAGE; i++) {
         int row = ROW1 + ROW_HEIGHT * i;
         long ch = page  + i;

--- a/src/pages/320x240x16/toggle_select.c
+++ b/src/pages/320x240x16/toggle_select.c
@@ -73,6 +73,8 @@ static int scroll_cb(guiObject_t *parent, u8 pos, s8 direction, void *data)
         }
     }
     GUI_RemoveHierObjects((guiObject_t *)&gui->symbolicon[0]);
+    FullRedraw = REDRAW_ONLY_DIRTY;
+    GUI_DrawBackground(0, 79, LCD_WIDTH - 16, LCD_HEIGHT - 79);
     show_icons((long)data, idx);
     return page;
 }
@@ -144,5 +146,5 @@ void PAGE_ToggleEditExit()
     if (PAGE_GetCurrentID() == PAGEID_MAINCFG) {
         PAGE_MainLayoutRestoreDialog(tp->tglidx);
     }
-        
+
 }

--- a/src/pages/common/_main_config.c
+++ b/src/pages/common/_main_config.c
@@ -186,6 +186,32 @@ static void dlgbut_cb(struct guiObject *obj, const void *data)
     (void)obj;
     int idx = (long)data;
     int i;
+#if (LCD_WIDTH == 320) || (LCD_WIDTH == 480)
+    u16 x, y, w, h;
+    //Close the dialog
+    if (OBJ_IS_USED(&gui->dialog)) {
+        u8 draw_mode = FullRedraw;
+        GUI_RemoveObj((guiObject_t *)&gui->dialog);
+        FullRedraw = draw_mode;
+    }
+    //Erase object
+    GetWidgetLoc(&pc->elem[idx], &x, &y, &w, &h);
+    if (x > 0) {
+        x -= 1;
+        w += 2;
+    }
+    if (y > 0) {
+        y -= 1;
+        h += 2;
+    }
+    if(x + w > LCD_WIDTH) {
+        w = LCD_WIDTH - x;
+    }
+    if(y + h > LCD_HEIGHT) {
+        h = LCD_HEIGHT - y;
+    }
+    GUI_DrawBackground(x, y, w, h);
+#endif
     //Remove object
     int type = ELEM_TYPE(pc->elem[idx]);
     for(i = idx+1; i < NUM_ELEMS; i++) {

--- a/src/pages/common/_main_layout.c
+++ b/src/pages/common/_main_layout.c
@@ -32,8 +32,11 @@ void draw_elements()
     int i;
     set_selected_for_move(-1);
     guiObject_t *obj = gui->y.header.next;
-    if (obj)
+    if (obj) {
+        u8 redraw_mode = FullRedraw;
         GUI_RemoveHierObjects(obj);
+        FullRedraw = redraw_mode;
+    }
     for (i = 0; i < NUM_ELEMS; i++) {
         if (! GetWidgetLoc(&pc->elem[i], &x, &y, &w, &h))
             break;
@@ -134,10 +137,27 @@ int guielem_idx(guiObject_t *obj)
 
 void move_elem()
 {
+    u16 x, y, w, h;
     guiObject_t *obj = GUI_GetSelected();
     if ((guiLabel_t *)obj < gui->elem)
         return;
     int idx = guielem_idx(obj);
+    GetWidgetLoc(&pc->elem[idx], &x, &y, &w, &h);
+    if (x > 0) {
+        x -= 1;
+        w += 2;
+    }
+    if (y > 0) {
+        y -= 1;
+        h += 2;
+    }
+    if(x + w > LCD_WIDTH) {
+        w = LCD_WIDTH - x;
+    }
+    if(y + h > LCD_HEIGHT) {
+        h = LCD_HEIGHT - y;
+    }
+    GUI_DrawBackground(x, y, w, h);
     ELEM_SET_X(pc->elem[idx], lp->selected_x);
     ELEM_SET_Y(pc->elem[idx], lp->selected_y);
     draw_elements();
@@ -154,6 +174,8 @@ void notify_cb(guiObject_t *obj)
     GetElementSize(ELEM_TYPE(pc->elem[idx]), &lp->selected_w, &lp->selected_h);
     if (ELEM_TYPE(pc->elem[idx]) == ELEM_MODELICO)
         AdjustIconSize(&lp->selected_x, &lp->selected_y, &lp->selected_h, &lp->selected_w);
+    GUI_Redraw((guiObject_t *)&gui->xlbl);
     GUI_Redraw((guiObject_t *)&gui->x);
+    GUI_Redraw((guiObject_t *)&gui->ylbl);
     GUI_Redraw((guiObject_t *)&gui->y);
 }

--- a/src/pages/common/_model_page.c
+++ b/src/pages/common/_model_page.c
@@ -308,7 +308,7 @@ static void file_press_cb(guiObject_t *obj, void *data)
     if (mp->file_state == 3) {
         CONFIG_ResetModel();
         CONFIG_SaveModelIfNeeded();
-        GUI_RedrawAllObjects();
+        FullRedraw = REDRAW_EVERYTHING;
     } else {
         PAGE_PushByID(PAGEID_LOADSAVE, mp->file_state);
     }

--- a/src/pages/common/advanced/_mixer_limits.c
+++ b/src/pages/common/advanced/_mixer_limits.c
@@ -225,6 +225,6 @@ static void revert_cb(guiObject_t *obj, const void *data)
     (void)data;
     (void)obj;
     memcpy(mp->limit, (const void *)&origin_limit, sizeof(origin_limit));
-    GUI_RedrawAllObjects();
+    FullRedraw = REDRAW_EVERYTHING;
 }
 

--- a/src/target/devo7e/target_defs.h
+++ b/src/target/devo7e/target_defs.h
@@ -12,24 +12,24 @@
 //No room for debug and standard gui
  #define HAS_STANDARD_GUI   0
 #else
- #define HAS_STANDARD_GUI   0
+ #define HAS_STANDARD_GUI   1
 #endif
 
 #define HAS_ADVANCED_GUI    1
-#define HAS_PERMANENT_TIMER 1
+#define HAS_PERMANENT_TIMER 0
 #define HAS_TELEMETRY       1
 #define HAS_EXTENDED_TELEMETRY 0
 #define HAS_TOUCH           0
 #define HAS_RTC             0
 #define HAS_VIBRATINGMOTOR  1
-#define HAS_DATALOG         1
+#define HAS_DATALOG         0
 #define HAS_SCANNER         0
-#define HAS_LAYOUT_EDITOR   1
+#define HAS_LAYOUT_EDITOR   0
 #define HAS_EXTRA_SWITCHES  OPTIONAL
 #define HAS_EXTRA_BUTTONS   0
 #define HAS_MULTIMOD_SUPPORT 1
 #define HAS_VIDEO           0
-#define HAS_4IN1_FLASH      1
+#define HAS_4IN1_FLASH      0
 #define HAS_EXTENDED_AUDIO  0
 #define HAS_AUDIO_UART5     0
 #define HAS_MUSIC_CONFIG    0

--- a/src/target/devo7e/target_defs.h
+++ b/src/target/devo7e/target_defs.h
@@ -12,21 +12,21 @@
 //No room for debug and standard gui
  #define HAS_STANDARD_GUI   0
 #else
- #define HAS_STANDARD_GUI   1
+ #define HAS_STANDARD_GUI   0
 #endif
 
 #define HAS_ADVANCED_GUI    1
-#define HAS_PERMANENT_TIMER 0
+#define HAS_PERMANENT_TIMER 1
 #define HAS_TELEMETRY       1
 #define HAS_EXTENDED_TELEMETRY 0
 #define HAS_TOUCH           0
 #define HAS_RTC             0
 #define HAS_VIBRATINGMOTOR  1
-#define HAS_DATALOG         0
+#define HAS_DATALOG         1
 #define HAS_SCANNER         0
-#define HAS_LAYOUT_EDITOR   0
+#define HAS_LAYOUT_EDITOR   1
 #define HAS_EXTRA_SWITCHES  OPTIONAL
-#define HAS_EXTRA_BUTTONS  0
+#define HAS_EXTRA_BUTTONS   0
 #define HAS_MULTIMOD_SUPPORT 1
 #define HAS_VIDEO           0
 #define HAS_4IN1_FLASH      1


### PR DESCRIPTION
- Avoid full page redraw for any scrollable object change. It looks much more naturally if updated the scrollable area only, but not the full page.
- Avoid full page redraw with every item position change at "Main layout edit" page.
- Avoid full page redraw after close any dialog window.
- Optimize redraw objects after close dialog window, redraw underlying objects only.