### PR TITLE
fix nrf24l01 pin assigment in hardware.ini

### DIFF
--- a/src/fs/common/hardware.ini
+++ b/src/fs/common/hardware.ini
@@ -23,6 +23,6 @@
 ; has_pa-a7105    = 1
 ; enable-cc2500   = A14
 ; has_pa-cc2500   = 1
-; enable-nrf24l01 = A14
+; enable-nrf24l01 = A15
 ; has_pa-nrf24l01 = 1
 ; enable-multimod = A13


### PR DESCRIPTION
While freshly installing the current 5.0.0 release,
I did get an error "missing modules nrf24l01".
This is because in default shipped hardware.ini,
the pin assignment in wrong.

This is a simple fix which hopefully solves a lot of people headaches.

Any feedback is welcome.