### PR TITLE
Speedup travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ addons:
 #      - gcc-arm-none-eabi
 
 #Do NOT set these.  They set 'CC' which breaks the build
-#language: c
+language: minimal
 #compiler: gcc
 
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ sudo: false
 
 addons:
   apt:
+    update: false
     packages:
       - build-essential
       - libc6-i386

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ env:
 #      - COMPILER=latest TARGET=devo8
 
 # use new docker environment
-sudo: false
+#sudo: false
 
 #sudo: required
-#dist: trusty
+dist: trusty
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ addons:
   apt:
     packages:
       - build-essential
-      - git
       - libc6-i386
       - mingw32
       - mingw32-binutils

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ env:
       - MAKETARGET=test
 #      - COMPILER=latest TARGET=devo8
 
-# use new docker environment
-#sudo: false
-
-#sudo: required
 dist: trusty
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,9 @@ addons:
 #language: c
 #compiler: gcc
 
+git:
+  depth: 5
+
 before_install:
    - pip install --user cpp-coveralls
    - if [ ! -d "$HOME/gcc-arm-none-eabi-4_8-2013q4/bin" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 env:
 #Do not define 'global' env vars here.  They cannot be used with API builds
     matrix:
+      fast_finish: true
       - MAKETARGET=zip_devo8
       - MAKETARGET=zip_devo10
       - MAKETARGET=zip_devo12


### PR DESCRIPTION
Some small changes to travis.yml to speed up builds a little:

1. git clone only shallow
2. omit apt-get update
3. git needs no update through apt
4. move away from docker container to trusty VM, as docker containers are phased out anyways by travis
5. set minimal language, as we only need a very basic environment