### PR TITLE
Fix crash in non-localized Tx

### DIFF
--- a/src/pages/common/_tx_configure.c
+++ b/src/pages/common/_tx_configure.c
@@ -17,7 +17,9 @@ static struct tx_configure_page * const cp = &pagemem.u.tx_configure_page;  // M
 static struct calibrate_obj * const guic = &gui_objs.u.calibrate;
 
 enum {
+#if SUPPORT_MULTI_LANGUAGE
     ITEM_LANG,
+#endif
     ITEM_MODE,
     ITEM_STICKS,
     ITEM_BUZZ,


### PR DESCRIPTION
This is regression when converting to new MULTI_LANGUAGE knob.