### PR TITLE
Move channel map into individual module

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -129,7 +129,7 @@ enum Protocols {
     PROTOCOL_COUNT,
 };
 #undef PROTODEF
-extern const u8 *ProtocolChannelMap[PROTOCOL_COUNT];
+extern const u8 *CurrentProtocolChannelMap;
 #define PROTO_MAP_LEN 5
 
 enum ModelType {

--- a/src/mixer_standard.c
+++ b/src/mixer_standard.c
@@ -45,7 +45,7 @@ void STDMIXER_Preset()
     mapped_std_channels.switches[SWITCHFUNC_DREXP_ELE] = INP_ELE_DR0;
     mapped_std_channels.switches[SWITCHFUNC_DREXP_RUD] = INP_FMOD0;
 
-    const u8 *ch_map = ProtocolChannelMap[Model.protocol];
+    const u8 *ch_map = CurrentProtocolChannelMap;
     if (! ch_map) {
         // for none protocol, assign any channel to thr is fine
         ch_map = EATRG;
@@ -64,7 +64,7 @@ void STDMIXER_Preset()
 
 void STDMIXER_SetChannelOrderByProtocol()
 {
-    const u8 *ch_map = ProtocolChannelMap[Model.protocol];
+    const u8 *ch_map = CurrentProtocolChannelMap;
     if (! ch_map) {
         // for none protocol, assign any channel to thr is fine
         ch_map = EATRG;

--- a/src/pages/common/_model_page.c
+++ b/src/pages/common/_model_page.c
@@ -244,7 +244,7 @@ static const char *protoselect_cb(guiObject_t *obj, int dir, void *data)
     enum Protocols new_protocol;
     new_protocol = GUI_TextSelectHelper(Model.protocol, PROTOCOL_NONE, PROTOCOL_COUNT-1, dir, 1, 1, &changed);
     if (changed) {
-        const u8 *oldmap = ProtocolChannelMap[Model.protocol];
+        const u8 *oldmap = CurrentProtocolChannelMap;
     	// DeInit() the old protocol (Model.protocol unchanged)
         PROTOCOL_DeInit();
         // Load() the new protocol

--- a/src/pages/common/advanced/_mixer_page.c
+++ b/src/pages/common/advanced/_mixer_page.c
@@ -71,8 +71,8 @@ const char *MIXPAGE_ChanNameProtoCB(guiObject_t *obj, const void *data)
     if ((Transmitter.ignore_src & SWITCH_NOSTOCK) == SWITCH_NOSTOCK)
         proto_map_length = PROTO_MAP_LEN - 1;
     #endif //HAS_SWITCHES_NOSTOCK
-    if (ch < proto_map_length && ProtocolChannelMap[Model.protocol]) {
-        INPUT_SourceNameAbbrevSwitch(tmp1, ProtocolChannelMap[Model.protocol][ch]);
+    if (ch < proto_map_length && CurrentProtocolChannelMap) {
+        INPUT_SourceNameAbbrevSwitch(tmp1, CurrentProtocolChannelMap[ch]);
         sprintf(tempstring, "%s%d-%s",
             (Model.limits[ch].flags & CH_REVERSE) ? "!" : "",
             (int)(ch + 1), tmp1);

--- a/src/pages/common/standard/_common_standard.c
+++ b/src/pages/common/standard/_common_standard.c
@@ -29,9 +29,9 @@ const char *STDMIX_channelname_cb(guiObject_t *obj, const void *data)
     if ((Transmitter.ignore_src & SWITCH_NOSTOCK) == SWITCH_NOSTOCK)
         proto_map_length = PROTO_MAP_LEN - 1;
     #endif //HAS_SWITCHES_NOSTOCK
-    if (ch < proto_map_length && ProtocolChannelMap[Model.protocol]) {
+    if (ch < proto_map_length && CurrentProtocolChannelMap) {
         char tmp1[30];
-        INPUT_SourceNameAbbrevSwitch(tmp1, ProtocolChannelMap[Model.protocol][ch]);
+        INPUT_SourceNameAbbrevSwitch(tmp1, CurrentProtocolChannelMap[ch]);
         snprintf(tempstring, sizeof(tempstring), "%d-%s", ch + 1, tmp1);
     }
     else if (ch == 4)

--- a/src/protocol/assan_nrf24l01.c
+++ b/src/protocol/assan_nrf24l01.c
@@ -279,6 +279,7 @@ const void *ASSAN_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return (void*)0L;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
         default: break;
     }

--- a/src/protocol/bayang_nrf24l01.c
+++ b/src/protocol/bayang_nrf24l01.c
@@ -543,6 +543,8 @@ const void *Bayang_Cmds(enum ProtoCmds cmd)
                                 PROTO_TELEM_OFF);
     case PROTOCMD_TELEMETRYTYPE:
         return (void *)(long) TELEM_DSM;
+    case PROTOCMD_CHANNELMAP:
+        return AETRG;
     default:
         break;
     }

--- a/src/protocol/bluefly_nrf24l01.c
+++ b/src/protocol/bluefly_nrf24l01.c
@@ -281,6 +281,7 @@ const void *BlueFly_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/bugs3_a7105.c
+++ b/src/protocol/bugs3_a7105.c
@@ -731,6 +731,7 @@ const void *BUGS3_Cmds(enum ProtoCmds cmd)
             return (void *)(long)(PROTO_TELEM_ON);
         case PROTOCMD_TELEMETRYTYPE:
             return (void *)(long) TELEM_FRSKY;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/bugs3mini_nrf24l01.c
+++ b/src/protocol/bugs3mini_nrf24l01.c
@@ -461,6 +461,7 @@ const void *BUGS3MINI_Cmds(enum ProtoCmds cmd)
             return (void *)(long) PROTO_TELEM_ON;
         case PROTOCMD_TELEMETRYTYPE:
             return (void *)(long) TELEM_FRSKY;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/cflie_nrf24l01.c
+++ b/src/protocol/cflie_nrf24l01.c
@@ -950,6 +950,7 @@ const void *CFlie_Cmds(enum ProtoCmds cmd)
             return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_OFF ? PROTO_TELEM_OFF : PROTO_TELEM_ON);
         case PROTOCMD_TELEMETRYTYPE: 
             return (void *)(long) TELEM_DSM;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/cg023_nrf24l01.c
+++ b/src/protocol/cg023_nrf24l01.c
@@ -348,6 +348,7 @@ const void *CG023_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return cg023_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/corona_cc2500.c
+++ b/src/protocol/corona_cc2500.c
@@ -377,6 +377,7 @@ const void *Corona_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return (void *)((long)Model.fixed_id);
         case PROTOCMD_GETOPTIONS: return corona_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -335,6 +335,7 @@ const void * CRSF_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN: return (void *)16L;
         case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
+	case PROTOCMD_CHANNELMAP: return UNCHG;
 #if HAS_EXTENDED_TELEMETRY
         case PROTOCMD_TELEMETRYSTATE:
             return (void *)(long)PROTO_TELEM_ON;

--- a/src/protocol/cx10_nrf24l01.c
+++ b/src/protocol/cx10_nrf24l01.c
@@ -493,6 +493,7 @@ const void *CX10_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return cx10_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/devo_cyrf6936.c
+++ b/src/protocol/devo_cyrf6936.c
@@ -616,6 +616,8 @@ const void *DEVO_Cmds(enum ProtoCmds cmd)
             return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_TELEMETRYTYPE: 
             return (void *)(long) TELEM_DEVO;
+        case PROTOCMD_CHANNELMAP:
+            return EATRG;
         default: break;
     }
     return 0;

--- a/src/protocol/dm002_nrf24l01.c
+++ b/src/protocol/dm002_nrf24l01.c
@@ -278,6 +278,7 @@ const void *DM002_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return (void*)0L;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/dsm2_cyrf6936.c
+++ b/src/protocol/dsm2_cyrf6936.c
@@ -861,6 +861,8 @@ const void *DSM2_Cmds(enum ProtoCmds cmd)
             return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_TELEMETRYTYPE: 
             return (void *)(long) TELEM_DSM;
+        case PROTOCMD_CHANNELMAP:
+            return TAERG;
         default: break;
     }
     return NULL;

--- a/src/protocol/e012_nrf24l01.c
+++ b/src/protocol/e012_nrf24l01.c
@@ -265,6 +265,7 @@ const void *E012_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return (void *)0L;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/e015_nrf24l01.c
+++ b/src/protocol/e015_nrf24l01.c
@@ -298,6 +298,7 @@ const void *E015_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return (void *)0L;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/esky150_nrf24l01.c
+++ b/src/protocol/esky150_nrf24l01.c
@@ -193,6 +193,8 @@ const void *ESKY150_Cmds(enum ProtoCmds cmd)
             return ESKY2_PROTOCOL_OPTIONS;
         case PROTOCMD_TELEMETRYSTATE: 
             return (void *)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP:
+            return TAERG;
         default: break;
     }
     return 0;

--- a/src/protocol/esky_nrf24l01.c
+++ b/src/protocol/esky_nrf24l01.c
@@ -370,6 +370,7 @@ const void *ESKY_Cmds(enum ProtoCmds cmd)
         // TODO: return id correctly
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_TELEMETRYSTATE: return (void *) PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/flysky_a7105.c
+++ b/src/protocol/flysky_a7105.c
@@ -446,6 +446,7 @@ const void *FLYSKY_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_GETOPTIONS:
             return flysky_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -649,6 +649,7 @@ const void *AFHDS2A_Cmds(enum ProtoCmds cmd)
             return (void *)(long) PROTO_TELEM_ON;
         case PROTOCMD_TELEMETRYTYPE:
             return (void *)(long) TELEM_FRSKY;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/fq777_nrf24l01.c
+++ b/src/protocol/fq777_nrf24l01.c
@@ -358,6 +358,7 @@ const void *FQ777_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return fq777_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/frsky1way_cc2500.c
+++ b/src/protocol/frsky1way_cc2500.c
@@ -347,6 +347,7 @@ const void *FRSKY1WAY_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return frsky_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/frsky2way_cc2500.c
+++ b/src/protocol/frsky2way_cc2500.c
@@ -507,6 +507,7 @@ const void *FRSKY2WAY_Cmds(enum ProtoCmds cmd)
             Telemetry.value[TELEM_FRSKY_MIN_CELL] = TELEMETRY_GetMaxValue(TELEM_FRSKY_MIN_CELL);
 #endif
             return 0;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/frskyx_cc2500.c
+++ b/src/protocol/frskyx_cc2500.c
@@ -959,6 +959,7 @@ const void *FRSKYX_Cmds(enum ProtoCmds cmd)
 #endif
             CLOCK_StopTimer();
             return (void *)(CC2500_Reset() ? 1L : -1L);
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/fy326_nrf24l01.c
+++ b/src/protocol/fy326_nrf24l01.c
@@ -400,6 +400,7 @@ const void *FY326_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return fy326_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/gw008_nrf24l01.c
+++ b/src/protocol/gw008_nrf24l01.c
@@ -263,6 +263,7 @@ const void *GW008_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return (void*)0L;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/h377_nrf24l01.c
+++ b/src/protocol/h377_nrf24l01.c
@@ -369,6 +369,7 @@ const void *H377_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_DEFAULT_NUMCHAN: printf("=>H377 : cmd %d PROTOCMD_DEFAULT_NUMCHAN\n", cmd); return (void *)6L;
         case PROTOCMD_CURRENT_ID: printf("=>H377 : cmd %d PROTOCMD_CURRENT_ID\n", cmd); return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_TELEMETRYSTATE: return (void *) PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/h8_3d_nrf24l01.c
+++ b/src/protocol/h8_3d_nrf24l01.c
@@ -503,6 +503,7 @@ const void *H8_3D_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return h8_3d_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/hisky_nrf24l01.c
+++ b/src/protocol/hisky_nrf24l01.c
@@ -446,6 +446,7 @@ const void *HiSky_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return hisky_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/hitec_cc2500.c
+++ b/src/protocol/hitec_cc2500.c
@@ -629,6 +629,7 @@ const void *Hitec_Cmds(enum ProtoCmds cmd)
             return (void *)(long)(PROTO_TELEM_ON);
         case PROTOCMD_TELEMETRYTYPE: 
             return (void *)(long) TELEM_FRSKY;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/hm830_nrf24l01.c
+++ b/src/protocol/hm830_nrf24l01.c
@@ -394,6 +394,7 @@ const void *HM830_Cmds(enum ProtoCmds cmd)
         // TODO: return id correctly
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return TAERG;
         default: break;
     }
     return 0;

--- a/src/protocol/hontai_nrf24l01.c
+++ b/src/protocol/hontai_nrf24l01.c
@@ -431,6 +431,7 @@ const void *HonTai_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return hontai_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/hubsan_a7105.c
+++ b/src/protocol/hubsan_a7105.c
@@ -674,6 +674,7 @@ const void *HUBSAN_Cmds(enum ProtoCmds cmd)
             return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_TELEMETRYTYPE: 
             return (void *)(long) TELEM_DEVO;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/inav_nrf24l01.c
+++ b/src/protocol/inav_nrf24l01.c
@@ -829,6 +829,7 @@ const void *INAV_Cmds(enum ProtoCmds cmd)
 #else
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
 #endif
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/interface.h
+++ b/src/protocol/interface.h
@@ -15,6 +15,7 @@ enum ProtoCmds {
     PROTOCMD_TELEMETRYTYPE,
     PROTOCMD_TELEMETRYRESET,
     PROTOCMD_RESET,
+    PROTOCMD_CHANNELMAP,
 };
 
 enum TXRX_State {
@@ -29,6 +30,12 @@ enum PinConfigState {
     DISABLED_PIN,
     RESET_PIN,
 };
+
+const u8 EATRG[PROTO_MAP_LEN];
+const u8 TAERG[PROTO_MAP_LEN];
+#define UNCHG ((void*)1)
+#define AETRG ((void*)0)
+
 #ifndef MODULAR
 #define PROTODEF(proto, module, map, cmd, name) extern const void * cmd(enum ProtoCmds);
 #include "protocol.h"

--- a/src/protocol/j6pro_cyrf6936.c
+++ b/src/protocol/j6pro_cyrf6936.c
@@ -303,6 +303,7 @@ const void *J6PRO_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
         case PROTOCMD_CURRENT_ID: return 0;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/joysway_a7105.c
+++ b/src/protocol/joysway_a7105.c
@@ -254,6 +254,7 @@ const void *JOYSWAY_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return joysway_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/kn_nrf24l01.c
+++ b/src/protocol/kn_nrf24l01.c
@@ -216,6 +216,8 @@ const void *KN_Cmds(enum ProtoCmds cmd)
             return KN_PROTOCOL_OPTIONS;
         case PROTOCMD_TELEMETRYSTATE: 
             return (void *)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP:
+            return TAERG;
         default: break;
     }
     return 0;

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -473,6 +473,7 @@ const void *MJXq_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return mjxq_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/mt99xx_nrf24l01.c
+++ b/src/protocol/mt99xx_nrf24l01.c
@@ -471,6 +471,7 @@ const void *MT99XX_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return mt99xx_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/ne260_nrf24l01.c
+++ b/src/protocol/ne260_nrf24l01.c
@@ -322,6 +322,7 @@ const void *NE260_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_DEFAULT_NUMCHAN: return (void *)4L;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_TELEMETRYSTATE: return (void *) PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/ppmout.c
+++ b/src/protocol/ppmout.c
@@ -120,6 +120,7 @@ const void * PPMOUT_Cmds(enum ProtoCmds cmd)
                 Model.proto_opts[PERIOD_PW] = 22500;
             }
             return ppm_opts;
+	case PROTOCMD_CHANNELMAP: return UNCHG;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
         default: break;
     }

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -565,6 +565,7 @@ const void *Q303_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return q303_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/sbus_uart.c
+++ b/src/protocol/sbus_uart.c
@@ -121,6 +121,7 @@ const void * SBUS_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN: return (void *)16L;
         case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
+	case PROTOCMD_CHANNELMAP: return UNCHG;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
         default: break;
     }

--- a/src/protocol/sfhss_cc2500.c
+++ b/src/protocol/sfhss_cc2500.c
@@ -401,6 +401,7 @@ const void *SFHSS_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_GETOPTIONS:
             return SFHSS_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/skyartec_cc2500.c
+++ b/src/protocol/skyartec_cc2500.c
@@ -242,6 +242,7 @@ const void *SKYARTEC_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_DEFAULT_NUMCHAN: return (void *)7L;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/slt_nrf24l01.c
+++ b/src/protocol/slt_nrf24l01.c
@@ -514,6 +514,7 @@ const void *SLT_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return slt_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/symax_nrf24l01.c
+++ b/src/protocol/symax_nrf24l01.c
@@ -512,7 +512,7 @@ const void *SYMAX_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return symax_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
-
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/testrf.c
+++ b/src/protocol/testrf.c
@@ -391,6 +391,8 @@ const void * TESTRF_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_GETOPTIONS:
             return testrf_opts;
+	case PROTOCMD_CHANNELMAP:
+	    return UNCHG;
         case PROTOCMD_SETOPTIONS:
             initialize();
             return 0;

--- a/src/protocol/testser.c
+++ b/src/protocol/testser.c
@@ -159,6 +159,7 @@ const void * TESTSER_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_NUMCHAN: return (void *)16L;
         case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+	case PROTOCMD_CHANNELMAP: return UNCHG;
         case PROTOCMD_GETOPTIONS: return testser_opts;
         default: break;
     }

--- a/src/protocol/usbhid.c
+++ b/src/protocol/usbhid.c
@@ -98,7 +98,8 @@ const void * USBHID_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN: return (void *)((unsigned long)USBHID_MAX_CHANNELS);
         case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+	case PROTOCMD_CHANNELMAP: return UNCHG;
+	case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
         default: break;
     }
     return 0;

--- a/src/protocol/v202_nrf24l01.c
+++ b/src/protocol/v202_nrf24l01.c
@@ -599,6 +599,7 @@ const void *V202_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
         case PROTOCMD_GETOPTIONS: return v202_opts;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/wfly_cyrf6936.c
+++ b/src/protocol/wfly_cyrf6936.c
@@ -354,6 +354,7 @@ const void *WFLY_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_CURRENT_ID:  return (void *)((unsigned long)Model.fixed_id);
         case PROTOCMD_GETOPTIONS: return (void*)0L;
         case PROTOCMD_TELEMETRYSTATE: return (void *) PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/protocol/wk2x01.c
+++ b/src/protocol/wk2x01.c
@@ -580,6 +580,8 @@ const void *WK2x01_Cmds(enum ProtoCmds cmd)
                 return wk2601_opts;
             break;
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP:
+            return EATRG;
         default: break;
     }
     return 0;

--- a/src/protocol/yd717_nrf24l01.c
+++ b/src/protocol/yd717_nrf24l01.c
@@ -522,6 +522,7 @@ const void *YD717_Cmds(enum ProtoCmds cmd)
 #else
         case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
 #endif
+        case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }
     return 0;

--- a/src/remap_channels.c
+++ b/src/remap_channels.c
@@ -46,7 +46,7 @@ static void map_inp(unsigned *chmap, u8 *val)
 void RemapChannelsForProtocol(const u8 *oldmap)
 {
     int i, j;
-    const u8 *map = ProtocolChannelMap[Model.protocol];
+    const u8 *map = CurrentProtocolChannelMap;
     unsigned chmap[PROTO_MAP_LEN];
 
     if(! oldmap || ! map || map == oldmap)


### PR DESCRIPTION
ChannelMap is always reference with Model.Protocol. Replace it with a CurrentChannelMap and leave the logic to decide the channel map to individual module. This save 244bytes from devo7e.
ROM: 0x08003000 - 0x0801ff10 = 115.77kB
RAM: 0x20000000 - 0x20002894 =  10.14kB

Didn't remove map from protocol.h where it is not used anymore. Use it as a documentation.