### PR TITLE
Fix fltk build after migrate to latest osx

### DIFF
--- a/src/target/common/emu/Makefile.inc
+++ b/src/target/common/emu/Makefile.inc
@@ -37,7 +37,8 @@ ifdef WINDOWS
     EXEEXT = exe
     ODIREXT = -w32
 else
-    LFLAGS := $(LFLAGS) `fltk-config --cxxflags --ldflags`
+    CFLAGS := $(CFLAGS) `fltk-config --cflags`
+    LFLAGS := $(LFLAGS) `fltk-config --ldflags`
     ifndef SOUND
         CFLAGS += -DNO_SOUND
     else


### PR DESCRIPTION
Latest OSX mojava has the build failure. Fix it via passing the correct CFLAGS and LDFLAGS.