### PR TITLE
Fix trim calculation

### DIFF
--- a/src/mixer.h
+++ b/src/mixer.h
@@ -34,6 +34,7 @@
 
 
 enum {
+    TRIM_MAX_VALUE = 190,
     TRIM_ONOFF     = 191,
     TRIM_TOGGLE    = 192,
     TRIM_MOMENTARY = 193,

--- a/src/pages/common/_trim_page.c
+++ b/src/pages/common/_trim_page.c
@@ -89,9 +89,9 @@ static const char *set_trimstep_cb(guiObject_t *obj, int dir, void *data)
     int i = ((long)data)& 0xff;
     u8 *value = ((long)data >> 8) ? &tp->trim.step : &Model.trims[i].step;
     //place switches before 0.1 on the spinbox
-    u8 v = ((int)*value + TRIM_SWITCH_TYPES - 1) % (190 + TRIM_SWITCH_TYPES);
-    v = GUI_TextSelectHelper(v, 0, 190 + TRIM_SWITCH_TYPES - 1, dir, 1, 5, NULL);
-    *value = ((int)v + 190) % (190 + TRIM_SWITCH_TYPES) + 1;
+    u8 v = ((int)*value + TRIM_SWITCH_TYPES - 1) % (TRIM_MAX_VALUE + TRIM_SWITCH_TYPES);
+    v = GUI_TextSelectHelper(v, 0, TRIM_MAX_VALUE + TRIM_SWITCH_TYPES - 1, dir, 1, 5, NULL);
+    *value = ((int)v + TRIM_MAX_VALUE) % (TRIM_MAX_VALUE + TRIM_SWITCH_TYPES) + 1;
 
     guiObject_t *negtrimObj = _get_obj(i, TRIM_MINUS);
     guiObject_t *switchObj  = _get_obj(i, TRIM_SWITCH);


### PR DESCRIPTION
The trim code is basically broken for many cases.
It is supposed to work as follows:
```
trim step moves in 0.1% increments from 0% to 10%
trim step moves in 1% increments from 10% to 100%
trim value has a maximum range of -100% to 100% and is independent of the step.  It should move 1% for a short-press of the trim button and 10% for a long-press of the trim button
the channel value should be adjusted based on trim-step * trim-value
```
The current code does not calculate the channel-adjustment properly with trim-step > 1% and does not consistently update the step-size with trim-step > 1%

This patch affects how trims are calculated and so could theoretically break models, but the trims were basically unusable in the range that the patch fixes anyway.
