### PR TITLE
Only run cyclic calculation once.  Add several mixer tests

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -463,6 +463,11 @@ s32 MIXER_ApplyLimits(unsigned channel, struct Limit *limit, volatile s32 *_raw,
 s8 *MIXER_GetTrim(unsigned i)
 {
     if (Model.trims[i].sw) {
+        //when using 0/1 the assumption is that sw points at the '0' input of a 2-way switch
+        //when using 0/1/2 the assumption is that sw points at the '0' input of a 3-way switch
+        //when using upto 6 positions, the assumption is that the sw points at a virtual channel
+        //the next n virtual channels (upto 6) make up a virtual n-way switch with only one having
+        //a value > 0.  This is described here: https://github.com/DeviationTX/deviation/pull/351
         for (int j = 0; j < 6; j++) {
             // Assume switch 0/1/2 are in order
             if(raw[Model.trims[i].sw+j] > 0) {

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -62,7 +62,7 @@ static s32 get_trim(unsigned src);
 // Period depends on protocol for protocols that run mixer manually
 static u32 mixer_period;
 
-static void MIXER_CreateCyclicOutput(volatile s32 *raw, s32 *cyc);
+static void MIXER_CreateCyclicOutput(volatile s32 *raw, s32 *cyclic);
 
 struct Mixer *MIXER_GetAllMixers()
 {
@@ -188,14 +188,14 @@ void MIXER_CalcChannels()
     MIXER_EvalMixers(raw);
 
     //4th step: apply auto-templates
-    s32 cyc[3];
-    MIXER_CreateCyclicOutput(raw, cyc);
+    s32 cyclic[3];
+    MIXER_CreateCyclicOutput(raw, cyclic);
     for (i = 0; i < NUM_OUT_CHANNELS; i++) {
         switch(Model.templates[i]) {
             case MIXERTEMPLATE_CYC1:
             case MIXERTEMPLATE_CYC2:
             case MIXERTEMPLATE_CYC3:
-                raw[NUM_INPUTS+i+1] = cyc[Model.templates[i] - MIXERTEMPLATE_CYC1];
+                raw[NUM_INPUTS+i+1] = cyclic[Model.templates[i] - MIXERTEMPLATE_CYC1];
                 break;
         }
     }
@@ -242,12 +242,12 @@ char* MIXER_GetChannelDisplayFormat(unsigned channel)
 
 #define REZ_SWASH_X(x)  ((x) - (x)/8 - (x)/128 - (x)/512)   //  1024*sin(60) ~= 886
 #define REZ_SWASH_Y(x)  (1*(x))   //  1024 => 1024
-void MIXER_CreateCyclicOutput(volatile s32 *raw, s32 *cyc)
+void MIXER_CreateCyclicOutput(volatile s32 *raw, s32 *cyclic)
 {
     if (! Model.swash_type) {
-        cyc[0] = raw[NUM_INPUTS + NUM_OUT_CHANNELS + 1];
-        cyc[1] = raw[NUM_INPUTS + NUM_OUT_CHANNELS + 2];
-        cyc[2] = raw[NUM_INPUTS + NUM_OUT_CHANNELS + 3];
+        cyclic[0] = raw[NUM_INPUTS + NUM_OUT_CHANNELS + 1];
+        cyclic[1] = raw[NUM_INPUTS + NUM_OUT_CHANNELS + 2];
+        cyclic[2] = raw[NUM_INPUTS + NUM_OUT_CHANNELS + 3];
         return;
     }
     s32 aileron    = raw[NUM_INPUTS + NUM_OUT_CHANNELS + 1];
@@ -262,41 +262,41 @@ void MIXER_CreateCyclicOutput(volatile s32 *raw, s32 *cyc)
     switch(Model.swash_type) {
     case SWASH_TYPE_NONE:
     case SWASH_TYPE_LAST:
-        cyc[0] = aileron;
-        cyc[1] = elevator;
-        cyc[2] = collective;
+        cyclic[0] = aileron;
+        cyclic[1] = elevator;
+        cyclic[2] = collective;
         break;
     case SWASH_TYPE_120:
         aileron  = Model.swashmix[0] * aileron / normalize;
         elevator = Model.swashmix[1] * elevator / normalize;
         collective = Model.swashmix[2] * collective / normalize;
-        cyc[0] = collective - elevator;
-        cyc[1] = collective + elevator/2 + aileron;
-        cyc[2] = collective + elevator/2 - aileron;
+        cyclic[0] = collective - elevator;
+        cyclic[1] = collective + elevator/2 + aileron;
+        cyclic[2] = collective + elevator/2 - aileron;
         break;
     case SWASH_TYPE_120X:
         aileron  = Model.swashmix[0] * aileron / normalize;
         elevator = Model.swashmix[1] * elevator / normalize;
         collective = Model.swashmix[2] * collective / normalize;
-        cyc[0] = collective - aileron;
-        cyc[1] = collective + aileron/2 + elevator;
-        cyc[2] = collective + aileron/2 - elevator;
+        cyclic[0] = collective - aileron;
+        cyclic[1] = collective + aileron/2 + elevator;
+        cyclic[2] = collective + aileron/2 - elevator;
         break;
     case SWASH_TYPE_140:
         aileron  = Model.swashmix[0] * aileron / normalize;
         elevator = Model.swashmix[1] * elevator / normalize;
         collective = Model.swashmix[2] * collective / normalize;
-        cyc[0] = collective - elevator;
-        cyc[1] = collective + elevator + aileron;
-        cyc[2] = collective + elevator - aileron;
+        cyclic[0] = collective - elevator;
+        cyclic[1] = collective + elevator + aileron;
+        cyclic[2] = collective + elevator - aileron;
         break;
     case SWASH_TYPE_90:
         aileron  = Model.swashmix[0] * aileron / normalize;
         elevator = Model.swashmix[1] * elevator / normalize;
         collective = Model.swashmix[2] * collective / normalize;
-        cyc[0] = collective - elevator;
-        cyc[1] = collective + aileron;
-        cyc[2] = collective - aileron;
+        cyclic[0] = collective - elevator;
+        cyclic[1] = collective + aileron;
+        cyclic[2] = collective - aileron;
         break;
     }
 }

--- a/src/tests/test_mixer.c
+++ b/src/tests/test_mixer.c
@@ -652,3 +652,27 @@ void TestTrimAsSwitch(CuTest *t)
     MIXER_UpdateTrim(CHAN_ButtonMask(neg), BUTTON_RELEASE, NULL);
     CuAssertIntEquals(t, 0, Model.trims[0].value[0]);
 }
+
+void TestTemplateName(CuTest *t)
+{
+    CONFIG_ReadLang(0);
+    CuAssertStrEquals(t, "None", MIXER_TemplateName(MIXERTEMPLATE_NONE));
+    CuAssertStrEquals(t, "Simple", MIXER_TemplateName(MIXERTEMPLATE_SIMPLE));
+    CuAssertStrEquals(t, "Expo&DR", MIXER_TemplateName(MIXERTEMPLATE_EXPO_DR));
+    CuAssertStrEquals(t, "Complex", MIXER_TemplateName(MIXERTEMPLATE_COMPLEX));
+    CuAssertStrEquals(t, "Cyclic1", MIXER_TemplateName(MIXERTEMPLATE_CYC1));
+    CuAssertStrEquals(t, "Cyclic2", MIXER_TemplateName(MIXERTEMPLATE_CYC2));
+    CuAssertStrEquals(t, "Cyclic3", MIXER_TemplateName(MIXERTEMPLATE_CYC3));
+    CuAssertStrEquals(t, "Unknown", MIXER_TemplateName(MIXERTEMPLATE_CYC3 + 1));
+}
+
+void TestSwashType(CuTest *t)
+{
+    CONFIG_ReadLang(0);
+    CuAssertStrEquals(t, "None", MIXER_SwashType(SWASH_TYPE_NONE));
+    CuAssertStrEquals(t, "120", MIXER_SwashType(SWASH_TYPE_120));
+    CuAssertStrEquals(t, "120X", MIXER_SwashType(SWASH_TYPE_120X));
+    CuAssertStrEquals(t, "140", MIXER_SwashType(SWASH_TYPE_140));
+    CuAssertStrEquals(t, "90", MIXER_SwashType(SWASH_TYPE_90));
+    CuAssertStrEquals(t, "", MIXER_SwashType(SWASH_TYPE_LAST));
+}

--- a/src/tests/test_mixer.c
+++ b/src/tests/test_mixer.c
@@ -418,6 +418,26 @@ void TestApplyMixerTrim(CuTest *t)
     CuAssertIntEquals(t, 1499, rawdata[3 + NUM_INPUTS]);
 }
 
+void TestApplyLimits(CuTest *t)
+{
+    struct Limit limit;
+    s32 rawdata[NUM_SOURCES + 1] = {0};
+    memset(&Model, 0, sizeof(Model));
+    memset((s32 *)Channels, 0, sizeof(Channels));
+
+    rawdata[NUM_INPUTS + 1 + NUM_OUT_CHANNELS] = 1000;
+    CuAssertIntEquals(t, 1000, MIXER_ApplyLimits(NUM_OUT_CHANNELS, &limit, rawdata, Channels, 0));
+
+    //Safety
+    limit.safetysw = INP_GEAR1;
+    Model.limits[0].safetyval = 50;
+    rawdata[INP_GEAR1] = -1;
+    rawdata[NUM_INPUTS + 1] = 200;
+    CuAssertIntEquals(t, 200, MIXER_ApplyLimits(0, &limit, rawdata, Channels, APPLY_SAFETY));
+    rawdata[INP_GEAR1] = 100;
+    CuAssertIntEquals(t, 5000, MIXER_ApplyLimits(0, &limit, rawdata, Channels, APPLY_SAFETY));
+}
+
 void TestGetTrim(CuTest *t)
 {
     memset(&Model, 0, sizeof(Model));

--- a/src/tests/test_mixer.c
+++ b/src/tests/test_mixer.c
@@ -653,6 +653,37 @@ void TestTrimAsSwitch(CuTest *t)
     CuAssertIntEquals(t, 0, Model.trims[0].value[0]);
 }
 
+void TestSetMixers(CuTest *t)
+{
+    struct Mixer newmixers[3];
+    memset(&Model, 0, sizeof(Model));
+    for (int i = 0; i < 3; i++) {
+        newmixers[i].src = 10 + i;
+        newmixers[i].dest = 21;
+    }
+    for (int i = 0; i < NUM_MIXERS-2; i++) {
+        Model.mixers[i].src = 1;
+        Model.mixers[i].dest = 20;
+    }
+    CuAssertIntEquals(t, 0, MIXER_SetMixers(newmixers, 3));
+    memset(&Model, 0, sizeof(Model));
+    Model.templates[20] = MIXERTEMPLATE_SIMPLE;
+    Model.templates[21] = MIXERTEMPLATE_SIMPLE;
+    for (int i = 0; i < 10; i++) {
+        Model.mixers[i].src = i + 1;
+        Model.mixers[i].dest = (i % 2) + 20;
+    }
+    CuAssertIntEquals(t, 1, MIXER_SetMixers(newmixers, 3));
+    int expected_src[] = {1, 3, 5, 7, 9, 10, 11, 12, 0, 0, 0};
+    int expected_dst[] = {20, 20, 20, 20, 20, 21, 21, 21, 0, 0, 0};
+    for (int i = 0; i < 10; i++) {
+        CuAssertIntEquals(t, expected_src[i], Model.mixers[i].src);
+        if (expected_src[i]) {
+            CuAssertIntEquals(t, expected_dst[i], Model.mixers[i].dest);
+        }
+    }
+}
+
 void TestTemplateName(CuTest *t)
 {
     CONFIG_ReadLang(0);

--- a/src/tests/test_mixer.c
+++ b/src/tests/test_mixer.c
@@ -379,6 +379,7 @@ void TestApplyMixerDelay(CuTest *t)
     s32 rawdata[NUM_SOURCES + 1];
     s32 origvalue;
     memset(&Model, 0, sizeof(Model));
+    mixer_period = 5;
 
     rawdata[1] = 1000;
     mixer_period = 5;
@@ -387,6 +388,7 @@ void TestApplyMixerDelay(CuTest *t)
     s32 target[] = {550, 550, 550, 550, 550, 550, 550, 400, 400, 400};
     s32 expected[] = {100, 200, 300, 400, 500, 550, 550, 450, 400, 400};
     rawdata[3 + NUM_INPUTS] = 0;
+    mixer_period = 5;
     for(unsigned i = 0; i < sizeof(expected) / sizeof(expected[0]); i++) {
         origvalue = rawdata[3 + NUM_INPUTS];
         rawdata[3 + NUM_INPUTS] = target[i];


### PR DESCRIPTION
For some reason we were calling MIXER_CreateCyclicOutput() for each cyclic channel even though it does the full caclulation each time it is called.