### PR TITLE
Update to GCC-8-2018-q4-major

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,9 @@ git:
 
 before_install:
    - pip install --user cpp-coveralls cpplint
-   - if [ ! -d "$HOME/gcc-arm-none-eabi-4_8-2013q4/bin" ]; then
+   - if [ ! -d "$HOME/gcc-arm-none-eabi-8-2018-q4-major/bin" ]; then
        pushd $HOME;
-       curl --retry 10 --retry-max-time 120 -L "https://launchpad.net/gcc-arm-embedded/4.8/4.8-2013-q4-major/+download/gcc-arm-none-eabi-4_8-2013q4-20131204-linux.tar.bz2" | tar xfj -;
+       curl --retry 10 --retry-max-time 120 -L "https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2018q4/gcc-arm-none-eabi-8-2018-q4-major-linux.tar.bz2" | tar xfj -;
        popd;
      fi;
    # don't build 'tests' because they don't work on a cross-compile, so we need to specify 'DIRS' explicitly
@@ -87,7 +87,7 @@ before_install:
 
 install:
   - export GITHUB_TOKEN='789c538d758e0a718c8ae537b7f6656776e20d768de18d546014e20876e1898933cd94648f75e06117e20000b71f080d'
-  - export PATH=$PATH:$HOME/gcc-arm-none-eabi-4_8-2013q4/bin
+  - export PATH=$PATH:$HOME/gcc-arm-none-eabi-8-2018-q4-major/bin
 #  - "export TRAVIS_COMMIT_MSG=\"$(git log --format=%B --no-merges -n 1)\""a
   - curl -s -L "https://api.travis-ci.org/repos/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID" | python -c 'import sys, json; a = json.load(sys.stdin); print "export TRAVIS_EVENT_TYPE=" + a.get("event_type",""); print "export TRAVIS_COMMIT_MSG=\"" + a.get("message","").replace("\"", "\\\"") + "\""'
   - source <(curl -s -L "https://api.travis-ci.org/repos/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID" | python -c 'import sys, json; a = json.load(sys.stdin); print "export TRAVIS_EVENT_TYPE=" + a.get("event_type",""); print "export TRAVIS_COMMIT_MSG=\"" + a.get("message","").replace("\"", "\\\"") + "\""')
@@ -148,7 +148,7 @@ after_success:
 cache:
   apt: true
   directories:
-  - $HOME/gcc-arm-none-eabi-4_8-2013q4
+  - $HOME/gcc-arm-none-eabi-8-2018-q4-major
   - $HOME/fltk-1.3.0-w32
   - $HOME/portaudio-w32
   - $HOME/mpg123-w32


### PR DESCRIPTION
Upgrade the compiler to latest arm-none-eabi-gcc from ARM. The current compiler is too old to get any support. The new compiler gives better warnings and potentially leverage some new optimization technology.