### PR TITLE
Fix regression on channel mapping

### DIFF
--- a/src/config/model.c
+++ b/src/config/model.c
@@ -22,7 +22,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-extern const u8 EATRG[PROTO_MAP_LEN];
+extern const u8 EATRG0[PROTO_MAP_LEN];
 
 struct Model Model;
 /*set this to write all model data even if it is the same as the default */
@@ -1457,7 +1457,7 @@ u8 CONFIG_ReadModel(u8 model_num) {
         Model.tx_power = TXPOWER_150mW;
     MIXER_SetMixers(NULL, 0);
     if(auto_map)
-        RemapChannelsForProtocol(EATRG);
+        RemapChannelsForProtocol(EATRG0);
     TIMER_Init();
     MIXER_RegisterTrimButtons();
     crc32 = Crc(&Model, sizeof(Model));
@@ -1569,7 +1569,7 @@ u8 CONFIG_ReadTemplate(const char *filename) {
         return 0;
     }
     if(auto_map)
-        RemapChannelsForProtocol(EATRG);
+        RemapChannelsForProtocol(EATRG0);
     MIXER_RegisterTrimButtons();
     STDMIXER_Preset(); // bug fix: this must be invoked in all modes
     if (Model.mixer_mode == MIXER_STANDARD)

--- a/src/mixer_standard.c
+++ b/src/mixer_standard.c
@@ -28,7 +28,7 @@
 #include "mixer_standard.h"
 
 MappedSimpleChannels mapped_std_channels;
-extern const u8 EATRG[PROTO_MAP_LEN];
+extern const u8 EATRG0[PROTO_MAP_LEN];
 
 void STDMIXER_Preset()
 {
@@ -48,7 +48,7 @@ void STDMIXER_Preset()
     const u8 *ch_map = CurrentProtocolChannelMap;
     if (! ch_map) {
         // for none protocol, assign any channel to thr is fine
-        ch_map = EATRG;
+        ch_map = EATRG0;
     }
     for (unsigned ch = 0; ch < 3; ch++) {  // only the first 3 channels need to check
         if (ch_map[ch] == INP_THROTTLE) {
@@ -67,7 +67,7 @@ void STDMIXER_SetChannelOrderByProtocol()
     const u8 *ch_map = CurrentProtocolChannelMap;
     if (! ch_map) {
         // for none protocol, assign any channel to thr is fine
-        ch_map = EATRG;
+        ch_map = EATRG0;
     }
     CLOCK_ResetWatchdog();// this function might be invoked after loading from template/model file, so feeding the dog in the middle
     unsigned safetysw = 0;

--- a/src/protocol/interface.h
+++ b/src/protocol/interface.h
@@ -31,10 +31,10 @@ enum PinConfigState {
     RESET_PIN,
 };
 
-const u8 EATRG[PROTO_MAP_LEN];
-const u8 TAERG[PROTO_MAP_LEN];
-#define UNCHG ((void*)1)
 #define AETRG ((void*)0)
+#define UNCHG ((void*)1)
+#define EATRG ((void*)2)
+#define TAERG ((void*)3)
 
 #ifndef MODULAR
 #define PROTODEF(proto, module, map, cmd, name) extern const void * cmd(enum ProtoCmds);

--- a/src/protocol/protocol.c
+++ b/src/protocol/protocol.c
@@ -33,9 +33,9 @@
 extern struct FAT FontFAT; //defined in screen/lcd_string.c
 
 //Not static because we need it in mixer.c
-const u8 EATRG[PROTO_MAP_LEN] =
+const u8 EATRG0[PROTO_MAP_LEN] =
     { INP_ELEVATOR, INP_AILERON, INP_THROTTLE, INP_RUDDER, INP_GEAR1 };
-const u8 TAERG[PROTO_MAP_LEN] =
+static const u8 TAERG0[PROTO_MAP_LEN] =
     { INP_THROTTLE, INP_AILERON, INP_ELEVATOR, INP_RUDDER, INP_GEAR1 };
 static const u8 AETRG0[PROTO_MAP_LEN] =
     { INP_AILERON, INP_ELEVATOR, INP_THROTTLE, INP_RUDDER, INP_GEAR1 };
@@ -352,14 +352,23 @@ const u8* PROTOCOL_GetChannelMap()
     const u8* channelmap = NULL;
     if(Model.protocol != PROTOCOL_NONE && PROTOCOL_LOADED)
     {
-        channelmap = PROTO_Cmds(PROTOCMD_CHANNELMAP);
-        if (channelmap == AETRG)
+        int map = (int)PROTO_Cmds(PROTOCMD_CHANNELMAP);
+        switch(map)
         {
-            channelmap = AETRG0;
-        }
-        else if (channelmap == UNCHG)
-        {
-            channelmap = NULL;
+            case (int)AETRG:
+                channelmap = AETRG0;
+                break;
+            case (int)UNCHG:
+                channelmap = NULL;
+                break;
+            case (int)TAERG:
+                channelmap = TAERG0;
+                break;
+            case (int)EATRG:
+                channelmap = EATRG0;
+                break;
+            default:
+                printf("Unknown channemap: %d\n", channelmap);
         }
     }
     return channelmap;


### PR DESCRIPTION
Channel mapping doesn't work expected in some protocol modules due to the variables are not initialized proper in the modular. Use a number instead of pointer to return from modular and convert it to the real pointer in main firmware.