### PR TITLE
Make some USB structure as const to save some RAM

### DIFF
--- a/src/target/common/devo/hid/hid_devo.c
+++ b/src/target/common/devo/hid/hid_devo.c
@@ -28,8 +28,8 @@ extern void (*pEpInt_IN[7])(void);
 extern void (*pEpInt_OUT[7])(void);
 extern void (* const HID_pEpInt_IN[7])(void);
 extern void (* const HID_pEpInt_OUT[7])(void);
-extern DEVICE_PROP HID_Device_Property;
-extern USER_STANDARD_REQUESTS HID_User_Standard_Requests;
+extern const DEVICE_PROP HID_Device_Property;
+extern const USER_STANDARD_REQUESTS HID_User_Standard_Requests;
 extern void USB_Enable(u8 type, u8 use_interrupt);
 extern void USB_Disable();
 

--- a/src/target/common/devo/msc2/lib/usb_core.c
+++ b/src/target/common/devo/msc2/lib/usb_core.c
@@ -255,7 +255,7 @@ RESULT Standard_ClearFeature(void)
   }
   else if (Type_Rec == (STANDARD_REQUEST | ENDPOINT_RECIPIENT))
   {/*EndPoint Clear Feature*/
-    DEVICE* pDev;
+    const DEVICE* pDev;
     uint32_t Related_Endpoint;
     uint32_t wIndex0;
     uint32_t rEP;

--- a/src/target/common/devo/msc2/lib/usb_core.h
+++ b/src/target/common/devo/msc2/lib/usb_core.h
@@ -233,9 +233,9 @@ RESULT Standard_ClearFeature(void);
 void SetDeviceAddress(uint8_t);
 void NOP_Process(void);
 
-extern DEVICE_PROP *Device_Property;
-extern  USER_STANDARD_REQUESTS *User_Standard_Requests;
-extern  DEVICE  Device_Table;
+extern const DEVICE_PROP *Device_Property;
+extern const USER_STANDARD_REQUESTS *User_Standard_Requests;
+extern const DEVICE  Device_Table;
 extern DEVICE_INFO Device_Info;
 
 /* cells saving status during interrupt servicing */

--- a/src/target/common/devo/msc2/lib/usb_init.c
+++ b/src/target/common/devo/msc2/lib/usb_init.c
@@ -29,7 +29,7 @@
 DEVICE_INFO *pInformation;
 /*  Points to the DEVICE_PROP structure of current device */
 /*  The purpose of this register is to speed up the execution */
-DEVICE_PROP *pProperty;
+const DEVICE_PROP *pProperty;
 /*  Temporary save the state of Rx & Tx status. */
 /*  Whenever the Rx or Tx state is changed, its value is saved */
 /*  in this variable first and will be set to the EPRB or EPRA */
@@ -37,7 +37,7 @@ DEVICE_PROP *pProperty;
 uint16_t	SaveState ;
 uint16_t  wInterrupt_Mask;
 DEVICE_INFO	Device_Info;
-USER_STANDARD_REQUESTS  *pUser_Standard_Requests;
+const USER_STANDARD_REQUESTS  *pUser_Standard_Requests;
 
 /* Extern variables ----------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/

--- a/src/target/common/devo/msc2/lib/usb_init.h
+++ b/src/target/common/devo/msc2/lib/usb_init.h
@@ -34,12 +34,12 @@ extern uint8_t	EPindex;
 extern DEVICE_INFO*	pInformation;
 /*  Points to the DEVICE_PROP structure of current device */
 /*  The purpose of this register is to speed up the execution */
-extern DEVICE_PROP*	pProperty;
+extern const DEVICE_PROP*	pProperty;
 /*  Temporary save the state of Rx & Tx status. */
 /*  Whenever the Rx or Tx state is changed, its value is saved */
 /*  in this variable first and will be set to the EPRB or EPRA */
 /*  at the end of interrupt process */
-extern USER_STANDARD_REQUESTS *pUser_Standard_Requests;
+extern const USER_STANDARD_REQUESTS *pUser_Standard_Requests;
 
 extern uint16_t	SaveState ;
 extern uint16_t wInterrupt_Mask;

--- a/src/target/common/devo/msc2/usb_devo8.c
+++ b/src/target/common/devo/msc2/usb_devo8.c
@@ -41,18 +41,18 @@ void usb_lp_can_rx0_isr()
 }
 void (*pEpInt_IN[7])(void) = {};
 void (*pEpInt_OUT[7])(void) = {};
-DEVICE_PROP *Device_Property;
-USER_STANDARD_REQUESTS *User_Standard_Requests;
+const DEVICE_PROP *Device_Property;
+const USER_STANDARD_REQUESTS *User_Standard_Requests;
 
 extern void (*MSC_pEpInt_IN[7])(void);
 extern void (*MSC_pEpInt_OUT[7])(void);
-extern DEVICE_PROP MSC_Device_Property;
-extern USER_STANDARD_REQUESTS MSC_User_Standard_Requests;
+extern const DEVICE_PROP MSC_Device_Property;
+extern const USER_STANDARD_REQUESTS MSC_User_Standard_Requests;
 
 extern void (*HID_pEpInt_IN[7])(void);
 extern void (*HID_pEpInt_OUT[7])(void);
-extern DEVICE_PROP HID_Device_Property;
-extern USER_STANDARD_REQUESTS HID_User_Standard_Requests;
+extern const DEVICE_PROP HID_Device_Property;
+extern const USER_STANDARD_REQUESTS HID_User_Standard_Requests;
 
 void MSC_Init() {
     memcpy(pEpInt_IN, MSC_pEpInt_IN, sizeof(pEpInt_IN));

--- a/src/target/common/devo/msc2/usb_prop.c
+++ b/src/target/common/devo/msc2/usb_prop.c
@@ -29,13 +29,13 @@
 /* Private variables ---------------------------------------------------------*/
  uint32_t Max_Lun = 0;
 
-DEVICE Device_Table =
+const DEVICE Device_Table =
   {
     EP_NUM,
     1
   };
 
-DEVICE_PROP MSC_Device_Property =
+const DEVICE_PROP MSC_Device_Property =
   {
     MASS_init,
     MASS_Reset,
@@ -51,7 +51,7 @@ DEVICE_PROP MSC_Device_Property =
     0x40 /*MAX PACKET SIZE*/
   };
 
-USER_STANDARD_REQUESTS MSC_User_Standard_Requests =
+const USER_STANDARD_REQUESTS MSC_User_Standard_Requests =
   {
     Mass_Storage_GetConfiguration,
     Mass_Storage_SetConfiguration,
@@ -64,19 +64,19 @@ USER_STANDARD_REQUESTS MSC_User_Standard_Requests =
     Mass_Storage_SetDeviceAddress
   };
 
-ONE_DESCRIPTOR MSC_Device_Descriptor =
+const ONE_DESCRIPTOR MSC_Device_Descriptor =
   {
     (uint8_t*)MASS_DeviceDescriptor,
     MASS_SIZ_DEVICE_DESC
   };
 
-ONE_DESCRIPTOR MSC_Config_Descriptor =
+const ONE_DESCRIPTOR MSC_Config_Descriptor =
   {
     (uint8_t*)MASS_ConfigDescriptor,
     MASS_SIZ_CONFIG_DESC
   };
 
-ONE_DESCRIPTOR MSC_String_Descriptor[5] =
+const ONE_DESCRIPTOR MSC_String_Descriptor[5] =
   {
     {(uint8_t*)MASS_StringLangID, MASS_SIZ_STRING_LANGID},
     {(uint8_t*)MASS_StringVendor, MASS_SIZ_STRING_VENDOR},


### PR DESCRIPTION
Some versions of compiler can detect this but some cannot. Don't rely on compiler to do this instead of make it explicit on which structure is const. Also change the type to make sure no warnings.