### PR TITLE
Generate a mini fon file

### DIFF
--- a/src/target/devo7e/Makefile.inc
+++ b/src/target/devo7e/Makefile.inc
@@ -1,6 +1,6 @@
 SCREENSIZE  := 128x64x1
 FILESYSTEMS := common base_fonts 128x64x1
-FONTS        = filesystem/$(FILESYSTEM)/media/12normal.fon \
+FONTS        = filesystem/$(FILESYSTEM)/media/12ascii.fon \
                filesystem/$(FILESYSTEM)/media/04b03.fon
 
 CRC_OFFSET       := 8192
@@ -13,5 +13,5 @@ include $(SDIR)/target/common/devo/Makefile.inc
 ifdef BUILD_TARGET
 $(TARGET).fs_wrapper: $(LAST_MODEL)
 	perl -p -i -e 's/; has_pa-cyrf6936 = 1/  has_pa-cyrf6936 = 0/' filesystem/$(FILESYSTEM)/hardware.ini
-
+	perl -p -i -e 's/=12normal/=12ascii/' filesystem/$(FILESYSTEM)/media/config.ini
 endif

--- a/src/target/devof12e/Makefile.inc
+++ b/src/target/devof12e/Makefile.inc
@@ -5,6 +5,7 @@ DFU_ARGS         := -c 12 -b 0x08004000
 
 DEFAULT_PROTOCOLS := 
 INCLUDE_FS := 0
+LANGUAGE := devof12e
 
 include $(SDIR)/target/common/devo/Makefile.inc
 include target/common/devo/Makefile.devofs.inc

--- a/src/target/emu_devo7e/Makefile.inc
+++ b/src/target/emu_devo7e/Makefile.inc
@@ -1,6 +1,6 @@
 SCREENSIZE  := 128x64x1
 FILESYSTEMS := common base_fonts 128x64x1
-FONTS        = filesystem/$(FILESYSTEM)/media/12normal.fon \
+FONTS        = filesystem/$(FILESYSTEM)/media/12ascii.fon \
                filesystem/$(FILESYSTEM)/media/04b03.fon
 
 
@@ -9,4 +9,5 @@ include target/common/emu/Makefile.inc
 ifdef BUILD_TARGET
 $(TARGET).fs_wrapper: $(LAST_MODEL)
 	perl -p -i -e 's/; has_pa-cyrf6936 = 1/  has_pa-cyrf6936 = 0/' filesystem/$(FILESYSTEM)/hardware.ini
+	perl -p -i -e 's/=12normal/=12ascii/' filesystem/$(FILESYSTEM)/media/config.ini
 endif

--- a/utils/extract_strings.pl
+++ b/utils/extract_strings.pl
@@ -11,7 +11,7 @@ my $target_list;
 my $objdir;
 my $count;
 # The following are legal alternatives to the default string
-my @targets = ("devo8", "devo10", "devo12");
+my @targets = ("devo8", "devo10", "devo12", "devof12e");
 
 sub fnv_16 {
     my ($input, $init_value) = @_;

--- a/utils/font/bdf_to_font.pl
+++ b/utils/font/bdf_to_font.pl
@@ -68,7 +68,8 @@ sub main {
 
 sub read_filter {
     my($filter_file)= @_;
-
+    my @str;
+    my %chars;
     my @files = glob("$filter_file/lang.*");
     foreach my $file (@files) {
         open(my $fh, '<:raw', $file)
@@ -103,7 +104,7 @@ sub read_filter {
                         my $a = ord($c);
                         if (($a > 256) and ($a != 65279))
                         {
-                            $char{$a} = $c;
+                            %chars{$a} = $c;
                         }
                     }
                 }
@@ -117,7 +118,7 @@ sub read_filter {
         }
     }
 
-    return \%char;
+    return \%chars;
 }
 
 sub read_bdf {


### PR DESCRIPTION
A mini font file only contains the font data for the characters which exist in localization files. Also support the filter out all ascii characters (<255), which F12E supports via its Font ROM.

The change is not ready to check-in. it depends on #511 #512.