### PR TITLE
Remove standard GUI from Devo 7e build

### DIFF
--- a/src/target/devo7e/target_defs.h
+++ b/src/target/devo7e/target_defs.h
@@ -17,15 +17,15 @@
 #endif
 
 #define HAS_ADVANCED_GUI    1
-#define HAS_PERMANENT_TIMER 0
+#define HAS_PERMANENT_TIMER 1
 #define HAS_TELEMETRY       1
 #define HAS_EXTENDED_TELEMETRY 0
 #define HAS_TOUCH           0
 #define HAS_RTC             0
 #define HAS_VIBRATINGMOTOR  1
-#define HAS_DATALOG         0
+#define HAS_DATALOG         1
 #define HAS_SCANNER         0
-#define HAS_LAYOUT_EDITOR   0
+#define HAS_LAYOUT_EDITOR   1
 #define HAS_EXTRA_SWITCHES  OPTIONAL
 #define HAS_EXTRA_BUTTONS   0
 #define HAS_MULTIMOD_SUPPORT 1

--- a/src/target/devo7e/target_defs.h
+++ b/src/target/devo7e/target_defs.h
@@ -12,7 +12,8 @@
 //No room for debug and standard gui
  #define HAS_STANDARD_GUI   0
 #else
- #define HAS_STANDARD_GUI   1
+//Nor for production build 
+ #define HAS_STANDARD_GUI   0
 #endif
 
 #define HAS_ADVANCED_GUI    1


### PR DESCRIPTION
I've a few protocols on hold but the 7e won't accept any more protocol definitions, time to remove the standard GUI from the 7e build ?