### PR TITLE
Fix warnings under new gcc

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -10,6 +10,7 @@
 #define ctassert(COND,MSG) typedef char static_assertion_##MSG[(COND)?1:-1]
 #define _UNUSED   __attribute__ ((unused))
 #define NO_INLINE __attribute__ ((noinline))
+#define FALLTHROUGH __attribute__ ((fallthrough))
 
 #define TEMPSTRINGLENGTH 400 //This is the max dialog size (80 characters * 5 lines)
                              //We could reduce this to ~240 on the 128x64 screens

--- a/src/common.h
+++ b/src/common.h
@@ -10,7 +10,6 @@
 #define ctassert(COND,MSG) typedef char static_assertion_##MSG[(COND)?1:-1]
 #define _UNUSED   __attribute__ ((unused))
 #define NO_INLINE __attribute__ ((noinline))
-#define FALLTHROUGH __attribute__ ((fallthrough))
 
 #define TEMPSTRINGLENGTH 400 //This is the max dialog size (80 characters * 5 lines)
                              //We could reduce this to ~240 on the 128x64 screens

--- a/src/config/model.c
+++ b/src/config/model.c
@@ -176,11 +176,13 @@ static const char TELEM_ABOVE[] =  "above";
 static const char TELEM_VALUE[] = "value";
 static const char TELEM_TH[] ="threshold";
 
+#if HAS_DATALOG
 /* Section: Datalog */
 static const char SECTION_DATALOG[] = "datalog";
 static const char DATALOG_RATE[] = "rate";
 #define DATALOG_SWITCH MIXER_SWITCH
 #define DATALOG_SOURCE TELEM_SRC
+#endif
 
 /* Section: Gui-QVGA */
 #define STRINGIFY(x) _STRINGIFY(x)

--- a/src/pages/128x64x1/advanced/mixer_setup.c
+++ b/src/pages/128x64x1/advanced/mixer_setup.c
@@ -417,7 +417,7 @@ void MIXPAGE_RedrawGraphs()
     switch(mp->cur_template) {
     case MIXERTEMPLATE_COMPLEX:
         GUI_Redraw(&gui->bar);
-        FALLTHROUGH;
+        /* FALLTHROUGH */
     case MIXERTEMPLATE_EXPO_DR:
     case MIXERTEMPLATE_SIMPLE:
         GUI_Redraw(&gui->graph);

--- a/src/pages/128x64x1/advanced/mixer_setup.c
+++ b/src/pages/128x64x1/advanced/mixer_setup.c
@@ -417,6 +417,7 @@ void MIXPAGE_RedrawGraphs()
     switch(mp->cur_template) {
     case MIXERTEMPLATE_COMPLEX:
         GUI_Redraw(&gui->bar);
+        FALLTHROUGH;
     case MIXERTEMPLATE_EXPO_DR:
     case MIXERTEMPLATE_SIMPLE:
         GUI_Redraw(&gui->graph);

--- a/src/protocol/cx10_nrf24l01.c
+++ b/src/protocol/cx10_nrf24l01.c
@@ -448,7 +448,7 @@ static void initialize()
         case FORMAT_Q282:
         case FORMAT_Q242:
             packet_size = Q282_PACKET_SIZE - CX10_PACKET_SIZE;  // difference in packet size
-            FALLTHROUGH;
+            /* FALLTHROUGH */
         case FORMAT_CX10_GREEN:
         case FORMAT_DM007:
         case FORMAT_JC3015_1:

--- a/src/protocol/cx10_nrf24l01.c
+++ b/src/protocol/cx10_nrf24l01.c
@@ -448,6 +448,7 @@ static void initialize()
         case FORMAT_Q282:
         case FORMAT_Q242:
             packet_size = Q282_PACKET_SIZE - CX10_PACKET_SIZE;  // difference in packet size
+            FALLTHROUGH;
         case FORMAT_CX10_GREEN:
         case FORMAT_DM007:
         case FORMAT_JC3015_1:

--- a/src/protocol/esky150_nrf24l01.c
+++ b/src/protocol/esky150_nrf24l01.c
@@ -236,8 +236,7 @@ static s32 rf_ch_idx = 0;
         esky2_bind_init(tx_addr_, packet_);
         tx_state_ = STATE_BINDING;
         packet_sent = 0;
-        //Do once, no break needed
-        FALLTHROUGH;
+        /* FALLTHROUGH */
     case STATE_BINDING:
         if(packet_sent < BIND_COUNT)
         {
@@ -249,16 +248,14 @@ static s32 rf_ch_idx = 0;
             PROTOCOL_SetBindState(0);
             MUSIC_Play(MUSIC_DONE_BINDING);
             tx_state_ = STATE_PRE_SEND;
-            //Do once, no break needed
-            FALLTHROUGH;
         }
+        /* FALLTHROUGH */
     case STATE_PRE_SEND:
             packet_sent = 0;
             esky2_send_init(tx_addr_, packet_);
             rf_ch_idx = 0;
             tx_state_ = STATE_SENDING;
-            //Do once, no break needed
-            FALLTHROUGH;
+            /* FALLTHROUGH */
     case STATE_SENDING:
         if(packet_sent >= PACKET_SEND_COUNT)
         {

--- a/src/protocol/esky150_nrf24l01.c
+++ b/src/protocol/esky150_nrf24l01.c
@@ -237,6 +237,7 @@ static s32 rf_ch_idx = 0;
         tx_state_ = STATE_BINDING;
         packet_sent = 0;
         //Do once, no break needed
+        FALLTHROUGH;
     case STATE_BINDING:
         if(packet_sent < BIND_COUNT)
         {
@@ -248,14 +249,16 @@ static s32 rf_ch_idx = 0;
             PROTOCOL_SetBindState(0);
             MUSIC_Play(MUSIC_DONE_BINDING);
             tx_state_ = STATE_PRE_SEND;
-           //Do once, no break needed
+            //Do once, no break needed
+            FALLTHROUGH;
         }
     case STATE_PRE_SEND:
             packet_sent = 0;
             esky2_send_init(tx_addr_, packet_);
             rf_ch_idx = 0;
             tx_state_ = STATE_SENDING;
-           //Do once, no break needed
+            //Do once, no break needed
+            FALLTHROUGH;
     case STATE_SENDING:
         if(packet_sent >= PACKET_SEND_COUNT)
         {

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -104,13 +104,13 @@ ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
 
 static int afhds2a_init()
 {
-    int i;
+    u8 i;
     u8 if_calibration1;
     u8 vco_calibration0;
     u8 vco_calibration1;
 
     A7105_WriteID(0x5475c52a);
-    for (i = 0; i < 0x33; i++)
+    for (i = 0; i < sizeof(AFHDS2A_regs); i++)
         if((s8)AFHDS2A_regs[i] != -1)
             A7105_WriteReg(i, AFHDS2A_regs[i]);
 

--- a/src/protocol/hubsan_a7105.c
+++ b/src/protocol/hubsan_a7105.c
@@ -487,6 +487,7 @@ static u16 hubsan_cb()
             A7105_WriteID(id_data);    
             bind_count = 0;
         }
+        FALLTHROUGH;
     case BIND_3:
     case BIND_5:
     case BIND_7:

--- a/src/protocol/hubsan_a7105.c
+++ b/src/protocol/hubsan_a7105.c
@@ -487,7 +487,7 @@ static u16 hubsan_cb()
             A7105_WriteID(id_data);    
             bind_count = 0;
         }
-        FALLTHROUGH;
+        /* FALLTHROUGH */
     case BIND_3:
     case BIND_5:
     case BIND_7:

--- a/src/protocol/j6pro_cyrf6936.c
+++ b/src/protocol/j6pro_cyrf6936.c
@@ -185,6 +185,7 @@ static u16 j6pro_cb()
             cyrf_bindinit();
             state = J6PRO_BIND_01;
             //no break because we want to send the 1st bind packet now
+            FALLTHROUGH;
         case J6PRO_BIND_01:
             CYRF_ConfigRFChannel(0x52);
             CYRF_SetTxRxMode(TX_EN);
@@ -248,10 +249,12 @@ static u16 j6pro_cb()
             set_radio_channels();
             cyrf_datainit();
             state = J6PRO_CHAN_1;
+            FALLTHROUGH;
         case J6PRO_CHAN_1:
             //Keep transmit power updated
             CYRF_SetPower(Model.tx_power);
             build_data_packet();
+            FALLTHROUGH;
             //return 3400;
         case J6PRO_CHAN_2:
             //return 3500;

--- a/src/protocol/j6pro_cyrf6936.c
+++ b/src/protocol/j6pro_cyrf6936.c
@@ -184,8 +184,8 @@ static u16 j6pro_cb()
         case J6PRO_BIND:
             cyrf_bindinit();
             state = J6PRO_BIND_01;
+            /* FALLTHROUGH */
             //no break because we want to send the 1st bind packet now
-            FALLTHROUGH;
         case J6PRO_BIND_01:
             CYRF_ConfigRFChannel(0x52);
             CYRF_SetTxRxMode(TX_EN);
@@ -249,12 +249,12 @@ static u16 j6pro_cb()
             set_radio_channels();
             cyrf_datainit();
             state = J6PRO_CHAN_1;
-            FALLTHROUGH;
+            /* FALLTHROUGH */
         case J6PRO_CHAN_1:
             //Keep transmit power updated
             CYRF_SetPower(Model.tx_power);
             build_data_packet();
-            FALLTHROUGH;
+            /* FALLTHROUGH */
             //return 3400;
         case J6PRO_CHAN_2:
             //return 3500;

--- a/src/protocol/kn_nrf24l01.c
+++ b/src/protocol/kn_nrf24l01.c
@@ -275,6 +275,7 @@ static s32 rf_ch_idx = 0;
         tx_state_ = STATE_BINDING;
         packet_sent = 0;
         //Do once, no break needed
+        FALLTHROUGH;
     case STATE_BINDING:
         if(packet_sent < bind_count)
         {
@@ -286,14 +287,16 @@ static s32 rf_ch_idx = 0;
             PROTOCOL_SetBindState(0);
             MUSIC_Play(MUSIC_DONE_BINDING);
             tx_state_ = STATE_PRE_SEND;
-           //Do once, no break needed
+            //Do once, no break needed
+            FALLTHROUGH;
         }
     case STATE_PRE_SEND:
             packet_sent = 0;
             kn_send_init(tx_addr_, packet_);
             rf_ch_idx = 0;
             tx_state_ = STATE_SENDING;
-           //Do once, no break needed
+            //Do once, no break needed
+            FALLTHROUGH;
     case STATE_SENDING:
         if(packet_sent >= packet_send_count)
         {

--- a/src/protocol/kn_nrf24l01.c
+++ b/src/protocol/kn_nrf24l01.c
@@ -274,8 +274,7 @@ static s32 rf_ch_idx = 0;
         kn_bind_init(tx_addr_, hopping_channels_, packet_);
         tx_state_ = STATE_BINDING;
         packet_sent = 0;
-        //Do once, no break needed
-        FALLTHROUGH;
+        /* FALLTHROUGH */
     case STATE_BINDING:
         if(packet_sent < bind_count)
         {
@@ -287,16 +286,14 @@ static s32 rf_ch_idx = 0;
             PROTOCOL_SetBindState(0);
             MUSIC_Play(MUSIC_DONE_BINDING);
             tx_state_ = STATE_PRE_SEND;
-            //Do once, no break needed
-            FALLTHROUGH;
         }
+        /* FALLTHROUGH */
     case STATE_PRE_SEND:
             packet_sent = 0;
             kn_send_init(tx_addr_, packet_);
             rf_ch_idx = 0;
             tx_state_ = STATE_SENDING;
-            //Do once, no break needed
-            FALLTHROUGH;
+            /* FALLTHROUGH */
     case STATE_SENDING:
         if(packet_sent >= packet_send_count)
         {

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -212,8 +212,7 @@ static void send_packet(u8 bind)
     case FORMAT_H26D:
     case FORMAT_H26WH:
         packet[10] = pan_tilt_value();
-        // fall through on purpose - no break
-        FALLTHROUGH;
+        /* FALLTHROUGH */
     case FORMAT_WLH08:
     case FORMAT_E010:
         packet[10] += GET_FLAG(CHANNEL_RTH, 0x02)

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -213,6 +213,7 @@ static void send_packet(u8 bind)
     case FORMAT_H26WH:
         packet[10] = pan_tilt_value();
         // fall through on purpose - no break
+        FALLTHROUGH;
     case FORMAT_WLH08:
     case FORMAT_E010:
         packet[10] += GET_FLAG(CHANNEL_RTH, 0x02)

--- a/src/protocol/wfly_cyrf6936.c
+++ b/src/protocol/wfly_cyrf6936.c
@@ -263,7 +263,7 @@ u16 WFLY_callback()
             WFLY_cyrf_data_config();
             packet_count=0;
             phase++;
-            FALLTHROUGH;
+            /* FALLTHROUGH */
         case WFLY_DATA:
             wait_write = MAX_WAIT_WRITE;
             while (wait_write-- > 0) // Wait max 200µs for TX to finish

--- a/src/protocol/wfly_cyrf6936.c
+++ b/src/protocol/wfly_cyrf6936.c
@@ -263,6 +263,7 @@ u16 WFLY_callback()
             WFLY_cyrf_data_config();
             packet_count=0;
             phase++;
+            FALLTHROUGH;
         case WFLY_DATA:
             wait_write = MAX_WAIT_WRITE;
             while (wait_write-- > 0) // Wait max 200µs for TX to finish


### PR DESCRIPTION
Fix warnings notified by new gcc.
1. Access array out of range
2. explicit on fall through in switch branches.