### PR TITLE
Convert mixer beep_lock and voice_lock variables to flags.

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -355,12 +355,12 @@ void MIXER_ApplyMixer(struct Mixer *mixer, volatile s32 *raw, s32 *orig_value)
         if (orig_value) {
             s32 new_value = raw[mixer->dest + NUM_INPUTS + 1];
             if (abs(value - new_value) > 100)
-                mixer->beep_lock = 0;
-            if (mixer->beep_lock == 0) {
+                MIXER_SET_BEEP_LOCK(mixer, 0);
+            if (! MIXER_BEEP_LOCK(mixer)) {
                 if ((value > *orig_value && value < new_value) ||
                     (value < *orig_value && value > new_value) ||
                     (abs(value - new_value) <= 10)) {
-                    mixer->beep_lock = 1;
+                    MIXER_SET_BEEP_LOCK(mixer, 1);
                     MUSIC_Play(MUSIC_MAXLEN);
                 }
             }
@@ -371,12 +371,12 @@ void MIXER_ApplyMixer(struct Mixer *mixer, volatile s32 *raw, s32 *orig_value)
         if (orig_value) {
             s32 new_value = raw[mixer->dest + NUM_INPUTS + 1];
             if (abs(value - new_value) > 100)
-                mixer->voice_lock = 0;
-            if (mixer->voice_lock == 0) {
+                MIXER_SET_VOICE_LOCK(mixer, 0);
+            if (! MIXER_VOICE_LOCK(mixer)) {
                 if ((value > *orig_value && value < new_value) ||
                     (value < *orig_value && value > new_value) ||
                     (abs(value - new_value) <= 10)) {
-                    mixer->voice_lock = 1;
+                    MIXER_SET_VOICE_LOCK(mixer, 1);
                     if (Model.voice.mixer[mixer->dest].music)
                         MUSIC_Play(Model.voice.mixer[mixer->dest].music);
                 }

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -25,8 +25,13 @@
 
 #define MIXER_MUX(x)        (((x)->flags) & 0x0F)
 #define MIXER_APPLY_TRIM(x) (((x)->flags) & 0x10)
+#define MIXER_BEEP_LOCK(x)  (((x)->flags) & 0x20)
+#define MIXER_VOICE_LOCK(x)  (((x)->flags) & 0x40)
 #define MIXER_SET_APPLY_TRIM(x,y) ((x)->flags = ((x)->flags & ~0x10) | ((y) ? 0x10 : 0))
 #define MIXER_SET_MUX(x,y)        ((x)->flags = ((x)->flags & ~0x0F) | (y))
+#define MIXER_SET_BEEP_LOCK(x,y) ((x)->flags = ((x)->flags & ~0x20) | ((y) ? 0x20 : 0))
+#define MIXER_SET_VOICE_LOCK(x,y) ((x)->flags = ((x)->flags & ~0x40) | ((y) ? 0x40 : 0))
+
 
 enum {
     TRIM_ONOFF     = 191,
@@ -135,8 +140,6 @@ struct Mixer {
     s8 scalar;
     s8 offset;
     u8 flags;
-    u8 beep_lock;
-    u8 voice_lock;
     //apply_trim;
     //enum MuxType mux;
 };


### PR DESCRIPTION
This patch saves 248bytes of RAM, 124 bytes of rom.

I am not currently setup to actually test this so I'd appreciate it if someone could double check it.