### PR TITLE
Don't run video_setstandard in every event loop

### DIFF
--- a/src/datalog.h
+++ b/src/datalog.h
@@ -47,7 +47,6 @@ extern const char *DATALOG_Source(char *str, int idx);
 extern int DATALOG_Remaining();
 extern void DATALOG_Reset();
 extern void DATALOG_UpdateState();
-extern int DATALOG_IsEnabled();
 extern const char *DATALOG_RateString(int idx);
 extern void DATALOG_ApplyMask(int idx, int set);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -318,8 +318,9 @@ void TOUCH_Handler() {
 void VIDEO_Update()
 {
     static u8 video_enable = 0;
-    static u8 video_standard_in_use = 0xFE; //unknown
-    //FIXME This is just like DATALOG_IsEnabled
+    static u32 check_standard_ms = 0;
+
+    // Check if Video is turn on
     int enabled = MIXER_SourceAsBoolean(Model.videosrc);
 
     if (enabled != video_enable) {
@@ -329,18 +330,28 @@ void VIDEO_Update()
             VIDEO_SetChannel(Model.videoch);
             VIDEO_Contrast(Model.video_contrast);
             VIDEO_Brightness(Model.video_brightness);
+            check_standard_ms = CLOCK_getms() + 3000;
         }
+        else
+            check_standard_ms = 0;
     }
-    if(video_enable) {
-        u8 video_standard_current = VIDEO_GetStandard();
-        if((video_standard_current > 0) &&
-           (video_standard_current < 8) &&
-           (video_standard_current != video_standard_in_use)) {
-            video_standard_in_use = video_standard_current;
-            VIDEO_SetStandard(video_standard_current);
+
+    if(video_enable &&
+        check_standard_ms > 0
+        && check_standard_ms < CLOCK_getms()) {
+            u8 video_standard_current = VIDEO_GetStandard();
+            if((video_standard_current > 0) &&
+               (video_standard_current < 8)) {
+                VIDEO_SetStandard(video_standard_current);
+                check_standard_ms = 0;
+            }
+            else {
+                check_standard_ms = CLOCK_getms() + 3000;
+            }
         }
-	AUTODIMMER_Check();
-    }
+
+    if(video_enable)
+        AUTODIMMER_Check();
 }
 #endif //HAS_VIDEO
 


### PR DESCRIPTION
Set a flag to let the _getstandard runs after video is enabled in 3 seconds.