### PR TITLE
Don't use image size to create mapped gfx

### DIFF
--- a/src/pages/common/_main_page.c
+++ b/src/pages/common/_main_page.c
@@ -293,11 +293,13 @@ void GetElementSize(unsigned type, u16 *w, u16 *h)
         [ELEM_BATTERY]  = BATTERY_H,
         [ELEM_TXPOWER]  = TXPOWER_H,
     };
+#ifndef _DEVO_F12E_TARGET_H_
     if (type == ELEM_MODELICO && Model.icon[0]) {
         if(LCD_ImageDimensions(CONFIG_GetCurrentIcon(), w, h))
             return;
         //We can't fix this during model-load because only 1 file can be open at a time
     }
+#endif
     *w = width[type];
     *h = height[type];
 }


### PR DESCRIPTION
first, the code cannot handle any size other than 6x4.
second, the unit of image size is pixel, while mapped gfx window is
char. They cannot use mixed. Let's always use 6x4 for devof12e.