### PR TITLE
New Format of localization File

### DIFF
--- a/src/pages/common/_lang_select.c
+++ b/src/pages/common/_lang_select.c
@@ -50,10 +50,7 @@ static const char *string_cb(guiObject_t *obj, const void *data)
                     && (u8)tempstring[1] == 0xbb
                     && (u8)tempstring[2] == 0xbf)
                 {
-                    //Remove BOM
-                    for(u32 i = 3; i < len; i++)
-                        tempstring[i-3] = tempstring[i];
-                    len -= 3;
+                    return tempstring + 3;
                 }
                 return tempstring;
             }

--- a/utils/extract_strings.pl
+++ b/utils/extract_strings.pl
@@ -11,7 +11,7 @@ my $target_list;
 my $objdir;
 my $count;
 # The following are legal alternatives to the default string
-my @targets = ("devo8", "devo10", "devof12e");
+my @targets = ("devo8", "devo10", "devo12");
 
 sub fnv_16 {
     my ($input, $init_value) = @_;


### PR DESCRIPTION
This change introduced a new file format for lang.* under language folder. The file is formatted in the way:
Line 1: <BOM>LanguageName
Line2-N: <16bit FNV Hash of english string>Localized String

The change increases the performance switching the language as we don't only read half of the content and don't need calculate hash as the hash is compute during build.
The change significantly reduces the size of localized file. After this change, I can successfully pack all localization files into 64KB SPI flash on F12E.