### PR TITLE
Added rssi telemetry sounds

### DIFF
--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -436,6 +436,9 @@ void TELEMETRY_Alarm()
                 case TELEM_DSM_GFORCE_YMAX:
                 case TELEM_DSM_GFORCE_ZMAX:
                 case TELEM_DSM_GFORCE_ZMIN: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_GFORCE,2); break;
+#if HAS_EXTENDED_TELEMETRY
+                case TELEM_DSM_FLOG_RSSI_DBM: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_DB,0); break;
+#endif
                 default: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_NONE,0);
           }
         }
@@ -463,6 +466,8 @@ void TELEMETRY_Alarm()
                 case TELEM_FRSKY_CURRENT: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_AMPS,2); break;
                 case TELEM_FRSKY_ALTITUDE: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_ALTITUDE,2); break;
 #endif
+                case TELEM_FRSKY_LRSSI:
+                case TELEM_FRSKY_RSSI: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_DB,0); break;
                 default: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_NONE,0);
             }
         }
@@ -474,6 +479,11 @@ void TELEMETRY_Alarm()
                     MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_VOLT,2); break;
                 case TELEM_CRSF_BATT_CURRENT: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_AMPS,2); break;
                 case TELEM_CRSF_GPS_ALTITUDE: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_ALTITUDE,2); break;
+                case TELEM_CRSF_TX_SNR:
+                case TELEM_CRSF_TX_RSSI:
+                case TELEM_CRSF_RX_SNR:
+                case TELEM_CRSF_RX_RSSI1:
+                case TELEM_CRSF_RX_RSSI2: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_DB,0); break;
                 default: MUSIC_PlayValue(MUSIC_GetTelemetryAlarm(MUSIC_TELEMALARM1 + k), TELEMETRY_GetValue(Model.telem_alarm[k]),VOICE_UNIT_NONE,0);
             }
         }

--- a/src/telemetry/telem_dsm.c
+++ b/src/telemetry/telem_dsm.c
@@ -145,7 +145,7 @@ const char * _dsm_str_by_value(char *str, u8 telem, s32 value)
         case TELEM_DSM_PBOX_ALARMV2:
         case TELEM_DSM_PBOX_ALARMC1:
         case TELEM_DSM_PBOX_ALARMC2:    strcpy(str, _tr(value?"On":"Off")); break;
-        case TELEM_DSM_FLOG_RSSI_DBM:
+        case TELEM_DSM_FLOG_RSSI_DBM:   _get_value_str(str, value, 0, 'd'); break;
         case TELEM_DSM_PBOX_CAPACITY1:
         case TELEM_DSM_PBOX_CAPACITY2:
         case TELEM_DSM_FPCAP_CAPACITY:


### PR DESCRIPTION
This PR contains the following changes:
- added VOICE_UNIT_DB sounds to all telemetry fields with 'd' as units.
- fixed dsm rssi telemetry to have proper unit - 'd'.