### PR TITLE
Enable LTO for non-modular build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -159,8 +159,6 @@ ifeq "$(TYPE)" "dev"
 endif
 ifdef MODULAR
 CFLAGS   +=  -DMODULAR=$(MODULAR)
-else
-CFLAGS   += -flto
 endif
 
 CFLAGS   := $(CFLAGS) -Wall -Wextra -Werror=undef -I. -D$(PROGMODE) -std=gnu99 -Itarget/$(TARGET) -Igui/$(SCREENSIZE) \

--- a/src/Makefile
+++ b/src/Makefile
@@ -159,6 +159,8 @@ ifeq "$(TYPE)" "dev"
 endif
 ifdef MODULAR
 CFLAGS   +=  -DMODULAR=$(MODULAR)
+else
+CFLAGS   += -flto
 endif
 
 CFLAGS   := $(CFLAGS) -Wall -Wextra -Werror=undef -I. -D$(PROGMODE) -std=gnu99 -Itarget/$(TARGET) -Igui/$(SCREENSIZE) \

--- a/src/Makefile
+++ b/src/Makefile
@@ -286,7 +286,7 @@ endif
 %.fs_wrapper: $(LAST_MODEL)
 	true
 
-.PHONY: $(PRE_FS) $(LAST_MODEL)
+.PHONY: $(PRE_FS) $(LAST_MODEL) $(TARGET).elf
 $(LAST_MODEL): model_template.ini tx_template.ini $(FONTS) $(PRE_FS)
 	@echo " + Copying template files for $(FILESYSTEM)"
 	mkdir -p filesystem/$(FILESYSTEM) || true
@@ -300,7 +300,7 @@ $(LAST_MODEL): model_template.ini tx_template.ini $(FONTS) $(PRE_FS)
 	cp model_template.ini filesystem/$(FILESYSTEM)/models/default.ini
 ifdef LANGUAGE
 	mkdir filesystem/$(FILESYSTEM)/language 2> /dev/null; \
-               ../utils/extract_strings.pl -fs $(FILESYSTEM) -targets $(LANGUAGE) -update -objdir $(ODIR)
+               ../utils/extract_strings.pl -fs $(FILESYSTEM) -targets $(LANGUAGE) -update -elffile $(TARGET).elf
 endif
 	export tx=$(FILESYSTEM); \
 	number=2 ; while [ $$number -le $(NUM_MODELS) ] ; do \
@@ -308,7 +308,7 @@ endif
 		number=`expr $$number + 1`; \
 		done
 	@echo " + Checking string list length for $(FILESYSTEM)"
-	../utils/check_string_size.pl -target $(FILESYSTEM) -objdir $(ODIR) -quiet
+	../utils/check_string_size.pl -target $(FILESYSTEM) -elffile $(TARGET).elf -quiet
 
 ######################
 #Necessary Font files#

--- a/src/protocol/assan_nrf24l01.c
+++ b/src/protocol/assan_nrf24l01.c
@@ -65,12 +65,12 @@ enum {
     DATA5
 };
 
-u8 hopping_frequency[2];
-u8 hopping_frequency_no;
-u8 packet[32];
-u8 tx_power;
-u8 state;
-u32 packet_count;
+static u8 hopping_frequency[2];
+static u8 hopping_frequency_no;
+static u8 packet[32];
+static u8 tx_power;
+static u8 state;
+static u32 packet_count;
 
 void init()
 {

--- a/src/protocol/wfly_cyrf6936.c
+++ b/src/protocol/wfly_cyrf6936.c
@@ -41,15 +41,15 @@
 #define WFLY_NUM_FREQUENCE 4
 #define WFLY_BIND_CHANNEL 0x09
 
-u8 packet[PACKET_LENGTH];
-u8 pkt[PACKET_LENGTH];
-u8 rx_tx_addr[5];
-u8 hopping_frequency[WFLY_NUM_FREQUENCE];
-u8 rf_ch_num;
-u32 bind_counter;
-u32 packet_count;
-u8 phase;
-u8 tx_power;
+static u8 packet[PACKET_LENGTH];
+static u8 pkt[PACKET_LENGTH];
+static u8 rx_tx_addr[5];
+static u8 hopping_frequency[WFLY_NUM_FREQUENCE];
+static u8 rf_ch_num;
+static u32 bind_counter;
+static u32 packet_count;
+static u8 phase;
+static u8 tx_power;
 
 enum {
     WFLY_BIND_TX=0,

--- a/src/target/common/devo/Makefile.inc
+++ b/src/target/common/devo/Makefile.inc
@@ -31,6 +31,9 @@ SRC_C   += $(wildcard $(SDIR)/target/common/devo/protocol/*.c) \
 endif
 
 CFLAGS   = -D"assert_param(x)=" -DSTM32F10X_HD -DSTM32F1 -mcpu=cortex-m3 -mthumb -mfix-cortex-m3-ldrd -fdata-sections -ffunction-sections -I$(SDIR)/target/common/devo -I$(SDIR)/target/common/devo/msc2/lib -I$(SDIR)/target/common/devo/msc2 -I$(SDIR)/libopencm3/include -I$(SDIR)/target/common/filesystems -fno-builtin-printf -Os --specs=nano.specs
+ifndef MODULAR
+CFLAGS  += -flto
+endif
 ifeq "$(HAS_4IN1_FLASH)" "1"
 CFLAGS  += -D"HAS_4IN1_FLASH=1"
 endif

--- a/src/target/common/devo/devo.ld
+++ b/src/target/common/devo/devo.ld
@@ -34,11 +34,13 @@ SECTIONS
 		*(.vectors)	/* Vector table */
 		INCLUDE objs/optimize.ld
 		. = _crc_offset;
-                KEEP(*(.crc))
+             KEEP(*(.crc))
 		*(.text*)	/* Program code */
+	} >rom
+
+	.rodata : {
 		. = ALIGN(4);
 		*(.rodata*)	/* Read-only data */
-		. = ALIGN(4);
 	} >rom
 
 	/* C++ Static constructors/destructors, also used for __attribute__

--- a/src/target/common/devo/err_handler.c
+++ b/src/target/common/devo/err_handler.c
@@ -95,7 +95,7 @@ void fault_printf(const char *str, unsigned int val)
 // hard fault handler in C,
 // with stack frame location as input parameter
 // called from HardFault_Handler in file xxx.s
-void fault_handler_c (unsigned int * hardfault_args, unsigned int fault_type)
+void __attribute__((used)) fault_handler_c (unsigned int * hardfault_args, unsigned int fault_type)
 {
   unsigned int stacked_r0;
   unsigned int stacked_r1;

--- a/src/target/common/devo/hid/hid_devo.c
+++ b/src/target/common/devo/hid/hid_devo.c
@@ -30,7 +30,7 @@ extern void (* const HID_pEpInt_IN[7])(void);
 extern void (* const HID_pEpInt_OUT[7])(void);
 extern DEVICE_PROP HID_Device_Property;
 extern USER_STANDARD_REQUESTS HID_User_Standard_Requests;
-extern void USB_Enable(u8 type, u8 use_interrupt);
+extern void USB_Enable(unsigned type, unsigned use_interrupt);
 extern void USB_Disable();
 
 extern volatile u8 PrevXferComplete;

--- a/utils/check_string_size.pl
+++ b/utils/check_string_size.pl
@@ -7,9 +7,9 @@ use Getopt::Long;
 
 my $target;
 my $quiet;
-my $objdir;
+my $elffile;
 my $log = "";
-GetOptions("target=s" => \$target, "quiet" => \$quiet, "objdir=s" => \$objdir);
+GetOptions("target=s" => \$target, "quiet" => \$quiet, "elffile=s" => \$elffile);
 
 my @dirs = grep {$_ !~ /common/ && (! $target || $_ =~ /$target/)} glob("filesystem/*");
 my $max_line_length = 0;
@@ -55,7 +55,7 @@ foreach my $target_dir (@dirs) {
         $target_line_length = $line_length if($line_length > $target_line_length);
     }
     my $cmd = "../utils/extract_strings.pl -target $target";
-    $cmd .= " -objdir $objdir" if($objdir);
+    $cmd .= " -elffile $elffile" if($elffile);
     my @lines = `$cmd`;
     my $count = scalar(@lines);
     $log .= sprintf("%-35s: %5d lines\n", $target, $count);

--- a/utils/extract_strings.pl
+++ b/utils/extract_strings.pl
@@ -7,13 +7,14 @@ my $update;
 my $lang;
 my $fs;
 my $target_list;
-my $objdir;
+my $elffile;
 my $count;
 # The following are legal alternatives to the default string
 my @targets = ("devo8", "devo10", "devo12");
 
 $ENV{CROSS} ||= "";
-GetOptions("update" => \$update, "language=s" => \$lang, "fs=s" => \$fs, "targets=s" => \$target_list, "count" => \$count, "objdir=s" => \$objdir);
+GetOptions("update" => \$update, "language=s" => \$lang, "fs=s" => \$fs,
+    "targets=s" => \$target_list, "count" => \$count, "elffile=s" => \$elffile);
 my @requested_targets = ();
 @requested_targets = split(/,/, $target_list) if($target_list);
 if($fs || @requested_targets) {
@@ -76,40 +77,38 @@ if($str) {
 #build string list
 my @out;
 #Filter out any strings that do not appear in any obj files
-if($objdir) {
+if($elffile) {
     my %allstr;
-    my @files = glob("$objdir/*.o");
-    foreach my $file (@files) {
-        #Parse all strings from the object files and add to the allstr hash
-        my @od = `$ENV{CROSS}objdump -s $file`;
-        my $str = "";
-        my $state = 0;
-        foreach(@od) {
-            my $orig = $_;
-            if(/section \.ro?data/) {
-                $str = "";
-                $state = 1;
-                next;
-            } elsif(/^Contents/ && ! /\.ro?data/) {
-                $str = "";
-                $state = 0;
-            } elsif($state) {
-                #Strip off everything but hex data
-                s/^\s+\S+\s//;
-                s/\s\s.*//;
-                s/ //g;
-                while(/(\S\S)/g) {
-                    #Iterate over each ascii character
-                    if($1 eq "00") {
-                        #NULL termination
-                        if($str) {
-                            $str =~ s/\n/\\n/g;  #Convert <CR> to \n
-                            $allstr{$str} = 1;
-                            $str = "";
-                        }
-                    } else {
-                        $str .= chr(hex($1));
+    my @files;
+    #Parse all strings from the object files and add to the allstr hash
+    my @od = `$ENV{CROSS}objdump -s $elffile`;
+    my $str = "";
+    my $state = 0;
+    foreach(@od) {
+        my $orig = $_;
+        if(/section \.ro?data/) {
+            $str = "";
+            $state = 1;
+            next;
+        } elsif(/^Contents/ && ! /\.ro?data/) {
+            $str = "";
+            $state = 0;
+        } elsif($state) {
+            #Strip off everything but hex data
+            s/^\s+\S+\s//;
+            s/\s\s.*//;
+            s/ //g;
+            while(/(\S\S)/g) {
+                #Iterate over each ascii character
+                if($1 eq "00") {
+                    #NULL termination
+                    if($str) {
+                        $str =~ s/\n/\\n/g;  #Convert <CR> to \n
+                        $allstr{$str} = 1;
+                        $str = "";
                     }
+                } else {
+                    $str .= chr(hex($1));
                 }
             }
         }


### PR DESCRIPTION
LTO build will further optimize the code to save more ROM and RAM. Also fix some warnings noticed by LTO linker.

Use devof12e build as example:
Before LTO:
ROM: 0x08004000 - 0x08039650 = 213.58kB
RAM: 0x20000000 - 0x200068b8 =  26.18kB

After LTO:
ROM: 0x08004000 - 0x08037500 = 205.25kB
RAM: 0x20000000 - 0x200067c8 =  25.95kB

Difference:
ROM: 8.30kB
RAM: 0.25kB