### PR TITLE
Make PROTO_TELEM_UNSUPPORTED to 0

### DIFF
--- a/src/pages/common/_pages.c
+++ b/src/pages/common/_pages.c
@@ -105,14 +105,14 @@ u8 PAGE_TelemStateCheck(char *str, int strlen)
 {
     (void)strlen;
     s8 state = PROTOCOL_GetTelemetryState();
-    if (state == -1) {
+    if (state == PROTO_TELEM_UNSUPPORTED) {
         sprintf(str, "%s%s%s",
             _tr("Telemetry"),
             LCD_DEPTH == 1?"\n":" ", // no translate for this string
             _tr("is not supported"));
         return 0;
     }
-    else if (state == 0) {
+    else if (state == PROTO_TELEM_OFF) {
         sprintf(str, "%s%s%s",
             _tr("Telemetry"),
             LCD_DEPTH == 1?"\n":" ",  // no translate for this string

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -330,7 +330,7 @@ void TELEMETRY_SetType(int type)
 //#define DEBUG_TELEMALARM
 void TELEMETRY_Alarm()
 {
-    if (! PROTOCOL_GetTelemetryState())
+    if (PROTOCOL_GetTelemetryState() == PROTO_TELEM_UNSUPPORTED)
         return;
 
     //Update 'updated' state every time we get here

--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -330,7 +330,7 @@ void TELEMETRY_SetType(int type)
 //#define DEBUG_TELEMALARM
 void TELEMETRY_Alarm()
 {
-    if (PROTOCOL_GetTelemetryState() == PROTO_TELEM_UNSUPPORTED)
+    if (PROTOCOL_GetTelemetryState() != PROTO_TELEM_ON)
         return;
 
     //Update 'updated' state every time we get here

--- a/src/telemetry.h
+++ b/src/telemetry.h
@@ -218,9 +218,9 @@ struct Telemetry {
 };
 
 enum {
-    PROTO_TELEM_UNSUPPORTED = -1,
-    PROTO_TELEM_OFF = 0,
-    PROTO_TELEM_ON  = 1,
+    PROTO_TELEM_UNSUPPORTED = 0,
+    PROTO_TELEM_OFF = 1,
+    PROTO_TELEM_ON  = 2,
 };
 
 
@@ -326,7 +326,7 @@ enum {
 
 /************************************************************************/
 
-extern struct Telemetry Telemetry; 
+extern struct Telemetry Telemetry;
 s32 TELEMETRY_GetValue(int idx);
 s32 _TELEMETRY_GetValue(struct Telemetry *t, int idx);
 const char * TELEMETRY_GetValueStr(char *str, int idx);


### PR DESCRIPTION
As most protocol doesn't support telemetry, make unsupport as 0 to save
ROM size 264 bytes. Also fixed the places which assumes the values.

For example of devof12e:
before:
ROM: 0x08004000 - 0x0803c13c = 224.31kB
RAM: 0x20000000 - 0x200069f8 =  26.49kB

After:
ROM: 0x08004000 - 0x0803c034 = 224.05kB
RAM: 0x20000000 - 0x200069f8 =  26.49kB