### PR TITLE
rework the way to expose protocol data

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -124,13 +124,12 @@ int PAGE_ModelDoneEditing();
 /* Protocol */
 #define PROTODEF(proto, module, map, init, name) proto,
 enum Protocols {
-    PROTOCOL_NONE,
+    PROTOCOL_NONE = 0,
     #include "protocol/protocol.h"
     PROTOCOL_COUNT,
 };
 #undef PROTODEF
 extern const u8 *ProtocolChannelMap[PROTOCOL_COUNT];
-extern const char * const ProtocolNames[PROTOCOL_COUNT];
 #define PROTO_MAP_LEN 5
 
 enum ModelType {
@@ -166,6 +165,8 @@ u8 PROTOCOL_GetTelemCapability();
 int PROTOCOL_DefaultNumChannels();
 void PROTOCOL_CheckDialogs();
 u32 PROTOCOL_CurrentID();
+const char * PROTOCOL_Name();
+const char * PROTOCOL_GetName(u16 idx);
 const char **PROTOCOL_GetOptions();
 void PROTOCOL_SetOptions();
 int PROTOCOL_GetTelemetryState();

--- a/src/config/model.c
+++ b/src/config/model.c
@@ -57,8 +57,6 @@ static const char RADIO_VIDEOCH[]  = "videoch";
 static const char RADIO_VIDEOCONTRAST[]  = "videocontrast";
 static const char RADIO_VIDEOBRIGHTNESS[]  = "videobrightness";
 
-#define RADIO_PROTOCOL_VAL Protocols
-
 static const char RADIO_NUM_CHANNELS[] = "num_channels";
 static const char RADIO_FIXED_ID[] = "fixed_id";
 

--- a/src/config/model.c
+++ b/src/config/model.c
@@ -653,7 +653,7 @@ int assign_int(void* ptr, const struct struct_map *map, int map_size)
     }
     if (MATCH_SECTION(SECTION_RADIO)) {
         if (MATCH_KEY(RADIO_PROTOCOL)) {
-            for (i = 0; i < NUM_STR_ELEMS(PROTOCOL_COUNT); i++) {
+            for (i = 0; i < PROTOCOL_COUNT; i++) {
                 if (MATCH_VALUE(PROTOCOL_GetName(i))) {
                     m->protocol = i;
                     PROTOCOL_Load(1);

--- a/src/config/model.c
+++ b/src/config/model.c
@@ -57,7 +57,7 @@ static const char RADIO_VIDEOCH[]  = "videoch";
 static const char RADIO_VIDEOCONTRAST[]  = "videocontrast";
 static const char RADIO_VIDEOBRIGHTNESS[]  = "videobrightness";
 
-#define RADIO_PROTOCOL_VAL ProtocolNames
+#define RADIO_PROTOCOL_VAL Protocols
 
 static const char RADIO_NUM_CHANNELS[] = "num_channels";
 static const char RADIO_FIXED_ID[] = "fixed_id";
@@ -653,8 +653,8 @@ int assign_int(void* ptr, const struct struct_map *map, int map_size)
     }
     if (MATCH_SECTION(SECTION_RADIO)) {
         if (MATCH_KEY(RADIO_PROTOCOL)) {
-            for (i = 0; i < NUM_STR_ELEMS(RADIO_PROTOCOL_VAL); i++) {
-                if (MATCH_VALUE(RADIO_PROTOCOL_VAL[i])) {
+            for (i = 0; i < NUM_STR_ELEMS(PROTOCOL_COUNT); i++) {
+                if (MATCH_VALUE(PROTOCOL_GetName(i))) {
                     m->protocol = i;
                     PROTOCOL_Load(1);
                     return 1;
@@ -1200,7 +1200,7 @@ u8 CONFIG_WriteModel(u8 model_num) {
     if(WRITE_FULL_MODEL || m->type != 0)
         fprintf(fh, "%s=%s\n", MODEL_TYPE, MODEL_TYPE_VAL[m->type]);
     fprintf(fh, "[%s]\n", SECTION_RADIO);
-    fprintf(fh, "%s=%s\n", RADIO_PROTOCOL, RADIO_PROTOCOL_VAL[m->protocol]);
+    fprintf(fh, "%s=%s\n", RADIO_PROTOCOL, PROTOCOL_GetName(m->protocol));
     write_int(fh, m, _secradio, MAPSIZE(_secradio));
     fprintf(fh, "%s=%s\n", RADIO_TX_POWER, RADIO_TX_POWER_VAL[m->tx_power]);
     fprintf(fh, "\n");

--- a/src/pages/128x64x1/model_config.c
+++ b/src/pages/128x64x1/model_config.c
@@ -213,7 +213,7 @@ void PAGE_VideoSetupInit(int page)
 void PAGE_ModelProtoInit(int page)
 {
     (void) page;
-    show_titlerow(ProtocolNames[Model.protocol]);
+    show_titlerow(PROTOCOL_Name());
 
     proto_strs = PROTOCOL_GetOptions();
     int idx = 0;

--- a/src/pages/320x240x16/model_config.c
+++ b/src/pages/320x240x16/model_config.c
@@ -64,7 +64,7 @@ void PAGE_ModelConfigInit(int page)
 void PAGE_ModelProtoInit(int page)
 {
     (void)page;
-    PAGE_ShowHeader(ProtocolNames[Model.protocol]);
+    PAGE_ShowHeader(PROTOCOL_Name());
     proto_strs = PROTOCOL_GetOptions();
     int row = ROW1;
     int pos = 0;

--- a/src/pages/common/_model_page.c
+++ b/src/pages/common/_model_page.c
@@ -269,12 +269,8 @@ static const char *protoselect_cb(guiObject_t *obj, int dir, void *data)
         configure_bind_button();
     }
     GUI_TextSelectEnablePress((guiTextSelect_t *)obj, PROTOCOL_GetOptions() ? 1 : 0);
-    if (Model.protocol == 0)
-        return _tr("None");
-    if(PROTOCOL_HasModule(Model.protocol))
-        return ProtocolNames[Model.protocol];
-    sprintf(tempstring, "*%s", ProtocolNames[Model.protocol]);
-    return tempstring;
+
+    return PROTOCOL_Name();
 }
 void proto_press_cb(guiObject_t *obj, void *data)
 {

--- a/src/pages/common/_model_page.c
+++ b/src/pages/common/_model_page.c
@@ -270,7 +270,12 @@ static const char *protoselect_cb(guiObject_t *obj, int dir, void *data)
     }
     GUI_TextSelectEnablePress((guiTextSelect_t *)obj, PROTOCOL_GetOptions() ? 1 : 0);
 
-    return PROTOCOL_Name();
+    if (Model.protocol == 0)
+        return _tr("None");
+    if (PROTOCOL_HasModule(Model.protocol))
+        return PROTOCOL_Name();
+    sprintf(tempstring, "*%s", PROTOCOL_Name());
+    return tempstring;
 }
 void proto_press_cb(guiObject_t *obj, void *data)
 {

--- a/src/protocol/protocol.c
+++ b/src/protocol/protocol.c
@@ -64,13 +64,43 @@ const void * (*PROTO_Cmds)(enum ProtoCmds) = NULL;
 #define PROTOCOL_LOADED PROTO_Cmds
 #endif
 
-#define PROTODEF(proto, module, map, cmd, name) name,
-const char * const ProtocolNames[PROTOCOL_COUNT] = {
-    "None",
+#ifdef MODULAR
+#define PROTODEF(proto, module, map, cmd, name) {module, name},
+const struct{
+    int module;
+    const char* name;
+}Protocols[PROTOCOL_COUNT] = {
+    { TX_MODULE_LAST, "None" },
     #include "protocol.h"
 };
 #undef PROTODEF
-static int get_module(int idx);
+#else
+#define PROTODEF(proto, module, map, cmd, name) {module, cmd, name},
+const struct{
+    int module;
+    const void * (*cmd)(enum ProtoCmds);
+    const char* name;
+}Protocols[PROTOCOL_COUNT] = {
+    { 0, NULL, "None"},
+    #include "protocol.h"
+};
+#undef PROTODEF
+#endif
+
+static int get_module(u16 idx);
+
+const char * PROTOCOL_GetName(u16 idx)
+{
+    if (idx > PROTOCOL_COUNT)
+        return _tr("None");
+    else
+        return Protocols[idx].name;
+}
+
+const char * PROTOCOL_Name()
+{
+    return PROTOCOL_GetName(Model.protocol);
+}
 
 void PROTOCOL_Init(u8 force)
 {
@@ -112,12 +142,15 @@ void PROTOCOL_Load(int no_dlg)
         return;
     char file[25];
     strcpy(file, "protocol/");
-    #define PROTODEF(proto, module, map, cmd, name) case proto: strcat(file,name); break;
-    switch(Model.protocol) {
-        #include "protocol.h"
-        default: *loaded_protocol = 0; return;
+
+    if (Model.protocol > PROTOCOL_COUNT)
+    {
+        *loaded_protocol = 0; return;
     }
-    #undef PROTODEF
+    else
+    {
+        strcat(file, Protocols[Model.protocol].name);
+    }
     file[17] = '\0'; //truncate filename to 8 characters
     strcat(file, ".mod");
     FILE *fh;
@@ -172,12 +205,7 @@ void PROTOCOL_Load(int no_dlg)
         printf("Module is not defined!\n");
         return;
     }
-    #define PROTODEF(proto, module, map, cmd, name) case proto: PROTO_Cmds = cmd; break;
-    switch(Model.protocol) {
-        #include "protocol.h"
-        default: PROTO_Cmds = NULL;
-    }
-    #undef PROTODEF
+    PROTO_Cmds = Protocols[Model.protocol].cmd;
 #endif
     PROTOCOL_SetSwitch(get_module(Model.protocol));
     if (PROTOCOL_GetTelemetryState() != PROTO_TELEM_UNSUPPORTED) {
@@ -367,15 +395,13 @@ void PROTOCOL_CheckDialogs()
         }
     }
 }
-static int get_module(int idx)
+
+static int get_module(u16 idx)
 {
-    int m = TX_MODULE_LAST;
-    #define PROTODEF(proto, module, map, cmd, name) case proto: m = module; break;
-    switch(idx) {
-        #include "protocol.h"
-    }
-    #undef PROTODEF
-    return m;
+    if (idx >= PROTOCOL_COUNT)
+        return TX_MODULE_LAST;
+    else
+        return Protocols[idx].module;
 }
 
 int PROTOCOL_HasModule(int idx)

--- a/src/protocol/protocol.c
+++ b/src/protocol/protocol.c
@@ -70,7 +70,7 @@ const struct{
     int module;
     const char* name;
 }Protocols[PROTOCOL_COUNT] = {
-    { TX_MODULE_LAST, "None" },
+    { 0, "None" },
     #include "protocol.h"
 };
 #undef PROTODEF


### PR DESCRIPTION
Use an array Protocols to expose various data to avoid big switch in the code.

This saves another 492bytes from devo7e build.