### PR TITLE
Enable optimized link for all devo targets

### DIFF
--- a/src/target/at9/at9.ld
+++ b/src/target/at9/at9.ld
@@ -3,7 +3,7 @@ MEMORY
 	rom (rx) : ORIGIN = 0x08003000, LENGTH = 500K  /* 12K is allocated to the bootloader, so only 500K is available */
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
 }
-_crc_offset = 0x1000; /* This is unneccessary but saves duplicating the ld file */
+_crc_offset = 0x150; /* This is unneccessary but saves duplicating the ld file */
 /*
  * INCLUDE ../target/common/devo/devo.ld
  */

--- a/src/target/common/devo/Makefile.inc
+++ b/src/target/common/devo/Makefile.inc
@@ -7,7 +7,6 @@ ifndef BUILD_TARGET
 CROSS    = arm-none-eabi-
 EXTRA_MAKEFILES := $(EXTRA_MAKEFILES) $(SDIR)/target/common/devo/Makefile.inc
 
-LINKFILE = $(SDIR)/target/$(TARGET)/$(TARGET).ld
 PROTO_LINKFILE = $(SDIR)/target/$(TARGET)/protocol.ld
 
 LIBOPENCM3 = $(SDIR)/libopencm3/lib/libopencm3_stm32f1.a
@@ -45,8 +44,18 @@ MODULE_FLAGS = -fno-builtin
 
 #LFLAGS   = -nostartfiles -Wl,-gc-sections -Wl,-Map=$(TARGET).map,--cref -nostdlib
 LFLAGS   = -nostartfiles -Wl,-gc-sections -Wl,-Map=$(TARGET).map,--cref -lc -lnosys -L$(SDIR) -Lobjs/$(TARGET) -Wl,-warn-common
+
+LINKFILE = $(SDIR)/target/$(TARGET)/$(TARGET).ld
 LFLAGS2  = -Wl,-T$(LINKFILE)
-LFLAGS2OPT  = -Wl,-T$(SDIR)/target/$(TARGET)/$(TARGET)_opt.ld
+
+ifdef OPTIMIZE_DFU
+LINKFILEOPT = $(SDIR)/target/$(TARGET)/$(TARGET)_opt.ld
+ifeq (,$(wildcard $(LINKFILEOPT)))
+LINKFILEOPT = $(LINKFILE)
+endif
+LFLAGS2OPT  = -Wl,-T$(LINKFILEOPT)
+CRC_OFFSET=$(shell grep _crc_offset $(LINKFILEOPT) | awk -F'[= ;]' '{print $$4}')
+endif
 
 #-lnosys
 

--- a/src/target/devo10/Makefile.inc
+++ b/src/target/devo10/Makefile.inc
@@ -5,4 +5,6 @@ FONTS        = filesystem/$(FILESYSTEM)/media/12normal.fon \
                filesystem/$(FILESYSTEM)/media/04b03.fon
 LANGUAGE   := devo10
 
+OPTIMIZE_DFU := 1
+
 include $(SDIR)/target/common/devo/Makefile.inc

--- a/src/target/devo12/Makefile.inc
+++ b/src/target/devo12/Makefile.inc
@@ -5,6 +5,8 @@ FONTS        = filesystem/$(FILESYSTEM)/media/15normal.fon \
                filesystem/$(FILESYSTEM)/media/23bold.fon
 LANGUAGE    := devo8,devo12
 
+OPTIMIZE_DFU := 1
+
 include $(SDIR)/target/common/devo/Makefile.inc
 
 ifndef BUILD_TARGET

--- a/src/target/devo7e-256/Makefile.inc
+++ b/src/target/devo7e-256/Makefile.inc
@@ -5,6 +5,8 @@ FONTS        = filesystem/$(FILESYSTEM)/media/12normal.fon \
                filesystem/$(FILESYSTEM)/media/04b03.fon
 LANGUAGE    := devo10
 
+OPTIMIZE_DFU := 1
+
 include $(SDIR)/target/common/devo/Makefile.inc
 
 ifndef BUILD_TARGET

--- a/src/target/devo7e/Makefile.inc
+++ b/src/target/devo7e/Makefile.inc
@@ -3,7 +3,6 @@ FILESYSTEMS := common base_fonts 128x64x1
 FONTS        = filesystem/$(FILESYSTEM)/media/12normal.fon \
                filesystem/$(FILESYSTEM)/media/04b03.fon
 
-CRC_OFFSET       := 8192
 OPTIMIZE_DFU     := 1
 MODULAR          := 0x20004000
 DFU_ARGS         := -c 7 -b 0x08003000

--- a/src/target/devo8/Makefile.inc
+++ b/src/target/devo8/Makefile.inc
@@ -5,4 +5,6 @@ FONTS        = filesystem/$(FILESYSTEM)/media/15normal.fon \
                filesystem/$(FILESYSTEM)/media/23bold.fon
 LANGUAGE    := devo8
 
+OPTIMIZE_DFU := 1
+
 include $(SDIR)/target/common/devo/Makefile.inc

--- a/src/target/devof12e-XMS/Makefile.inc
+++ b/src/target/devof12e-XMS/Makefile.inc
@@ -3,8 +3,9 @@ SCREENSIZE  := text
 DFU_ARGS    := -c 12 -b 0x08004000
 LANGUAGE   := devo10
 
-include $(SDIR)/target/common/devo/Makefile.inc
+OPTIMIZE_DFU := 1
 
+include $(SDIR)/target/common/devo/Makefile.inc
 
 ifndef BUILD_TARGET
 

--- a/src/target/devof12e/Makefile.inc
+++ b/src/target/devof12e/Makefile.inc
@@ -3,15 +3,16 @@ FILESYSTEMS := common text text_gfx
 
 DFU_ARGS         := -c 12 -b 0x08004000
 
-DEFAULT_PROTOCOLS := 
+DEFAULT_PROTOCOLS :=
 INCLUDE_FS := 0
+OPTIMIZE_DFU := 1
 
 include $(SDIR)/target/common/devo/Makefile.inc
 include target/common/devo/Makefile.devofs.inc
 
 ifndef BUILD_TARGET
 
-MEDIA_FILES = 
+MEDIA_FILES =
 NUM_MODELS ?= 10
 
 else

--- a/src/target/devof4-XMS/Makefile.inc
+++ b/src/target/devof4-XMS/Makefile.inc
@@ -1,7 +1,6 @@
 FILESYSTEMS := common text
 SCREENSIZE  := text
 
-CRC_OFFSET       := 8192
 OPTIMIZE_DFU     := 1
 MODULAR          := 0x20004000
 DFU_ARGS         := -c 4 -b 0x08003000

--- a/src/target/devof4/Makefile.inc
+++ b/src/target/devof4/Makefile.inc
@@ -1,7 +1,6 @@
 SCREENSIZE  := text
 FILESYSTEMS := common text
 
-CRC_OFFSET       := 8192
 OPTIMIZE_DFU     := 1
 MODULAR          := 0x20004000
 DFU_ARGS         := -c 4 -b 0x08003000

--- a/src/target/devof7-XMS/Makefile.inc
+++ b/src/target/devof7-XMS/Makefile.inc
@@ -1,7 +1,6 @@
 FILESYSTEMS := common text
 SCREENSIZE  := text
 
-CRC_OFFSET       := 8192
 OPTIMIZE_DFU     := 1
 MODULAR          := 0x20004000
 DFU_ARGS         := -c 7 -b 0x08003000

--- a/src/target/devof7/Makefile.inc
+++ b/src/target/devof7/Makefile.inc
@@ -1,7 +1,6 @@
 SCREENSIZE  := text
 FILESYSTEMS := common text
 
-CRC_OFFSET       := 8192
 OPTIMIZE_DFU     := 1
 MODULAR          := 0x20004000
 DFU_ARGS         := -c 7 -b 0x08003000

--- a/src/target/ir8m/Makefile.inc
+++ b/src/target/ir8m/Makefile.inc
@@ -5,6 +5,8 @@ FONTS        = filesystem/$(FILESYSTEM)/media/12normal.fon \
                filesystem/$(FILESYSTEM)/media/04b03.fon
 LANGUAGE    := devo10
 
+OPTIMIZE_DFU := 1
+
 include $(SDIR)/target/common/devo/Makefile.inc
 
 ifdef BUILD_TARGET

--- a/src/target/t8sg/Makefile.inc
+++ b/src/target/t8sg/Makefile.inc
@@ -5,6 +5,8 @@ FONTS        = filesystem/$(FILESYSTEM)/media/12normal.fon \
                filesystem/$(FILESYSTEM)/media/04b03.fon
 LANGUAGE    := devo10
 
+OPTIMIZE_DFU := 1
+
 include $(SDIR)/target/common/devo/Makefile.inc
 
 ifdef BUILD_TARGET

--- a/src/target/t8sg_v2/Makefile.inc
+++ b/src/target/t8sg_v2/Makefile.inc
@@ -5,6 +5,8 @@ FONTS        = filesystem/$(FILESYSTEM)/media/12normal.fon \
                filesystem/$(FILESYSTEM)/media/04b03.fon
 LANGUAGE    := devo10
 
+OPTIMIZE_DFU := 1
+
 include $(SDIR)/target/common/devo/Makefile.inc
 
 ifdef BUILD_TARGET

--- a/src/target/t8sg_v2_plus/Makefile.inc
+++ b/src/target/t8sg_v2_plus/Makefile.inc
@@ -5,6 +5,8 @@ FONTS        = filesystem/$(FILESYSTEM)/media/12normal.fon \
                filesystem/$(FILESYSTEM)/media/04b03.fon
 LANGUAGE    := devo10
 
+OPTIMIZE_DFU := 1
+
 include $(SDIR)/target/common/devo/Makefile.inc
 
 ifdef BUILD_TARGET

--- a/utils/repack_ld.pl
+++ b/utils/repack_ld.pl
@@ -9,7 +9,7 @@ use Getopt::Long;
 my %map;
 my $free = 0;
 my $mapfile;
-GetOptions("mapfile=s" => \$mapfile, "size=i" => \$free);
+GetOptions("mapfile=s" => \$mapfile, "size=o" => \$free);
 read_map($mapfile);
 repack_obj();
 


### PR DESCRIPTION
For most targets, no need to have seperate _opt.ld now. Enhence Makefile to use original ld file.
at9 crc offset set to 0x150 right after vector table to avoid padding.