### PR TITLE
Fix strict-alias of type FAT

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -29,11 +29,6 @@ typedef uint64_t u64;
 #include "target.h"
 #include "std.h"
 
-//FATFS is defined by target_defs.h
-struct FAT {
-    char inaccessible[FATSTRUCT_SIZE];
-};
-
 //Compatibility with Atmega
 #define FLASHBYTETABLE static const u8
 #define FLASHWORDTABLE static const u16

--- a/src/datalog.c
+++ b/src/datalog.c
@@ -43,7 +43,7 @@ const u32 sample_rate[DLOG_RATE_LAST] = {
     [DLOG_RATE_1MIN]  = 60000,
 };
 
-static struct FAT DatalogFAT;
+static FATFS DatalogFAT;
 static FILE *fh;
 static u32 next_update;
 static u32 dlog_pos;

--- a/src/protocol/protocol.c
+++ b/src/protocol/protocol.c
@@ -131,6 +131,8 @@ void PROTOCOL_Load(int no_dlg)
     (void)no_dlg;
 #ifdef ENABLE_MODULAR
     FATFS ModuleFAT;
+    FILE *fh;
+
     if(! PROTOCOL_HasModule(Model.protocol)) {
         *loaded_protocol = 0;
         return;
@@ -151,11 +153,9 @@ void PROTOCOL_Load(int no_dlg)
     }
     file[17] = '\0'; //truncate filename to 8 characters
     strcat(file, ".mod");
-    FILE *fh;
-    //Thatis necessary because we need to be able to load the
-    //protocol while an ini file is open, and we don't want to
-    //waste the RAM for an extra filehandle
-    finit(&ModuleFAT, "module"); //In case no fonts are loaded yet
+
+    memset(&ModuleFAT, 0, sizeof(ModuleFAT));
+    finit(&ModuleFAT, "protocol");
     fh = fopen2(&ModuleFAT, file, "r");
     //printf("Loading %s: %08lx\n", file, fh);
     if(! fh) {

--- a/src/protocol/protocol.c
+++ b/src/protocol/protocol.c
@@ -30,7 +30,7 @@
 #define HAS_4IN1_FLASH 0
 #endif
 
-extern struct FAT FontFAT; //defined in screen/lcd_string.c
+extern FATFS FontFAT; //defined in screen/lcd_string.c
 
 //Not static because we need it in mixer.c
 const u8 EATRG0[PROTO_MAP_LEN] =

--- a/src/screen/320x240x16/lcd_string.c
+++ b/src/screen/320x240x16/lcd_string.c
@@ -15,7 +15,7 @@
 #include "common.h"
 #include "gui/gui.h"
 
-struct FAT FontFAT = {{0}};
+FATFS FontFAT;
 /*
  * The font 'font_table' begins with a list of u24 values which represent
  * the offeset (from the beginning of the font file) of each character.

--- a/src/screen/320x240x16/lcd_string.c
+++ b/src/screen/320x240x16/lcd_string.c
@@ -15,7 +15,8 @@
 #include "common.h"
 #include "gui/gui.h"
 
-FATFS FontFAT;
+static FATFS FontFAT;
+
 /*
  * The font 'font_table' begins with a list of u24 values which represent
  * the offeset (from the beginning of the font file) of each character.

--- a/src/screen/text/lcd_string.c
+++ b/src/screen/text/lcd_string.c
@@ -21,8 +21,6 @@
 #define HEIGHT(x) (x.zoom)
 #define get_width(x) HEIGHT(cur_str.font)
 
-FATFS FontFAT;
-
 void LCD_SetXY(unsigned int x, unsigned int y)
 {
     cur_str.x_start = x;

--- a/src/screen/text/lcd_string.c
+++ b/src/screen/text/lcd_string.c
@@ -21,7 +21,7 @@
 #define HEIGHT(x) (x.zoom)
 #define get_width(x) HEIGHT(cur_str.font)
 
-struct FAT FontFAT = {{0}};
+FATFS FontFAT;
 
 void LCD_SetXY(unsigned int x, unsigned int y)
 {

--- a/src/target/common/devo/common_devo.h
+++ b/src/target/common/devo/common_devo.h
@@ -5,7 +5,7 @@
 #error "Don't include target_defs.h directly, include target.h instead."
 #endif
 
-#ifndef FATSTRUCT_SIZE
+#if !defined(EMULATOR) || EMULATOR != USE_NATIVE_FS
     #if defined USE_DEVOFS && USE_DEVOFS == 1
         #include "enable_devofs.h"
     #else

--- a/src/target/common/emu/common_emu.h
+++ b/src/target/common/emu/common_emu.h
@@ -7,7 +7,9 @@
 
 //FAT is unused for the emulator
 #if EMULATOR == USE_NATIVE_FS
-    #define FATSTRUCT_SIZE 1
+    typedef struct {
+        int dummy;
+    }FATFS;
     #define fs_is_initialized(x) x
     #define fs_add_file_descriptor(x, y) (void)NULL
 #endif

--- a/src/target/common/filesystems/enable_devofs.h
+++ b/src/target/common/filesystems/enable_devofs.h
@@ -3,8 +3,6 @@
 
     #include "devofs/devofs.h"
 
-    #define FATSTRUCT_SIZE sizeof(FATFS)
-
     #define fs_mount      df_mount
     #define fs_open       df_open
     #define fs_read       df_read

--- a/src/target/common/filesystems/enable_petit_fat.h
+++ b/src/target/common/filesystems/enable_petit_fat.h
@@ -3,8 +3,6 @@
 
     #include "petit_fat/petit_fat.h"
 
-    #define FATSTRUCT_SIZE sizeof(FATFS)
-
     #define fs_mount                        pf_mount
     #define fs_is_initialized(x)            (((char *)(x))[0] != 0)
     #define fs_add_file_descriptor(x, y)    FS_Mount(x, y)

--- a/src/target/devof12e/lcd.h
+++ b/src/target/devof12e/lcd.h
@@ -28,8 +28,6 @@ void TW8816_SetVideoStandard(u8 standard);
 #define LCD_ALIGN_CENTER    1
 #define LCD_ALIGN_RIGHT     2
 
-extern FATFS FontFAT;
-
 struct font_def 
 {
         u8 idx;

--- a/src/target/devof12e/lcd.h
+++ b/src/target/devof12e/lcd.h
@@ -28,7 +28,7 @@ void TW8816_SetVideoStandard(u8 standard);
 #define LCD_ALIGN_CENTER    1
 #define LCD_ALIGN_RIGHT     2
 
-extern struct FAT FontFAT;
+extern FATFS FontFAT;
 
 struct font_def 
 {

--- a/src/target/devof7/lcd.h
+++ b/src/target/devof7/lcd.h
@@ -9,7 +9,7 @@
 #define LCD_ALIGN_CENTER    1
 #define LCD_ALIGN_RIGHT     2
 
-extern struct FAT FontFAT;
+extern FATFS FontFAT;
 
 struct font_def 
 {

--- a/src/target/devof7/lcd.h
+++ b/src/target/devof7/lcd.h
@@ -9,8 +9,6 @@
 #define LCD_ALIGN_CENTER    1
 #define LCD_ALIGN_RIGHT     2
 
-extern FATFS FontFAT;
-
 struct font_def 
 {
         u8 idx;


### PR DESCRIPTION
In new compiler, strict-alias is assumed to have better optimization. The current implementation to use an array to simulate the struct FATFS breaks this assumption and cause gcc 8.2 generate wrong code. Fix it via using the exact type.