### PR TITLE
Fix the build of devof4

### DIFF
--- a/src/target/common/devo/Makefile.inc
+++ b/src/target/common/devo/Makefile.inc
@@ -45,11 +45,13 @@ MODULE_FLAGS = -fno-builtin
 #LFLAGS   = -nostartfiles -Wl,-gc-sections -Wl,-Map=$(TARGET).map,--cref -nostdlib
 LFLAGS   = -nostartfiles -Wl,-gc-sections -Wl,-Map=$(TARGET).map,--cref -lc -lnosys -L$(SDIR) -Lobjs/$(TARGET) -Wl,-warn-common
 
+ifeq ($(LINKFILE),)
 LINKFILE = $(SDIR)/target/$(TARGET)/$(TARGET).ld
+endif
 LFLAGS2  = -Wl,-T$(LINKFILE)
 
 ifdef OPTIMIZE_DFU
-LINKFILEOPT = $(SDIR)/target/$(TARGET)/$(TARGET)_opt.ld
+LINKFILEOPT = $(basename $(LINKFILE))_opt.ld
 ifeq (,$(wildcard $(LINKFILEOPT)))
 LINKFILEOPT = $(LINKFILE)
 endif

--- a/src/target/devof12e-XMS/Makefile.inc
+++ b/src/target/devof12e-XMS/Makefile.inc
@@ -5,6 +5,8 @@ LANGUAGE   := devo10
 
 OPTIMIZE_DFU := 1
 
+LINKFILE = $(SDIR)/target/devof12e/devof12e.ld
+
 include $(SDIR)/target/common/devo/Makefile.inc
 
 ifndef BUILD_TARGET

--- a/src/target/devof12e-XMS/devof12e-XMS.ld
+++ b/src/target/devof12e-XMS/devof12e-XMS.ld
@@ -1,1 +1,0 @@
-INCLUDE target/devof12e/devof12e.ld

--- a/src/target/devof4-XMS/Makefile.inc
+++ b/src/target/devof4-XMS/Makefile.inc
@@ -5,6 +5,8 @@ OPTIMIZE_DFU     := 1
 MODULAR          := 0x20004000
 DFU_ARGS         := -c 4 -b 0x08003000
 
+LINKFILE = $(SDIR)/target/devof7/devof7.ld
+
 include target/common/devo/Makefile.inc
 
 ifndef BUILD_TARGET

--- a/src/target/devof4-XMS/devof4-XMS.ld
+++ b/src/target/devof4-XMS/devof4-XMS.ld
@@ -1,1 +1,0 @@
-INCLUDE target/devof7/devof7.ld

--- a/src/target/devof4-XMS/devof4-XMS_opt.ld
+++ b/src/target/devof4-XMS/devof4-XMS_opt.ld
@@ -1,1 +1,0 @@
-INCLUDE target/devof7/devof7_opt.ld

--- a/src/target/devof4/Makefile.inc
+++ b/src/target/devof4/Makefile.inc
@@ -6,6 +6,8 @@ MODULAR          := 0x20004000
 DFU_ARGS         := -c 4 -b 0x08003000
 # 0x08003000
 
+LINKFILE = $(SDIR)/target/devof7/devof7.ld
+
 PRE_FS = $(ODIR)/.pre_fs
 
 INCLUDE_FS := 0

--- a/src/target/devof4/devof4.ld
+++ b/src/target/devof4/devof4.ld
@@ -1,1 +1,0 @@
-INCLUDE target/devof7/devof7.ld

--- a/src/target/devof4/devof4_opt.ld
+++ b/src/target/devof4/devof4_opt.ld
@@ -1,1 +1,0 @@
-INCLUDE target/devof7/devof7_opt.ld

--- a/src/target/devof7-XMS/Makefile.inc
+++ b/src/target/devof7-XMS/Makefile.inc
@@ -5,6 +5,8 @@ OPTIMIZE_DFU     := 1
 MODULAR          := 0x20004000
 DFU_ARGS         := -c 7 -b 0x08003000
 
+LINKFILE = $(SDIR)/target/devof7/devof7.ld
+
 include target/common/devo/Makefile.inc
 
 ifndef BUILD_TARGET

--- a/src/target/devof7-XMS/devof7-XMS.ld
+++ b/src/target/devof7-XMS/devof7-XMS.ld
@@ -1,1 +1,0 @@
-INCLUDE target/devof7/devof7.ld

--- a/src/target/devof7-XMS/devof7-XMS_opt.ld
+++ b/src/target/devof7-XMS/devof7-XMS_opt.ld
@@ -1,1 +1,0 @@
-INCLUDE target/devof7/devof7_opt.ld


### PR DESCRIPTION
The logic to auto detect CRCOFFSET cannot work with the include. So let the target set LINKFILE to the file it is using directly.