### PR TITLE
remove PAGE_RemoveAllObjects in Page Init function

### DIFF
--- a/src/pages/128x64x1/about_page.c
+++ b/src/pages/128x64x1/about_page.c
@@ -33,7 +33,6 @@ static struct about_obj * const gui = &gui_objs.u.about;
 void PAGE_AboutInit(int page)
 {
     (void)page;
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(PAGE_GetName(PAGEID_ABOUT));
 
     tempstring_cpy((const char *) _tr("Deviation FW version:"));

--- a/src/pages/128x64x1/chantest_page.c
+++ b/src/pages/128x64x1/chantest_page.c
@@ -108,7 +108,6 @@ void PAGE_ChantestInit(int page)
 {
     (void)page;
     PAGE_SetActionCB(_action_cb);
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(cp->type == MONITOR_RAWINPUT ? _tr("Stick input") : _tr("Mixer output"));
     if (cp->type != MONITOR_RAWINPUT )
         cp->type = MONITOR_MIXEROUTPUT;// cp->type may not be initialized yet, so do it here

--- a/src/pages/128x64x1/debuglog_page.c
+++ b/src/pages/128x64x1/debuglog_page.c
@@ -32,9 +32,8 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 void PAGE_DebuglogInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(PAGE_GetName(PAGEID_DEBUGLOG));
+    PAGE_SetModal(0);
 
     find_line_ends();
     GUI_CreateScrollable(&gui->scrollable,

--- a/src/pages/128x64x1/debuglog_page.c
+++ b/src/pages/128x64x1/debuglog_page.c
@@ -33,7 +33,6 @@ void PAGE_DebuglogInit(int page)
 {
     (void)page;
     PAGE_ShowHeader(PAGE_GetName(PAGEID_DEBUGLOG));
-    PAGE_SetModal(0);
 
     find_line_ends();
     GUI_CreateScrollable(&gui->scrollable,

--- a/src/pages/128x64x1/main_config.c
+++ b/src/pages/128x64x1/main_config.c
@@ -60,7 +60,7 @@ void PAGE_MainLayoutInit(int page)
     PAGE_ShowHeader(_tr("Layout: Long-Press ENT"));
     PAGE_SetActionCB(_action_cb);
 #else
-    PAGE_ShowHeader(_tr(PAGE_GetName(PAGEID_MAINCFG)));
+    PAGE_ShowHeader(PAGE_GetName(PAGEID_MAINCFG));
 #endif
     memset(gui, 0, sizeof(*gui));
     memset(lp, 0, sizeof(*lp));

--- a/src/pages/128x64x1/main_page.c
+++ b/src/pages/128x64x1/main_page.c
@@ -68,7 +68,6 @@ void PAGE_MainInit(int page)
     memset(gui, 0, sizeof(struct mainpage_obj));
     PAGE_SetModal(0);
     PAGE_SetActionCB(_action_cb);
-    PAGE_RemoveAllObjects();
     next_scan = CLOCK_getms()+BATTERY_SCAN_MSEC;
 
     GUI_CreateLabelBox(&gui->name, MODEL_NAME_X, MODEL_NAME_Y, //64, 12,

--- a/src/pages/128x64x1/main_page.c
+++ b/src/pages/128x64x1/main_page.c
@@ -66,7 +66,6 @@ void PAGE_MainInit(int page)
     TGLICO_LoadFonts();
     memset(mp, 0, sizeof(struct main_page));// Bug fix: must initialize this structure to avoid unpredictable issues in the PAGE_MainEvent
     memset(gui, 0, sizeof(struct mainpage_obj));
-    PAGE_SetModal(0);
     PAGE_SetActionCB(_action_cb);
     next_scan = CLOCK_getms()+BATTERY_SCAN_MSEC;
 

--- a/src/pages/128x64x1/model_page.c
+++ b/src/pages/128x64x1/model_page.c
@@ -149,7 +149,6 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 void PAGE_ModelInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     memset(gui, 0, sizeof(struct modelpage_obj));
     mp->file_state = 0;
     mp->last_txpower = Model.tx_power;

--- a/src/pages/128x64x1/model_page.c
+++ b/src/pages/128x64x1/model_page.c
@@ -150,7 +150,6 @@ void PAGE_ModelInit(int page)
 {
     (void)page;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     memset(gui, 0, sizeof(struct modelpage_obj));
     mp->file_state = 0;
     mp->last_txpower = Model.tx_power;

--- a/src/pages/128x64x1/pages.c
+++ b/src/pages/128x64x1/pages.c
@@ -60,6 +60,7 @@ void PAGE_ChangeByID(enum PageID id, s8 menuPage)
     else if (pages[cur_page].init == PAGE_MenuInit)
         quick_page_enabled = 0;
     PAGE_RemoveAllObjects();
+    PAGE_SetModal(0);
     ActionCB = default_button_action_cb;
     pages[cur_page].init(menuPage);
     if (page_scrollable) {

--- a/src/pages/128x64x1/range_page.c
+++ b/src/pages/128x64x1/range_page.c
@@ -40,7 +40,6 @@ static unsigned action_cb(u32 button, unsigned flags, void *data) {
 }
 
 static void _draw_page(int has_pa) {
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(PAGE_GetName(PAGEID_RANGE));
 
     if (!has_pa) {

--- a/src/pages/128x64x1/splash_page.c
+++ b/src/pages/128x64x1/splash_page.c
@@ -30,7 +30,6 @@ void PAGE_SplashInit(int page)
         PAGE_ChangeByID(PAGEID_MAIN, 0);
         return;
     }
-    PAGE_RemoveAllObjects();
     PAGE_SetActionCB(_action_cb);
     u16 w, h;
     LCD_ImageDimensions(SPLASH_FILE, &w, &h);

--- a/src/pages/128x64x1/standard/common_standard.c
+++ b/src/pages/128x64x1/standard/common_standard.c
@@ -58,7 +58,6 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 
 void STANDARD_Init(const struct page_defs *page_defs)
 {
-    PAGE_SetModal(0);
     PAGE_RemoveAllObjects();
     PAGE_ShowHeader(_tr(page_defs->title));
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,

--- a/src/pages/128x64x1/standard/curves_page.c
+++ b/src/pages/128x64x1/standard/curves_page.c
@@ -89,7 +89,6 @@ static void show_page(CurvesMode _curve_mode, int page)
 {
     (void)page;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     memset(mp, 0, sizeof(*mp));
     curve_mode = _curve_mode;
     int count;

--- a/src/pages/128x64x1/standard/curves_page.c
+++ b/src/pages/128x64x1/standard/curves_page.c
@@ -88,7 +88,6 @@ static void press_cb(guiObject_t *obj, void *data)
 static void show_page(CurvesMode _curve_mode, int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     memset(mp, 0, sizeof(*mp));
     curve_mode = _curve_mode;
     int count;

--- a/src/pages/128x64x1/standard/drexp_page.c
+++ b/src/pages/128x64x1/standard/drexp_page.c
@@ -75,7 +75,6 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 void PAGE_DrExpInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     // draw a underline only:
     GUI_CreateRect(&gui->rect, 0, HEADER_WIDGET_HEIGHT, LCD_WIDTH, 1, &DEFAULT_FONT);
     memset(mp, 0, sizeof(*mp));

--- a/src/pages/128x64x1/standard/drexp_page.c
+++ b/src/pages/128x64x1/standard/drexp_page.c
@@ -76,7 +76,6 @@ void PAGE_DrExpInit(int page)
 {
     (void)page;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     // draw a underline only:
     GUI_CreateRect(&gui->rect, 0, HEADER_WIDGET_HEIGHT, LCD_WIDTH, 1, &DEFAULT_FONT);
     memset(mp, 0, sizeof(*mp));

--- a/src/pages/128x64x1/standard/gyrosense_page.c
+++ b/src/pages/128x64x1/standard/gyrosense_page.c
@@ -39,7 +39,6 @@ enum {
 void PAGE_GyroSenseInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     memset(mp, 0, sizeof(*mp));
     int expected = INPUT_NumSwitchPos(mapped_std_channels.switches[SWITCHFUNC_GYROSENSE]);
     int count = STDMIX_GetMixers(mp->mixer_ptr, mapped_std_channels.aux2, GYROMIXER_COUNT);

--- a/src/pages/128x64x1/standard/gyrosense_page.c
+++ b/src/pages/128x64x1/standard/gyrosense_page.c
@@ -40,7 +40,6 @@ void PAGE_GyroSenseInit(int page)
 {
     (void)page;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     memset(mp, 0, sizeof(*mp));
     int expected = INPUT_NumSwitchPos(mapped_std_channels.switches[SWITCHFUNC_GYROSENSE]);
     int count = STDMIX_GetMixers(mp->mixer_ptr, mapped_std_channels.aux2, GYROMIXER_COUNT);

--- a/src/pages/128x64x1/standard/swash_page.c
+++ b/src/pages/128x64x1/standard/swash_page.c
@@ -37,7 +37,6 @@ enum {
 void PAGE_SwashInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     get_swash();
     PAGE_ShowHeaderWithSize(_tr("SwashType"), LABEL_WIDTH, HEADER_HEIGHT);
     GUI_CreateTextSelectPlate(&gui->type, FIELD_X, 0, FIELD_WIDTH, HEADER_WIDGET_HEIGHT, &TEXTSEL_FONT, NULL, swash_val_cb, NULL); // FIXME: need a special value for header button/textsels

--- a/src/pages/128x64x1/standard/swash_page.c
+++ b/src/pages/128x64x1/standard/swash_page.c
@@ -38,7 +38,6 @@ void PAGE_SwashInit(int page)
 {
     (void)page;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     get_swash();
     PAGE_ShowHeaderWithSize(_tr("SwashType"), LABEL_WIDTH, HEADER_HEIGHT);
     GUI_CreateTextSelectPlate(&gui->type, FIELD_X, 0, FIELD_WIDTH, HEADER_WIDGET_HEIGHT, &TEXTSEL_FONT, NULL, swash_val_cb, NULL); // FIXME: need a special value for header button/textsels

--- a/src/pages/128x64x1/standard/switchassign_page.c
+++ b/src/pages/128x64x1/standard/switchassign_page.c
@@ -75,7 +75,6 @@ void PAGE_SwitchAssignInit(int page)
     (void)page;
     PAGE_SetActionCB(_action_cb);
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     refresh_switches();
 
     PAGE_ShowHeader(_tr("Press ENT to change"));

--- a/src/pages/128x64x1/standard/switchassign_page.c
+++ b/src/pages/128x64x1/standard/switchassign_page.c
@@ -74,7 +74,6 @@ void PAGE_SwitchAssignInit(int page)
 {
     (void)page;
     PAGE_SetActionCB(_action_cb);
-    PAGE_SetModal(0);
     refresh_switches();
 
     PAGE_ShowHeader(_tr("Press ENT to change"));

--- a/src/pages/128x64x1/standard/throhold_page.c
+++ b/src/pages/128x64x1/standard/throhold_page.c
@@ -36,7 +36,6 @@ void PAGE_ThroHoldInit(int page)
 {
     (void)page;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
 
     PAGE_ShowHeader(_tr("Throttle hold"));
 

--- a/src/pages/128x64x1/standard/throhold_page.c
+++ b/src/pages/128x64x1/standard/throhold_page.c
@@ -35,8 +35,6 @@ enum {
 void PAGE_ThroHoldInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
-
     PAGE_ShowHeader(_tr("Throttle hold"));
 
     u8 y = HEADER_HEIGHT + HEADER_OFFSET;

--- a/src/pages/128x64x1/standard/traveladj_page.c
+++ b/src/pages/128x64x1/standard/traveladj_page.c
@@ -57,8 +57,6 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 void PAGE_TravelAdjInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
-
     PAGE_ShowHeader(("")); // draw a underline only
     GUI_CreateLabelBox(&gui->dnlbl, HEADER1_X, 0, HEADER1_WIDTH, LINE_HEIGHT, &TITLE_FONT, NULL, NULL, _tr("Down"));
     GUI_CreateLabelBox(&gui->uplbl, HEADER2_X, 0, HEADER2_WIDTH, LINE_HEIGHT, &TITLE_FONT, NULL, NULL, _tr("Up"));

--- a/src/pages/128x64x1/standard/traveladj_page.c
+++ b/src/pages/128x64x1/standard/traveladj_page.c
@@ -58,7 +58,6 @@ void PAGE_TravelAdjInit(int page)
 {
     (void)page;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
 
     PAGE_ShowHeader(("")); // draw a underline only
     GUI_CreateLabelBox(&gui->dnlbl, HEADER1_X, 0, HEADER1_WIDTH, LINE_HEIGHT, &TITLE_FONT, NULL, NULL, _tr("Down"));

--- a/src/pages/128x64x1/telemconfig_page.c
+++ b/src/pages/128x64x1/telemconfig_page.c
@@ -74,7 +74,6 @@ void PAGE_TelemconfigInit(int page)
     (void)page;
     //if (page < 0)
     //    page = current_selected;
-    PAGE_SetModal(0);
     if (telem_state_check() == 0) {
         GUI_CreateLabelBox(&gui->msg, MSG_X, MSG_Y, 0, 0, &DEFAULT_FONT, NULL, NULL, tempstring);
         OBJ_SET_USED(&gui->value, 0);  // A indication not allow to scroll up/down

--- a/src/pages/128x64x1/telemconfig_page.c
+++ b/src/pages/128x64x1/telemconfig_page.c
@@ -75,7 +75,6 @@ void PAGE_TelemconfigInit(int page)
     //if (page < 0)
     //    page = current_selected;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     if (telem_state_check() == 0) {
         GUI_CreateLabelBox(&gui->msg, MSG_X, MSG_Y, 0, 0, &DEFAULT_FONT, NULL, NULL, tempstring);
         OBJ_SET_USED(&gui->value, 0);  // A indication not allow to scroll up/down

--- a/src/pages/128x64x1/telemtest_page.c
+++ b/src/pages/128x64x1/telemtest_page.c
@@ -409,7 +409,6 @@ static const struct telem_layout2 *_get_telem_layout2()
 static void _show_page()
 {
     const struct telem_layout2 *page = _get_telem_layout2();
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(page->header == dsm_header_basic ? _tr("Telemetry monitor") : "");
     tp->font = TINY_FONT;
     tp->font.style = LABEL_SQUAREBOX;

--- a/src/pages/128x64x1/telemtest_page.c
+++ b/src/pages/128x64x1/telemtest_page.c
@@ -442,7 +442,6 @@ void PAGE_ShowTelemetryAlarm()
 void PAGE_TelemtestInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     PAGE_SetActionCB(_action_cb);
     if (telem_state_check() == 0) {
         current_page = telemetry_off;

--- a/src/pages/128x64x1/timer_page.c
+++ b/src/pages/128x64x1/timer_page.c
@@ -99,7 +99,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 static void _show_page(int page)
 {
     (void)page;
-    PAGE_ShowHeader(_tr(PAGE_GetName(PAGEID_TIMER))); // using the same name as related menu item to reduce language strings
+    PAGE_ShowHeader(PAGE_GetName(PAGEID_TIMER)); // using the same name as related menu item to reduce language strings
 
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,
                      LCD_HEIGHT - HEADER_HEIGHT, NUM_TIMERS, row_cb, NULL, NULL, NULL);

--- a/src/pages/128x64x1/tx_configure.c
+++ b/src/pages/128x64x1/tx_configure.c
@@ -212,7 +212,6 @@ void PAGE_TxConfigureInit(int page)
 {
     (void)page;
     cp->enable = CALIB_NONE;
-    PAGE_SetModal(0);
     PAGE_ShowHeader(_tr("Configure"));
 
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,

--- a/src/pages/128x64x1/tx_configure.c
+++ b/src/pages/128x64x1/tx_configure.c
@@ -213,7 +213,6 @@ void PAGE_TxConfigureInit(int page)
     (void)page;
     cp->enable = CALIB_NONE;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(_tr("Configure"));
 
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,

--- a/src/pages/128x64x1/usb_page.c
+++ b/src/pages/128x64x1/usb_page.c
@@ -32,7 +32,6 @@ static struct usb_obj * const gui = &gui_objs.u.usb;
 
 static void _draw_page(u8 enable)
 {
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(_tr("USB"));
 
     snprintf(tempstring, sizeof(tempstring), "%s %s",

--- a/src/pages/128x64x1/voiceconfig_page.c
+++ b/src/pages/128x64x1/voiceconfig_page.c
@@ -55,7 +55,6 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 void PAGE_VoiceconfigInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     if ( !AUDIO_VoiceAvailable() ) {
         GUI_CreateLabelBox(&gui->msg, MSG_X, MSG_Y, 0, 0, &LABEL_FONT, NULL, NULL,
             _tr("External voice\ncurrently not\navailable"));

--- a/src/pages/128x64x1/voiceconfig_page.c
+++ b/src/pages/128x64x1/voiceconfig_page.c
@@ -61,7 +61,6 @@ void PAGE_VoiceconfigInit(int page)
             _tr("External voice\ncurrently not\navailable"));
         return;
     }
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(PAGE_GetName(PAGEID_VOICECFG));
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,
                      LINE_SPACE * 2, MODEL_CUSTOM_ALARMS, row_cb, NULL, NULL, NULL);

--- a/src/pages/320x240x16/lang_select.c
+++ b/src/pages/320x240x16/lang_select.c
@@ -40,7 +40,7 @@ void PAGE_LanguageInit(int page)
 {
     (void)page;
     int num_lang = count_num_languages();
-    PAGE_ShowHeader(_tr(PAGE_GetName(PAGEID_LANGUAGE)));
+    PAGE_ShowHeader(PAGE_GetName(PAGEID_LANGUAGE));
 
     int min_rows = num_lang >= LISTBOX_ITEMS ? num_lang : LISTBOX_ITEMS;
     GUI_CreateScrollable(&gui->scrollable, LCD_WIDTH/2-100, 40, 200, LISTBOX_ITEMS * LINE_HEIGHT, LINE_HEIGHT, min_rows, row_cb, NULL, NULL, (void *)(long)num_lang);

--- a/src/pages/320x240x16/main_page.c
+++ b/src/pages/320x240x16/main_page.c
@@ -50,7 +50,6 @@ void PAGE_MainInit(int page)
     (void)page;
     memset(mp, 0, sizeof(struct main_page));
     memset(gui, 0, sizeof(*gui));
-    PAGE_SetModal(0);
     BUTTON_RegisterCallback(&mp->action,
           CHAN_ButtonMask(BUT_ENTER)
           | CHAN_ButtonMask(BUT_EXIT)

--- a/src/pages/320x240x16/model_page.c
+++ b/src/pages/320x240x16/model_page.c
@@ -49,7 +49,6 @@ void PAGE_ModelInit(int page)
     mp->last_mixermode = Model.mixer_mode;
     mp->last_txpower = Model.tx_power;
     mp->file_state = 0;
-    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_MODEL));
 
     enum {

--- a/src/pages/320x240x16/pages.c
+++ b/src/pages/320x240x16/pages.c
@@ -66,6 +66,7 @@ void PAGE_ChangeByID(enum PageID id, s8 menuPage)
     if (HAS_TOUCH) {
         GUI_ChangeSelectionOnTouch(1);
     }
+    PAGE_SetModal(0);
     ActionCB = default_button_action_cb;
     pages[cur_page].init(menuPage);
     if (page_scrollable) {

--- a/src/pages/320x240x16/range_page.c
+++ b/src/pages/320x240x16/range_page.c
@@ -35,7 +35,6 @@ static const char *startstop_dlg(struct guiObject *gui, const void *data) {
 #define INFO_Y 70
 
 static void _draw_page(int has_pa) {
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(PAGE_GetName(PAGEID_RANGE));
     if (!has_pa) {
         snprintf(tempstring, sizeof(tempstring), _tr("No range test possible."));

--- a/src/pages/320x240x16/rtc_config.c
+++ b/src/pages/320x240x16/rtc_config.c
@@ -60,7 +60,6 @@ struct Rtc {
 void PAGE_RTCInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_RTC));
     u32 time = RTC_GetValue();
     u32 timevalue = RTC_GetTimeValue(time);

--- a/src/pages/320x240x16/splash_page.c
+++ b/src/pages/320x240x16/splash_page.c
@@ -29,7 +29,6 @@ void PAGE_SplashInit(int page)
         PAGE_ChangeByID(PAGEID_MAIN, 0);
         return;
     }
-    PAGE_RemoveAllObjects();
     PAGE_SetActionCB(_action_cb);
     u16 w, h;
     LCD_ImageDimensions(SPLASH_FILE, &w, &h);

--- a/src/pages/320x240x16/telemconfig_page.c
+++ b/src/pages/320x240x16/telemconfig_page.c
@@ -35,7 +35,6 @@ void PAGE_TelemconfigInit(int page)
         LABEL_WIDTH = (COL2 - COL1),
     };
     const u8 row_height = 25;
-    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_TELEMCFG));
 
     if (telem_state_check() == 0) {

--- a/src/pages/320x240x16/telemtest_page.c
+++ b/src/pages/320x240x16/telemtest_page.c
@@ -172,7 +172,6 @@ void PAGE_ShowTelemetryAlarm()
 void PAGE_TelemtestInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_TELEMMON));
     if (telem_state_check() == 0) {
         GUI_CreateLabelBox(&gui->msg, 20, 80, 280, 100, &NARROW_FONT, NULL, NULL, tempstring);

--- a/src/pages/320x240x16/tx_configure.c
+++ b/src/pages/320x240x16/tx_configure.c
@@ -239,7 +239,6 @@ void PAGE_TxConfigureInit(int page)
     (void)page;
     cp->enable = CALIB_NONE;
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(PAGE_GetName(PAGEID_TXCFG));
     GUI_CreateScrollable(&gui->scrollable, 0, 32, LCD_WIDTH, LCD_HEIGHT-32,
                      LCD_HEIGHT-32, MAX_PAGE+1, row_cb, NULL, NULL, NULL);
@@ -328,7 +327,7 @@ void PAGE_TouchEvent(void)
             printf("Debug: scale(%d, %d) offset(%d, %d)\n", (int)xscale, (int)yscale, (int)xoff, (int)yoff);
             SPITouch_Calibrate(xscale, yscale, xoff, yoff);
             PAGE_RemoveAllObjects();
-            PAGE_ShowHeader(_tr(PAGE_GetName(PAGEID_TOUCH)));
+            PAGE_ShowHeader(PAGE_GetName(PAGEID_TOUCH));
             GUI_CreateLabelBox(&guic->msg, (LCD_WIDTH - 150) / 2, (LCD_HEIGHT - 25) / 2, 150, 25, &SMALLBOX_FONT, coords_cb, NULL, NULL);
             memset(&cp->coords, 0, sizeof(cp->coords));
             cp->state = 6;

--- a/src/pages/320x240x16/tx_configure.c
+++ b/src/pages/320x240x16/tx_configure.c
@@ -238,7 +238,6 @@ void PAGE_TxConfigureInit(int page)
 {
     (void)page;
     cp->enable = CALIB_NONE;
-    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_TXCFG));
     GUI_CreateScrollable(&gui->scrollable, 0, 32, LCD_WIDTH, LCD_HEIGHT-32,
                      LCD_HEIGHT-32, MAX_PAGE+1, row_cb, NULL, NULL, NULL);

--- a/src/pages/320x240x16/usb_page.c
+++ b/src/pages/320x240x16/usb_page.c
@@ -27,7 +27,6 @@ const char *show_usb_date_cb(guiObject_t *obj, const void *data);
 
 static void _draw_page(u8 enable)
 {
-    PAGE_RemoveAllObjects();
     PAGE_ShowHeader(PAGE_GetName(PAGEID_USB));
 #if HAS_RTC
     GUI_CreateLabelBox(&gui->time, (LCD_WIDTH - (113 + 113 +20)) / 2, 40, 113, 28, &SMALLBOX_FONT, show_usb_time_cb, NULL, NULL);

--- a/src/pages/320x240x16/voiceconfig_page.c
+++ b/src/pages/320x240x16/voiceconfig_page.c
@@ -45,7 +45,6 @@ void PAGE_VoiceconfigInit(int page)
 {
     (void)page;
     int init_y = 40;
-    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_VOICECFG));
 
     if ( !AUDIO_VoiceAvailable() ) {

--- a/src/pages/common/_menus.c
+++ b/src/pages/common/_menus.c
@@ -45,7 +45,6 @@ static int menu_get_next_rowidx(unsigned *i)
 
 void _menu_init(int page)
 {
-    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(page));
 
     unsigned idx = 0;

--- a/src/pages/common/_menus.c
+++ b/src/pages/common/_menus.c
@@ -46,8 +46,7 @@ static int menu_get_next_rowidx(unsigned *i)
 void _menu_init(int page)
 {
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
-    PAGE_ShowHeader(_tr(PAGE_GetName(page)));
+    PAGE_ShowHeader(PAGE_GetName(page));
 
     unsigned idx = 0;
     unsigned i = 0;

--- a/src/pages/common/_range_page.c
+++ b/src/pages/common/_range_page.c
@@ -32,7 +32,6 @@ void RANGE_test(int start) {
 
 void PAGE_RangeInit(int page) {
     (void)page;
-    PAGE_SetModal(0);
     memset(mp, 0, sizeof(&mp));
     mp->old_power = Model.tx_power;
     _draw_page(PROTOCOL_HasPowerAmp(Model.protocol) 

--- a/src/pages/common/_scanner_page.c
+++ b/src/pages/common/_scanner_page.c
@@ -118,7 +118,6 @@ void PAGE_ScannerInit(int page)
     (void)page;
     memset(sp, 0, sizeof(struct scanner_page));
 
-    PAGE_SetModal(0);
     _draw_page(1);
 }
 

--- a/src/pages/common/_timer_page.c
+++ b/src/pages/common/_timer_page.c
@@ -33,7 +33,6 @@ static void _show_page(int page);
 void PAGE_TimerInit(int page)
 {
     PAGE_SetModal(0);
-    PAGE_RemoveAllObjects();
     _show_page(page);
 }
 

--- a/src/pages/common/_trim_page.c
+++ b/src/pages/common/_trim_page.c
@@ -147,7 +147,6 @@ static void okcancel_cb(guiObject_t *obj, const void *data)
 void PAGE_TrimInit(int page)
 {
     (void)page;
-    PAGE_RemoveAllObjects();
 
     _show_page();
 }

--- a/src/pages/common/_usb_page.c
+++ b/src/pages/common/_usb_page.c
@@ -42,7 +42,6 @@ unsigned usb_cb(u32 button, unsigned flags, void *data)
 void PAGE_USBInit(int page)
 {
     (void)page;
-    PAGE_SetModal(0);
     _draw_page(0);
     BUTTON_RegisterCallback(&up->action, CHAN_ButtonMask(BUT_ENTER), BUTTON_PRESS | BUTTON_RELEASE | BUTTON_PRIORITY, usb_cb, NULL);
 }

--- a/src/pages/text/external_osd.c
+++ b/src/pages/text/external_osd.c
@@ -20,5 +20,4 @@
 void PAGE_ExternalOSDInit(int page)
 {
     (void)page;
-    PAGE_RemoveAllObjects();
 }

--- a/src/pages/text/splash_page.c
+++ b/src/pages/text/splash_page.c
@@ -32,7 +32,6 @@ void PAGE_SplashInit(int page)
         PAGE_ChangeByID(PAGEID_MAIN, 0);
         return;
     }
-    PAGE_RemoveAllObjects();
     PAGE_SetActionCB(_action_cb);
 
     GUI_CreateLabelBox(&gui->splash_text, 3*ITEM_SPACE, 4*LINE_HEIGHT, 0, 0, &MODELNAME_FONT, NULL, NULL, _tr("Deviation"));


### PR DESCRIPTION
It is not needed as it is called already by PAGE_ChangeByID before calling Init function.
Also remove _tr call to the result of PAGE_GetName, which is already localized.