### PR TITLE
Remove Beken BK2421 / BK2423 support

### DIFF
--- a/src/protocol/assan_nrf24l01.c
+++ b/src/protocol/assan_nrf24l01.c
@@ -85,9 +85,6 @@ void init()
     NRF24L01_WriteReg(NRF24L01_02_EN_RXADDR, 0x01);         // Enable data pipe 0 only
     NRF24L01_WriteReg(NRF24L01_11_RX_PW_P0, PACKET_SIZE);
     NRF24L01_SetPower(Model.tx_power);
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 void send_packet()

--- a/src/protocol/bayang_nrf24l01.c
+++ b/src/protocol/bayang_nrf24l01.c
@@ -379,10 +379,6 @@ static void bay_init()
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00); // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x01);
     NRF24L01_Activate(0x73);
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
-
     NRF24L01_SetTxRxMode(TX_EN);
 }
 

--- a/src/protocol/bluefly_nrf24l01.c
+++ b/src/protocol/bluefly_nrf24l01.c
@@ -105,10 +105,6 @@ static void bluefly_init()
     NRF24L01_SetBitrate(NRF24L01_BR_250K);           // BlueFly - 250kbps
     NRF24L01_SetPower(Model.tx_power);
     NRF24L01_WriteReg(NRF24L01_07_STATUS, 0x70);     // Clear data ready, data sent, and retransmit
-
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 // HiSky channel sequence: AILE  ELEV  THRO  RUDD  GEAR  PITCH, channel data value is from 0 to 1000

--- a/src/protocol/bugs3mini_nrf24l01.c
+++ b/src/protocol/bugs3mini_nrf24l01.c
@@ -170,9 +170,6 @@ static void bugs3mini_init()
     NRF24L01_Activate(0x73);                          // Activate feature register
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);       // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x00);     // Set feature bits on
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 #define CHAN_RANGE (CHAN_MAX_VALUE - CHAN_MIN_VALUE)

--- a/src/protocol/cflie_nrf24l01.c
+++ b/src/protocol/cflie_nrf24l01.c
@@ -710,44 +710,6 @@ static int cflie_init()
 
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x01);       // Enable Dynamic Payload Length on pipe 0
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x06);     // Enable Dynamic Payload Length, enable Payload with ACK
-
-    // Check for Beken BK2421/BK2423 chip
-    // It is done by using Beken specific activate code, 0x53
-    // and checking that status register changed appropriately
-    // There is no harm to run it on nRF24L01 because following
-    // closing activate command changes state back even if it
-    // does something on nRF24L01
-    NRF24L01_Activate(0x53); // magic for BK2421 bank switch
-    dbgprintf("Trying to switch banks\n");
-    if (NRF24L01_ReadReg(NRF24L01_07_STATUS) & 0x80) {
-        dbgprintf("BK2421 detected\n");
-        long nul = 0;
-        // Beken registers don't have such nice names, so we just mention
-        // them by their numbers
-        // It's all magic, eavesdropped from real transfer and not even from the
-        // data sheet - it has slightly different values
-        NRF24L01_WriteRegisterMulti(0x00, (u8 *) "\x40\x4B\x01\xE2", 4);
-        NRF24L01_WriteRegisterMulti(0x01, (u8 *) "\xC0\x4B\x00\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x02, (u8 *) "\xD0\xFC\x8C\x02", 4);
-        NRF24L01_WriteRegisterMulti(0x03, (u8 *) "\xF9\x00\x39\x21", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xC1\x96\x9A\x1B", 4);
-        NRF24L01_WriteRegisterMulti(0x05, (u8 *) "\x24\x06\x7F\xA6", 4);
-        NRF24L01_WriteRegisterMulti(0x06, (u8 *) &nul, 4);
-        NRF24L01_WriteRegisterMulti(0x07, (u8 *) &nul, 4);
-        NRF24L01_WriteRegisterMulti(0x08, (u8 *) &nul, 4);
-        NRF24L01_WriteRegisterMulti(0x09, (u8 *) &nul, 4);
-        NRF24L01_WriteRegisterMulti(0x0A, (u8 *) &nul, 4);
-        NRF24L01_WriteRegisterMulti(0x0B, (u8 *) &nul, 4);
-        NRF24L01_WriteRegisterMulti(0x0C, (u8 *) "\x00\x12\x73\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x0D, (u8 *) "\x46\xB4\x80\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x0E, (u8 *) "\x41\x10\x04\x82\x20\x08\x08\xF2\x7D\xEF\xFF", 11);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xC7\x96\x9A\x1B", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xC1\x96\x9A\x1B", 4);
-    } else {
-        dbgprintf("nRF24L01 detected\n");
-    }
-    NRF24L01_Activate(0x53); // switch bank back
-
     // 50ms delay in callback
     return 50000;
 }

--- a/src/protocol/cg023_nrf24l01.c
+++ b/src/protocol/cg023_nrf24l01.c
@@ -264,9 +264,6 @@ static void cg023_init()
 
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);       // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x00);     // Set feature bits on
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 MODULE_CALLTYPE

--- a/src/protocol/cx10_nrf24l01.c
+++ b/src/protocol/cx10_nrf24l01.c
@@ -339,9 +339,6 @@ static void cx10_init()
 
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);       // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x00);     // Set feature bits on
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 MODULE_CALLTYPE

--- a/src/protocol/dm002_nrf24l01.c
+++ b/src/protocol/dm002_nrf24l01.c
@@ -203,9 +203,6 @@ static void DM002_init()
     NRF24L01_WriteReg(NRF24L01_02_EN_RXADDR, 0x01);  // Enable data pipe 0 only
     NRF24L01_SetBitrate(NRF24L01_BR_1M);             // 1Mbps
     NRF24L01_SetPower(Model.tx_power);
-    
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 MODULE_CALLTYPE

--- a/src/protocol/e012_nrf24l01.c
+++ b/src/protocol/e012_nrf24l01.c
@@ -175,9 +175,6 @@ static void e012_init()
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);       // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x01);     // Set feature bits on
     NRF24L01_Activate(0x73);
-    
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 static void initialize_txid()

--- a/src/protocol/e015_nrf24l01.c
+++ b/src/protocol/e015_nrf24l01.c
@@ -123,9 +123,6 @@ static void e015_init()
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);       // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x01);     // Set feature bits on
     NRF24L01_Activate(0x73);
-    
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 #define CHAN_RANGE (CHAN_MAX_VALUE - CHAN_MIN_VALUE)

--- a/src/protocol/esky150_nrf24l01.c
+++ b/src/protocol/esky150_nrf24l01.c
@@ -312,40 +312,6 @@ static void esky2_init(u8 tx_addr[], u8 hopping_ch[])
     // Enable: Dynamic Payload Length, Payload with ACK , W_TX_PAYLOAD_NOACK
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, BV(NRF2401_1D_EN_DPL) | BV(NRF2401_1D_EN_ACK_PAY) | BV(NRF2401_1D_EN_DYN_ACK));
 
-    
-    // Check for Beken BK2421/BK2423 chip
-    // It is done by using Beken specific activate code, 0x53
-    // and checking that status register changed appropriately
-    // There is no harm to run it on nRF24L01 because following
-    // closing activate command changes state back even if it
-    // does something on nRF24L01
-    NRF24L01_Activate(0x53); // magic for BK2421 bank switch
-    dbgprintf("Trying to switch banks\n");
-    if (NRF24L01_ReadReg(NRF24L01_07_STATUS) & 0x80) {
-        dbgprintf("BK2421 detected\n");
-//        long nul = 0;
-        // Beken registers don't have such nice names, so we just mention
-        // them by their numbers
-        // It's all magic, eavesdropped from real transfer and not even from the
-        // data sheet - it has slightly different values
-        // It initializes all values needed for the 2Mbps mode 
-        NRF24L01_WriteRegisterMulti(0x00, (u8 *) "\x40\x4B\x01\xE2", 4);
-        NRF24L01_WriteRegisterMulti(0x01, (u8 *) "\xC0\x4B\x00\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x02, (u8 *) "\xD0\xFC\x8C\x02", 4);
-        NRF24L01_WriteRegisterMulti(0x03, (u8 *) "\x99\x00\x39\x21", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xD9\x96\x82\x1B", 4);
-        NRF24L01_WriteRegisterMulti(0x05, (u8 *) "\x24\x06\x7F\xA6", 4);
-        NRF24L01_WriteRegisterMulti(0x08, (u8 *) "\x00\x00\x00\x00", 4);        
-        NRF24L01_WriteRegisterMulti(0x0C, (u8 *) "\x00\x12\x73\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x0D, (u8 *) "\x46\xB4\x80\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x0E, (u8 *) "\x41\x10\x04\x82\x20\x08\x08\xF2\x7D\xEF\xFF", 11);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xDF\x96\x82\x1B", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xD9\x96\x82\x1B", 4);
-    } else {
-        dbgprintf("nRF24L01 detected\n");
-    }
-    NRF24L01_Activate(0x53); // switch bank back
-
     tx_power_ = Model.tx_power;
     NRF24L01_SetPower(Model.tx_power);
     

--- a/src/protocol/esky_nrf24l01.c
+++ b/src/protocol/esky_nrf24l01.c
@@ -142,12 +142,6 @@ static void esky_init(u8 bind)
     NRF24L01_WriteReg(NRF24L01_15_RX_PW_P4, PAYLOADSIZE);
     NRF24L01_WriteReg(NRF24L01_16_RX_PW_P5, PAYLOADSIZE);
     NRF24L01_WriteReg(NRF24L01_17_FIFO_STATUS, 0x00);      // Just in case, no real bits to write here
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
-
-    // Implicit delay in callback
-    // delay(50);
 }
 
 static void esky_init2()

--- a/src/protocol/fq777_nrf24l01.c
+++ b/src/protocol/fq777_nrf24l01.c
@@ -272,9 +272,6 @@ static void init()
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);      // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x01);
     NRF24L01_Activate(0x73);
-    
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 u16 fq777_callback()

--- a/src/protocol/fy326_nrf24l01.c
+++ b/src/protocol/fy326_nrf24l01.c
@@ -220,9 +220,6 @@ static void fy326_init()
     NRF24L01_Activate(0x73);
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x3f);
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x07);
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 MODULE_CALLTYPE

--- a/src/protocol/gw008_nrf24l01.c
+++ b/src/protocol/gw008_nrf24l01.c
@@ -162,9 +162,6 @@ static void gw008_init()
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);      // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x01);    // Set feature bits on
     NRF24L01_Activate(0x73);
-    
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 static void initialize_txid()

--- a/src/protocol/h377_nrf24l01.c
+++ b/src/protocol/h377_nrf24l01.c
@@ -161,10 +161,6 @@ static void h377_init()
     NRF24L01_SetBitrate(0);                          // 1Mbps
     NRF24L01_SetPower(Model.tx_power);
     NRF24L01_WriteReg(NRF24L01_07_STATUS, 0x70);     // Clear data ready, data sent, and retransmit
-
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 // H377 channel sequence: AILE  ELEV  THRO  RUDD  GEAR  PITH, channel data value is from 0 to 1000

--- a/src/protocol/h8_3d_nrf24l01.c
+++ b/src/protocol/h8_3d_nrf24l01.c
@@ -384,9 +384,6 @@ static void h8_3d_init()
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);      // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x01);
     NRF24L01_Activate(0x73);
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 MODULE_CALLTYPE

--- a/src/protocol/hisky_nrf24l01.c
+++ b/src/protocol/hisky_nrf24l01.c
@@ -198,10 +198,6 @@ static void hisky_init()
         NRF24L01_SetBitrate(NRF24L01_BR_1M);   // 1Mbps
     NRF24L01_SetPower(Model.tx_power);
     NRF24L01_WriteReg(NRF24L01_07_STATUS, 0x70);     // Clear data ready, data sent, and retransmit
-
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 // HiSky channel sequence: AILE  ELEV  THRO  RUDD  GEAR  PITH, channel data value is from 0 to 1000

--- a/src/protocol/hm830_nrf24l01.c
+++ b/src/protocol/hm830_nrf24l01.c
@@ -163,9 +163,6 @@ static void HM830_init()
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD,   0x3F);
     //NRF24L01_ReadReg(NRF24L01_07_STATUS) ==> 0x07
 
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
-
     NRF24L01_FlushTx();
     //NRF24L01_ReadReg(NRF24L01_07_STATUS) ==> 0x0e
     NRF24L01_WriteReg(NRF24L01_07_STATUS, 0x0e);

--- a/src/protocol/hontai_nrf24l01.c
+++ b/src/protocol/hontai_nrf24l01.c
@@ -312,9 +312,6 @@ static void ht_init()
         NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x3f);       // match other stock settings even though AA disabled...
         NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x07);
     }
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 static void ht_init2()

--- a/src/protocol/iface_nrf24l01.h
+++ b/src/protocol/iface_nrf24l01.h
@@ -126,8 +126,6 @@ u8 NRF24L01_FlushTx();
 u8 NRF24L01_FlushRx();
 u8 NRF24L01_Activate(u8 code);
 
-void BK2421_init();
-
 // Bitrate 0 - 1Mbps, 1 - 2Mbps, 3 - 250K (for nRF24L01+)
 u8 NRF24L01_SetBitrate(u8 bitrate);
 

--- a/src/protocol/inav_nrf24l01.c
+++ b/src/protocol/inav_nrf24l01.c
@@ -557,9 +557,6 @@ static void init_nrf24l01(void)
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, BV(NRF24L01_1D_EN_ACK_PAY) | BV(NRF24L01_1D_EN_DPL));
 #endif
 
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
-
     NRF24L01_SetTxRxMode(TX_EN); // enter transmit mode, sets up NRF24L01_00_CONFIG register
 }
 

--- a/src/protocol/kn_nrf24l01.c
+++ b/src/protocol/kn_nrf24l01.c
@@ -353,10 +353,6 @@ static void kn_init(u8 tx_addr[], u8 hopping_ch[])
     // Enable: Dynamic Payload Length to enable PCF
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, BV(NRF2401_1D_EN_DPL));
 
-    
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
-
     tx_power_ = Model.tx_power;
     NRF24L01_SetPower(Model.tx_power);
     

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -346,9 +346,6 @@ static void mjxq_init()
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);       // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x00);
     NRF24L01_Activate(0x73);
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 static void mjxq_init2()

--- a/src/protocol/mt99xx_nrf24l01.c
+++ b/src/protocol/mt99xx_nrf24l01.c
@@ -311,9 +311,6 @@ static void mt99xx_init()
     NRF24L01_ReadReg(NRF24L01_1D_FEATURE);
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);       // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x00);     // Set feature bits on
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
     
     // Power on, TX mode, 2byte CRC    
     XN297_Configure(BV(NRF24L01_00_EN_CRC) | BV(NRF24L01_00_CRCO) | BV(NRF24L01_00_PWR_UP));

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -431,9 +431,6 @@ static void q303_init()
     NRF24L01_WriteReg(NRF24L01_1C_DYNPD, 0x00);       // Disable dynamic payload length on all pipes
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x01);     // Set feature bits on
     NRF24L01_Activate(0x73);
-    
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
 }
 
 MODULE_CALLTYPE

--- a/src/protocol/slt_nrf24l01.c
+++ b/src/protocol/slt_nrf24l01.c
@@ -152,13 +152,6 @@ static void SLT_init()
     else // V2, Q200
         NRF24L01_WriteRegisterMulti(NRF24L01_0A_RX_ADDR_P0, (u8*)"\x7E\xB8\x63\xA9", SLT_TXID_SIZE);
     NRF24L01_FlushRx();
-
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
-
-    // Implicit delay in callback
-    // delay(50);
 }
 
 

--- a/src/protocol/spi/nrf24l01.c
+++ b/src/protocol/spi/nrf24l01.c
@@ -273,34 +273,6 @@ int NRF24L01_Reset()
     return (status1 == status2 && (status1 & 0x0f) == 0x0e);
 }
 
-// Check for Beken BK2421/BK2423 chip
-// It is done by using Beken specific activate code, 0x53
-// and checking that status register changed appropriately
-// There is no harm to run it on nRF24L01 because following
-// closing activate command changes state back even if it
-// does something on nRF24L01
-void BK2421_init()
-{
-    NRF24L01_Activate(0x53); // magic for BK2421 bank switch
-    if (NRF24L01_ReadReg(NRF24L01_07_STATUS) & 0x80) {
-        // Beken registers don't have such nice names, so we just mention
-        // them by their numbers
-        // It's all magic, eavesdropped from real transfer and not even from the
-        // data sheet - it has slightly different values
-        NRF24L01_WriteRegisterMulti(0x00, (u8 *) "\x40\x4B\x01\xE2", 4);
-        NRF24L01_WriteRegisterMulti(0x01, (u8 *) "\xC0\x4B\x00\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x02, (u8 *) "\xD0\xFC\x8C\x02", 4);
-        NRF24L01_WriteRegisterMulti(0x03, (u8 *) "\x99\x00\x39\x21", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xD9\x96\x82\x1B", 4);
-        NRF24L01_WriteRegisterMulti(0x05, (u8 *) "\x24\x06\x7F\xA6", 4);
-        NRF24L01_WriteRegisterMulti(0x0C, (u8 *) "\x00\x12\x73\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x0D, (u8 *) "\x46\xB4\x80\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xDF\x96\x82\x1B", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xD9\x96\x82\x1B", 4);
-    }
-    NRF24L01_Activate(0x53); // switch bank back
-}
-
 //
 // XN297 emulation layer
 //////////////////////////

--- a/src/protocol/symax_nrf24l01.c
+++ b/src/protocol/symax_nrf24l01.c
@@ -357,9 +357,6 @@ static void symax_init()
 
     NRF24L01_ReadReg(NRF24L01_07_STATUS);
 
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
-
     NRF24L01_FlushTx();
     NRF24L01_ReadReg(NRF24L01_07_STATUS);
     NRF24L01_WriteReg(NRF24L01_07_STATUS, 0x0e);

--- a/src/protocol/testrf.c
+++ b/src/protocol/testrf.c
@@ -308,35 +308,6 @@ static void init_nrf()
     //NRF24L01_WriteRegisterMulti(NRF24L01_0A_RX_ADDR_P0, rx_tx_addr, 5);
     //NRF24L01_WriteRegisterMulti(NRF24L01_10_TX_ADDR, rx_tx_addr, 5);
 
-    // Check for Beken BK2421/BK2423 chip
-    // It is done by using Beken specific activate code, 0x53
-    // and checking that status register changed appropriately
-    // There is no harm to run it on nRF24L01 because following
-    // closing activate command changes state back even if it
-    // does something on nRF24L01
-    NRF24L01_Activate(0x53); // magic for BK2421 bank switch
-    //dbgprintf("Trying to switch banks\n");
-    if (NRF24L01_ReadReg(NRF24L01_07_STATUS) & 0x80) {
-        //dbgprintf("BK2421 detected\n");
-        // Beken registers don't have such nice names, so we just mention
-        // them by their numbers
-        // It's all magic, eavesdropped from real transfer and not even from the
-        // data sheet - it has slightly different values
-        NRF24L01_WriteRegisterMulti(0x00, (u8 *) "\x40\x4B\x01\xE2", 4);
-        NRF24L01_WriteRegisterMulti(0x01, (u8 *) "\xC0\x4B\x00\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x02, (u8 *) "\xD0\xFC\x8C\x02", 4);
-        NRF24L01_WriteRegisterMulti(0x03, (u8 *) "\x99\x00\x39\x21", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xD9\x96\x82\x1B", 4);
-        NRF24L01_WriteRegisterMulti(0x05, (u8 *) "\x24\x06\x7F\xA6", 4);
-        NRF24L01_WriteRegisterMulti(0x0C, (u8 *) "\x00\x12\x73\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x0D, (u8 *) "\x46\xB4\x80\x00", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xDF\x96\x82\x1B", 4);
-        NRF24L01_WriteRegisterMulti(0x04, (u8 *) "\xD9\x96\x82\x1B", 4);
-    } else {
-        //dbgprintf("nRF24L01 detected\n");
-    }
-    NRF24L01_Activate(0x53); // switch bank back
-
     NRF24L01_WriteReg(NRF24L01_05_RF_CH, Model.proto_opts[TESTRF_RFCHAN]);   // reset packet loss counter
     NRF24L01_SetPower(Model.proto_opts[TESTRF_POWER]);
     NRF24L01_SetTxRxMode(TX_EN);

--- a/src/protocol/v202_nrf24l01.c
+++ b/src/protocol/v202_nrf24l01.c
@@ -239,11 +239,6 @@ static void v202_init()
     NRF24L01_WriteRegisterMulti(NRF24L01_0A_RX_ADDR_P0, rx_tx_addr, 5);
     NRF24L01_WriteRegisterMulti(NRF24L01_0B_RX_ADDR_P1, rx_p1_addr, 5);
     NRF24L01_WriteRegisterMulti(NRF24L01_10_TX_ADDR, rx_tx_addr, 5);
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
-
-    // Implicit delay in callback
-    // delay(50);
 }
 
 static void V202_init2()

--- a/src/protocol/yd717_nrf24l01.c
+++ b/src/protocol/yd717_nrf24l01.c
@@ -340,12 +340,6 @@ static void yd717_init()
 
     NRF24L01_WriteRegisterMulti(NRF24L01_0A_RX_ADDR_P0, rx_tx_addr, 5);
     NRF24L01_WriteRegisterMulti(NRF24L01_10_TX_ADDR, rx_tx_addr, 5);
-
-    // Check for Beken BK2421/BK2423 chip
-    BK2421_init();
-
-    // Implicit delay in callback
-    // delay(50);
 }
 
 


### PR DESCRIPTION
Remove Beken BK2421/BK2423 support as a nrf24l01 alternative, only @hexfet used it and it's not required anymore.