### PR TITLE
Fix issue with exiting USB mode in t8sg V2 transmitters. 

### DIFF
--- a/src/target/common/devo/power.c
+++ b/src/target/common/devo/power.c
@@ -64,16 +64,16 @@ void PWR_Shutdown()
 int PWR_CheckPowerSwitch()
 {
 #if defined(HAS_BUTTON_POWER_ON) && HAS_BUTTON_POWER_ON
-    static u16 debounce = 0;
+    static u32 debounce = 0;
 #endif
 
     if(gpio_get(_PWRSW_PORT, _PWRSW_PIN)) {
 #if defined(HAS_BUTTON_POWER_ON) && HAS_BUTTON_POWER_ON
-        debounce++;
+        if (debounce == 0) debounce = CLOCK_getms();
     } else {
         debounce = 0;
     }
-    if(debounce >= 200) { // 200 * 5 msec = 1 sec
+    if(debounce && (CLOCK_getms() - debounce) >= 1000) { // 1 sec
 #endif
         return 1;
     }


### PR DESCRIPTION
After powering up in USB mode, the next press of the power button would cause immediate reset on T8SG V2 transmitters.  The CheckPowerSwitch function assumed it was being called every 5ms from the event loop.  That's not true after powering up in USB mode.  Changed the function to be independent of call rate.