### PR TITLE
Change the default font size on AT9 to 15p

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -322,6 +322,14 @@ filesystem/$(FILESYSTEM)/media/15normal.fon: fonts/15normal.bdf
 	mkdir -p filesystem/$(FILESYSTEM)/media/
 	../utils/font/bdf_to_font.pl -maxsize 15 -mode bin $< -out $@ -minspace 8
 
+filesystem/$(FILESYSTEM)/media/12ascii.fon: fonts/12normal.bdf
+	mkdir -p filesystem/$(FILESYSTEM)/media/
+	../utils/font/bdf_to_font.pl -maxsize 12 -mode bin $< -out $@ -minspace 10 -ascii
+
+filesystem/$(FILESYSTEM)/media/15ascii.fon: fonts/15normal.bdf
+	mkdir -p filesystem/$(FILESYSTEM)/media/
+	../utils/font/bdf_to_font.pl -maxsize 15 -mode bin $< -out $@ -minspace 8 -ascii
+
 filesystem/$(FILESYSTEM)/media/23bold.fon: fonts/23bold.bdf
 	mkdir -p filesystem/$(FILESYSTEM)/media/
 	../utils/font/bdf_to_font.pl -maxsize 23 -mode bin $< -out $@ -minspace 8

--- a/src/fs/320x240x1/media/config.ini
+++ b/src/fs/320x240x1/media/config.ini
@@ -1,32 +1,32 @@
 ; avaliable fonts:
-; 5x7, 10normal, 10narrow, 10normal, 14bold, 18bold, 23bold, 48normal
+; 5x7, 10normal, 10narrow, 15normal, 14bold, 18bold, 23bold, 48normal
 ;colors are specified as RGB888: ff0000 is red, 00ff00 is green, 0000ff is blue
 [general]
 ;  bat_icon=1
    header_time=1
 
 [font-default]
-  font=10normal
+  font=15normal
   font_color=000000
 
 [font-label]
-  font=10normal
+  font=15normal
   font_color=000000
   align=left
 
 [font-list]
-  font=10normal
+  font=15normal
   font_color=000000
   align=left
 
 [font-section]
-  font=10normal
+  font=15normal
   font_color=000000
   box_type=underline
   align=left
 
 [font-narrow]
-  font=10normal
+  font=15normal
   font_color=000000
   align=center
 
@@ -84,7 +84,7 @@
   transparent=1
 
 [font-title]
-  font=10normal
+  font=15normal
   font_color=FFFFFF
   align=left
 
@@ -123,52 +123,52 @@
 
 [font-battery]
 ;Battery
-  font=10normal
+  font=15normal
   font_color=B5FF00
 
 [font-batt_alarm]
 ;Battery
-  font=10normal
+  font=15normal
   font_color=FF0000
 
 [font-dialogtitle]
-  font=10normal
+  font=15normal
   font_color=FFFFFF
   bg_color=000000
 
 [font-dialogbody]
-  font=10normal
+  font=15normal
   font_color=000000
   bg_color=E6E6E6
   outline_color=000000
 
 [font-normalbox]
-  font=10normal
+  font=15normal
   font_color=000000
   bg_color=FFFFFF
   box_type=fill
   
 [font-normalboxneg]
-  font=10normal
+  font=15normal
   font_color=FFFFFF
   bg_color=FF0000
   box_type=fill
 
 [font-textsel]
-  font=10normal
+  font=15normal
   font_color=000000
 
 [font-button]
-  font=10normal
+  font=15normal
   font_color=000000
 
 [font-listbox]
-  font=10normal
+  font=15normal
   font_color=000000
   box_type=listbox
   align=left
 
 [font-menu]
-  font=10normal
+  font=15normal
   font_color=000000
   align=left

--- a/src/target/at9/Makefile.inc
+++ b/src/target/at9/Makefile.inc
@@ -3,14 +3,13 @@ HAS_FLASH_DETECT ?= $(HAS_4IN1_FLASH)
 
 ifeq "$(HAS_4IN1_FLASH)" "1"
 FILESYSTEMS := common base_fonts 320x240x16
-SCREENSIZE  := 320x240x16
-FONTS        = filesystem/$(FILESYSTEM)/media/15normal.fon \
-               filesystem/$(FILESYSTEM)/media/23bold.fon
 else
 FILESYSTEMS := common base_fonts 320x240x1
-SCREENSIZE  := 320x240x16
-FONTS        = filesystem/$(FILESYSTEM)/media/23bold.fon
 endif
+
+SCREENSIZE  := 320x240x16
+FONTS        = filesystem/$(FILESYSTEM)/media/15ascii.fon \
+               filesystem/$(FILESYSTEM)/media/23bold.fon
 
 DFU_ARGS    := -D 0x0483:0xdf12 -b 0x08003000
 
@@ -81,6 +80,7 @@ $(TARGET)-fs.dfu: $(ODIR)/devo.fs
 	$(SDIR)/../utils/dfu.py --name "$(HGVERSION) Filesystem" -D 0x0483:0xdf12 -b 0x08040000:$< $@
 
 $(TARGET).fs_wrapper: $(LAST_MODEL)
+	perl -p -i -e 's/=15normal/=15ascii/' filesystem/$(FILESYSTEM)/media/config.ini
 	rm filesystem/$(FILESYSTEM)/datalog.bin
 
 $(TARGET).zip: $(ALL)

--- a/src/target/emu_at9/Makefile.inc
+++ b/src/target/emu_at9/Makefile.inc
@@ -1,7 +1,14 @@
 SCREENSIZE  := 320x240x16
 FILESYSTEMS := common base_fonts 320x240x1
-FONTS        = filesystem/$(FILESYSTEM)/media/23bold.fon
+FONTS        = filesystem/$(FILESYSTEM)/media/15ascii.fon \
+				filesystem/$(FILESYSTEM)/media/23bold.fon
 
 NUM_MODELS ?= 10
 
 include target/common/emu/Makefile.inc
+
+ifdef BUILD_TARGET
+$(TARGET).fs_wrapper: $(LAST_MODEL)
+	perl -p -i -e 's/=15normal/=15ascii/' filesystem/$(FILESYSTEM)/media/config.ini
+	rm filesystem/$(FILESYSTEM)/datalog.bin
+endif

--- a/utils/font/bdf_to_font.pl
+++ b/utils/font/bdf_to_font.pl
@@ -10,6 +10,7 @@ my $ascent = 0;
 my $descent = 0;
 my $maxsize = 0;
 my $minspace = 0;
+my $ascii = '';
 main();
 sub main {
     my $out = "bdf_font";
@@ -18,8 +19,20 @@ sub main {
                "debug=i" => \$debug,
                "mode=s" => \$mode,
                "minspace=i" => \$minspace, 
-               "maxsize=i" => \$maxsize);
+               "maxsize=i" => \$maxsize,
+               "ascii!" =>\$ascii);
     my $char = read_bdf(shift @ARGV);
+
+    if ($ascii){
+        my %newchar;
+        foreach my $c (%$char) {
+            if ($c < 255) {
+                my $v = $char->{$c};
+                $newchar{$c} = $v;
+            }
+        }
+        $char = \%newchar;
+    }
 
     $out =~ s/\.fon$//;
     if($mode =~ /analyze/) {


### PR DESCRIPTION
Based on the change of generate ascii font file, we can pack 15normal.fon into the 64KB SPI flash on AT9. So switch it to 15p as default which is much more readable.