### PR TITLE
Cleanup variable declaration

### DIFF
--- a/src/config/model.h
+++ b/src/config/model.h
@@ -17,10 +17,10 @@
 #endif
 
 /* INI file consts */
-const char *MODEL_NAME;
-const char *MODEL_ICON;
-const char *MODEL_TYPE;
-const char *MODEL_TEMPLATE;
+extern const char *MODEL_NAME;
+extern const char *MODEL_ICON;
+extern const char *MODEL_TYPE;
+extern const char *MODEL_TEMPLATE;
 #define UNKNOWN_ICON ("media/noicon" IMG_EXT)
 
 //This cannot be computed, and must be manually updated

--- a/src/extended_audio.c
+++ b/src/extended_audio.c
@@ -25,6 +25,13 @@
 #endif // EMULATOR
 
 #if HAS_EXTENDED_AUDIO
+u16 voice_map_entries;
+struct VoiceMap voice_map[MAX_VOICEMAP_ENTRIES];
+
+u16 audio_queue[AUDIO_QUEUE_LENGTH];
+u8 next_audio;
+u8 num_audio;
+u32 audio_queue_time;
 
 // Initialize UART for extended-audio
 void AUDIO_Init() {

--- a/src/extended_audio.h
+++ b/src/extended_audio.h
@@ -12,11 +12,10 @@ void AUDIO_CheckQueue();
 int AUDIO_AddQueue(u16 music);
 int AUDIO_VoiceAvailable();
 
-u16 audio_queue[AUDIO_QUEUE_LENGTH];
-u8 next_audio;
-u8 num_audio;
-u32 audio_queue_time;
-
+extern u16 audio_queue[AUDIO_QUEUE_LENGTH];
+extern u8 next_audio;
+extern u8 num_audio;
+extern u32 audio_queue_time;
 
 #endif
 #endif

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -50,7 +50,7 @@ extern volatile u8 ppmin_num_channels;
 
 volatile s32 Channels[NUM_OUT_CHANNELS];
 
-struct Transmitter Transmitter;
+extern struct Transmitter Transmitter;
 
 static volatile s32 raw[NUM_SOURCES + 1];
 static buttonAction_t button_action;

--- a/src/music.h
+++ b/src/music.h
@@ -106,7 +106,7 @@ struct  Voice {
 #endif
 };
 
-u16 voice_map_entries;
+extern u16 voice_map_entries;
 
 struct VoiceMap {
     u16 id;
@@ -116,7 +116,7 @@ struct VoiceMap {
 #endif
 };
 
-struct VoiceMap voice_map[MAX_VOICEMAP_ENTRIES];
+extern struct VoiceMap voice_map[MAX_VOICEMAP_ENTRIES];
 
 u16 MUSIC_GetTelemetryAlarm(enum Music music);
 u16 MUSIC_GetTimerAlarm(enum Music music);

--- a/src/pages/128x64x1/guiobj.h
+++ b/src/pages/128x64x1/guiobj.h
@@ -351,7 +351,7 @@ struct stdtravel_obj {
     guiScrollable_t scrollable;
 };
 
-struct gui_objs {
+struct _gui_objs {
     struct dialog_obj dialog;
     union {
         struct about_obj about;
@@ -400,6 +400,8 @@ struct gui_objs {
         struct stdchan_obj stdchan;
         struct toggleselect_obj toggleselect;
     } u;
-} gui_objs;
+};
+
+extern struct _gui_objs gui_objs;
 
 #endif //_GUIOBJ_H_

--- a/src/pages/128x64x1/pages.c
+++ b/src/pages/128x64x1/pages.c
@@ -18,6 +18,7 @@ static unsigned action_cb(u32 button, unsigned flags, void *data);
 
 #include "../common/_pages.c"
 
+struct _gui_objs gui_objs;
 static u8 quick_page_enabled;
 static u16 *current_selected;
 static guiScrollable_t *page_scrollable;

--- a/src/pages/320x240x16/guiobj.h
+++ b/src/pages/320x240x16/guiobj.h
@@ -593,7 +593,7 @@ struct stdtravel_obj {
     guiScrollbar_t scrollbar;
 };
 
-struct gui_objs {
+struct _gui_objs {
     struct page_obj page;
     struct dialog_obj dialog;
     union {
@@ -643,5 +643,7 @@ struct gui_objs {
         struct stdtravel_obj stdtravel;
         struct stdchan_obj stdchan;
     } u;
-} gui_objs;
+};
+
+extern struct _gui_objs gui_objs;
 #endif

--- a/src/pages/320x240x16/pages.c
+++ b/src/pages/320x240x16/pages.c
@@ -14,6 +14,7 @@
  */
 #include "pages.h"
 
+struct _gui_objs gui_objs;
 static struct page_obj * const gui = &gui_objs.page;
 
 static void (*enter_cmd)(guiObject_t *obj, const void *data);

--- a/src/pages/text/guiobj.h
+++ b/src/pages/text/guiobj.h
@@ -351,7 +351,7 @@ struct stdtravel_obj {
     guiScrollable_t scrollable;
 };
 
-struct gui_objs {
+struct _gui_objs {
     struct dialog_obj dialog;
     union {
         struct about_obj about;
@@ -400,6 +400,8 @@ struct gui_objs {
         struct stdchan_obj stdchan;
         struct toggleselect_obj toggleselect;
     } u;
-} gui_objs;
+};
+
+extern struct _gui_objs gui_objs;
 
 #endif //_GUIOBJ_H_

--- a/src/pages/text/pages.c
+++ b/src/pages/text/pages.c
@@ -3,3 +3,5 @@
 #include "pages.h"
 #include "gui/gui.h"
 #include "../128x64x1/pages.c"
+
+struct _gui_objs gui_objs;

--- a/src/protocol/assan_nrf24l01.c
+++ b/src/protocol/assan_nrf24l01.c
@@ -64,12 +64,12 @@ enum {
     DATA5
 };
 
-u8 hopping_frequency[2];
-u8 hopping_frequency_no;
-u8 packet[32];
-u8 tx_power;
-u8 state;
-u32 packet_count;
+static u8 hopping_frequency[2];
+static u8 hopping_frequency_no;
+static u8 packet[32];
+static u8 tx_power;
+static u8 state;
+static u32 packet_count;
 
 void init()
 {

--- a/src/protocol/dsm2_cyrf6936.c
+++ b/src/protocol/dsm2_cyrf6936.c
@@ -175,14 +175,14 @@ static const u8 ch_map12[] = {1, 5, 2, 4, 6, 10, 0xff,    0, 7, 3, 8, 9, 11, 0xf
 static const u8 ch_map14[] = {1, 5, 2, 3, 4,  6,    8,    1, 5, 2, 3, 0,  7,    9};
 #endif
 
-u8 packet[16];
-u8 channels[23];
-u8 chidx;
-u8 sop_col;
-u8 data_col;
-u16 state;
-u8 crcidx;
-u8 binding;
+static u8 packet[16];
+static u8 channels[23];
+static u8 chidx;
+static u8 sop_col;
+static u8 data_col;
+static u16 state;
+static u8 crcidx;
+static u8 binding;
 
 #ifdef USE_FIXED_MFGID
     //static const u8 cyrfmfg_id[6] = {0x5e, 0x28, 0xa3, 0x1b, 0x00, 0x00}; //dx8
@@ -191,9 +191,9 @@ u8 binding;
     static u8 cyrfmfg_id[6];
 #endif
 
-u8 num_channels;
-u16 crc;
-u8 model;
+static u8 num_channels;
+static u16 crc;
+static u8 model;
 
 static void build_bind_packet()
 {

--- a/src/protocol/dsm2_cyrf6936.c
+++ b/src/protocol/dsm2_cyrf6936.c
@@ -88,18 +88,18 @@ ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
 #endif
 
 enum {
-    DSM2_BIND = 0,
-    DSM2_CHANSEL     = BIND_COUNT + 0,
-    DSM2_CH1_WRITE_A = BIND_COUNT + 1,
-    DSM2_CH1_CHECK_A = BIND_COUNT + 2,
-    DSM2_CH2_WRITE_A = BIND_COUNT + 3,
-    DSM2_CH2_CHECK_A = BIND_COUNT + 4,
-    DSM2_CH2_READ_A  = BIND_COUNT + 5,
-    DSM2_CH1_WRITE_B = BIND_COUNT + 6,
-    DSM2_CH1_CHECK_B = BIND_COUNT + 7,
-    DSM2_CH2_WRITE_B = BIND_COUNT + 8,
-    DSM2_CH2_CHECK_B = BIND_COUNT + 9,
-    DSM2_CH2_READ_B  = BIND_COUNT + 10,
+    DSM2_CH1_WRITE_A = 1,
+    DSM2_CH1_CHECK_A = 2,
+    DSM2_CH2_WRITE_A = 3,
+    DSM2_CH2_CHECK_A = 4,
+    DSM2_CH2_READ_A  = 5,
+    DSM2_CH1_WRITE_B = 6,
+    DSM2_CH1_CHECK_B = 7,
+    DSM2_CH2_WRITE_B = 8,
+    DSM2_CH2_CHECK_B = 9,
+    DSM2_CH2_READ_B  = 10,
+    DSM2_BIND        = 11,
+    DSM2_CHANSEL     = BIND_COUNT + 11,
 };
    
 static const u8 pncodes[5][9][8] = {
@@ -667,7 +667,7 @@ static u16 dsm2_cb()
 #define WRITE_DELAY   1550  // Time after write to verify write complete
 #define READ_DELAY     600  // Time before write to check read state, and switch channels.
                             // Telemetry read+processing =~200us and switch channels =~300us
-    if(state < DSM2_CHANSEL) {
+    if(state >= DSM2_BIND && state < DSM2_CHANSEL) {
         //Binding
         state += 1;
         if(state & 1) {
@@ -680,7 +680,7 @@ static u16 dsm2_cb()
             CYRF_ReadRegister(CYRF_04_TX_IRQ_STATUS);
             return 1500;
         }
-    } else if(state < DSM2_CH1_WRITE_A) {
+    } else if(state == DSM2_CHANSEL) {
         //Select channels and configure for writing data
         //CYRF_FindBestChannels(ch, 2, 10, 1, 79);
         cyrf_transfer_config();

--- a/src/protocol/ppmout.c
+++ b/src/protocol/ppmout.c
@@ -31,7 +31,7 @@
 #endif
 #define PPMOUT_MAX_CHANNELS NUM_OUT_CHANNELS
 static volatile u16 pulses[PPMOUT_MAX_CHANNELS+2];
-u8 num_channels;
+static u8 num_channels;
 
 #define STEP_SIZE "3276810"  // == 10small/50large == (50 << 16) | 10
 #define STEPSIZE2 "32768100" // == 100small / 500large == (500 << 16) | 100

--- a/src/protocol/usbhid.c
+++ b/src/protocol/usbhid.c
@@ -39,7 +39,7 @@
 #endif
 //if sizeof(packet) changes, must change wMaxPacketSize to match in Joystick_ConfigDescriptor
 static s8 packet[USBHID_ANALOG_CHANNELS + 1];
-u8 num_channels;
+static u8 num_channels;
 volatile u8 PrevXferComplete;
 extern void HID_Write(s8 *packet, u8 num_channels);
 

--- a/src/target/common/devo/Makefile.inc
+++ b/src/target/common/devo/Makefile.inc
@@ -44,7 +44,7 @@ endif
 MODULE_FLAGS = -fno-builtin
 
 #LFLAGS   = -nostartfiles -Wl,-gc-sections -Wl,-Map=$(TARGET).map,--cref -nostdlib
-LFLAGS   = -nostartfiles -Wl,-gc-sections -Wl,-Map=$(TARGET).map,--cref -lc -lnosys -L$(SDIR) -Lobjs/$(TARGET)
+LFLAGS   = -nostartfiles -Wl,-gc-sections -Wl,-Map=$(TARGET).map,--cref -lc -lnosys -L$(SDIR) -Lobjs/$(TARGET) -Wl,-warn-common
 LFLAGS2  = -Wl,-T$(LINKFILE)
 LFLAGS2OPT  = -Wl,-T$(SDIR)/target/$(TARGET)/$(TARGET)_opt.ld
 

--- a/src/target/common/devo/hid/hid_usb_istr.c
+++ b/src/target/common/devo/hid/hid_usb_istr.c
@@ -22,6 +22,7 @@
 #include "hid_usb_prop.h"
 #include "hid_usb_istr.h"
 #include "usb_pwr.h"
+#include "usb_regs.h"
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/

--- a/src/target/common/devo/hid/hid_usb_istr.c
+++ b/src/target/common/devo/hid/hid_usb_istr.c
@@ -27,7 +27,7 @@
 /* Private define ------------------------------------------------------------*/
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-__IO uint16_t wIstr;  /* ISTR register last read value */
+extern __IO uint16_t wIstr;  /* ISTR register last read value */
 
 /* Extern variables ----------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/

--- a/src/target/common/devo/proto_stubs.c
+++ b/src/target/common/devo/proto_stubs.c
@@ -32,7 +32,8 @@ extern void MCU_SerialNumber();
 extern void PROTO_CS_HI();
 extern void PROTO_CS_LO();
 extern void MUSIC_Beep();
-extern void rand32();
+extern void rand32(const void *);
+extern const void *TAERG;
 
 void PROTO_Stubs(int idx)
 {
@@ -52,5 +53,5 @@ void PROTO_Stubs(int idx)
     PROTO_CS_HI();
     PROTO_CS_LO();
     MUSIC_Beep();
-    rand32();
+    rand32(TAERG);
 }

--- a/src/target/common/devo/proto_stubs.c
+++ b/src/target/common/devo/proto_stubs.c
@@ -32,8 +32,7 @@ extern void MCU_SerialNumber();
 extern void PROTO_CS_HI();
 extern void PROTO_CS_LO();
 extern void MUSIC_Beep();
-extern void rand32(const void *);
-extern const void *TAERG;
+extern void rand32();
 
 void PROTO_Stubs(int idx)
 {
@@ -53,5 +52,5 @@ void PROTO_Stubs(int idx)
     PROTO_CS_HI();
     PROTO_CS_LO();
     MUSIC_Beep();
-    rand32(TAERG);
+    rand32();
 }

--- a/src/target/common/devo/spi_proto.c
+++ b/src/target/common/devo/spi_proto.c
@@ -167,7 +167,9 @@ void SPI_ProtoInit()
             gpio_set(port->port, port->pin);
         }
     }
+#ifdef ENABLE_MODULAR
     PROTO_Stubs(0);
+#endif
 }
 
 void SPI_AVRProgramInit()


### PR DESCRIPTION
Make sure we only declare variables in header files. Move allocation to .c file. Also declare the local variables with "static".