### PR TITLE
Reduce stack usage of page-reordering

### DIFF
--- a/src/pages/common/advanced/_mixer_page.c
+++ b/src/pages/common/advanced/_mixer_page.c
@@ -111,21 +111,25 @@ static const char *reorder_text_cb(u8 idx)
 
 static void reorder_mixers_by_list(u8 *list)
 {
-    int i, j, k = 0;
-    struct Mixer tmpmix[NUM_MIXERS];
-    memset(tmpmix, 0, sizeof(tmpmix));
-    for(j = 0; j < NUM_CHANNELS; j++) {
-        for(i = 0; i <NUM_MIXERS; i++) {
-            if(Model.mixers[i].src && Model.mixers[i].dest == list[j]-1) {
-                memcpy(&tmpmix[k], &Model.mixers[i], sizeof(struct Mixer));
-                tmpmix[k].dest = j;
-                k++;
+    struct Mixer tmpmix;
+    int pos = 0;
+    for(int newdest = 0; newdest < NUM_CHANNELS; newdest++) {
+        int olddest = list[newdest]-1;
+        int match = pos;
+        while(match < NUM_MIXERS) {
+            if (Model.mixers[match].src && Model.mixers[match].dest == olddest) {
+                if (match != pos) {
+                    tmpmix = Model.mixers[match];
+                    memmove(&Model.mixers[pos+1], &Model.mixers[pos], sizeof(struct Mixer) * (match-pos));
+                    Model.mixers[pos] = tmpmix;
+                }
+                Model.mixers[pos].dest = newdest;
+                pos++;
             }
+            match++;
         }
     }
-    memcpy(Model.mixers, tmpmix, sizeof(Model.mixers));
 }
-
 
 static void reorder_limits_by_list(u8 *list)
 {

--- a/src/pages/common/advanced/_mixer_page.c
+++ b/src/pages/common/advanced/_mixer_page.c
@@ -121,7 +121,7 @@ static void reorder_mixers_by_list(u8 *list)
     }
     for (int i = 0; i < NUM_MIXERS; i++) {
         int dest = Model.mixers[i].dest;
-        if (! Model.mixers[i].src)
+        if (!Model.mixers[i].src)
             break;
         if (reorder[dest] != 0xff) {
             Model.mixers[i].dest = reorder[dest];
@@ -134,10 +134,10 @@ static void reorder_limits_by_list(u8 *list)
     unsigned j;
     struct Limit tmplimits[NUM_OUT_CHANNELS];
     u8 tmptemplates[NUM_CHANNELS];
-    for(j = 0; j < NUM_CHANNELS; j++) {
-        if(j < NUM_OUT_CHANNELS) {
-           if(list[j]-1 < NUM_OUT_CHANNELS) {
-               tmplimits[j] = Model.limits[list[j]-1]; 
+    for (j = 0; j < NUM_CHANNELS; j++) {
+        if (j < NUM_OUT_CHANNELS) {
+           if (list[j]-1 < NUM_OUT_CHANNELS) {
+               tmplimits[j] = Model.limits[list[j]-1];
            } else {
                MIXER_SetDefaultLimit(&tmplimits[j]);
            }
@@ -150,7 +150,7 @@ static void reorder_limits_by_list(u8 *list)
 
 static void reorder_return_cb(u8 *list)
 {
-    if (! list)
+    if (!list)
         return;
     reorder_mixers_by_list(list);
     reorder_limits_by_list(list);

--- a/src/pages/common/advanced/_mixer_page.c
+++ b/src/pages/common/advanced/_mixer_page.c
@@ -109,38 +109,50 @@ static const char *reorder_text_cb(u8 idx)
     return MIXPAGE_ChanNameProtoCB(NULL, (void *)i);
 }
 
+static void reorder_mixers_by_list(u8 *list)
+{
+    int i, j, k = 0;
+    struct Mixer tmpmix[NUM_MIXERS];
+    memset(tmpmix, 0, sizeof(tmpmix));
+    for(j = 0; j < NUM_CHANNELS; j++) {
+        for(i = 0; i <NUM_MIXERS; i++) {
+            if(Model.mixers[i].src && Model.mixers[i].dest == list[j]-1) {
+                memcpy(&tmpmix[k], &Model.mixers[i], sizeof(struct Mixer));
+                tmpmix[k].dest = j;
+                k++;
+            }
+        }
+    }
+    memcpy(Model.mixers, tmpmix, sizeof(Model.mixers));
+}
+
+
+static void reorder_limits_by_list(u8 *list)
+{
+    unsigned j;
+    struct Limit tmplimits[NUM_OUT_CHANNELS];
+    u8 tmptemplates[NUM_CHANNELS];
+    for(j = 0; j < NUM_CHANNELS; j++) {
+        if(j < NUM_OUT_CHANNELS) {
+           if(list[j]-1 < NUM_OUT_CHANNELS) {
+               tmplimits[j] = Model.limits[list[j]-1]; 
+           } else {
+               MIXER_SetDefaultLimit(&tmplimits[j]);
+           }
+        }
+        tmptemplates[j] = Model.templates[list[j]-1];
+    }
+    memcpy(Model.templates, tmptemplates, sizeof(Model.templates));
+    memcpy(Model.limits, tmplimits, sizeof(Model.limits));
+}
+
 static void reorder_return_cb(u8 *list)
 {
-    if (list) {
-        int i, j, k = 0;
-        struct Mixer tmpmix[NUM_MIXERS];
-        memset(tmpmix, 0, sizeof(tmpmix));
-        for(j = 0; j < NUM_CHANNELS; j++) {
-            for(i = 0; i <NUM_MIXERS; i++) {
-                if(Model.mixers[i].src && Model.mixers[i].dest == list[j]-1) {
-                    memcpy(&tmpmix[k], &Model.mixers[i], sizeof(struct Mixer));
-                    tmpmix[k].dest = j;
-                    k++;
-                }
-            }
-        }
-        memcpy(Model.mixers, tmpmix, sizeof(Model.mixers));
-        struct Limit tmplimits[NUM_OUT_CHANNELS];
-        u8 tmptemplates[NUM_CHANNELS];
-        for(j = 0; j < NUM_CHANNELS; j++) {
-            if(j < NUM_OUT_CHANNELS) {
-               if(list[j]-1 < NUM_OUT_CHANNELS) {
-                   tmplimits[j] = Model.limits[list[j]-1]; 
-               } else {
-                   MIXER_SetDefaultLimit(&tmplimits[j]);
-               }
-            }
-            tmptemplates[j] = Model.templates[list[j]-1];
-        }
-        memcpy(Model.templates, tmptemplates, sizeof(Model.templates));
-        memcpy(Model.limits, tmplimits, sizeof(Model.limits));
-        MIXER_SetMixers(NULL, 0);
-    }
+    if (! list)
+        return;
+    reorder_mixers_by_list(list);
+    reorder_limits_by_list(list);
+    MIXER_SetMixers(NULL, 0);
 }
 
 static void reorder_cb(guiObject_t *obj, const void *data)
@@ -231,3 +243,5 @@ void virtname_cb(guiObject_t *obj, const void *data)
     GUI_CreateKeyboard(&gui->keyboard, KEYBOARD_ALPHA, tempstring, sizeof(Model.virtname[ch])-1, _changename_done_cb, &callback_result);
 }
 
+#define TESTNAME pages_advanced_mixer
+#include <tests.h>

--- a/src/tests/test_pages_advanced_mixer.c
+++ b/src/tests/test_pages_advanced_mixer.c
@@ -23,25 +23,25 @@ void TestMixerPageReorder(CuTest *t)
     reorder_return_cb(list);
 
     printf("%d %d\n", NUM_CHANNELS, NUM_OUT_CHANNELS+1);
-    
-    for(unsigned i = 0; i < 2*sizeof(order); i++) {
+
+    for (unsigned i = 0; i < 2*sizeof(order); i++) {
         unsigned dest = i / 2;
         unsigned src = 1 + (list[dest]-1) + (i % 2);
         printf("%d: src %d == %d   dest %d == %d\n", i, src, Model.mixers[i].src, dest, Model.mixers[i].dest);
     }
-    for(unsigned i = 0; i < 2*sizeof(order); i++) {
+    for (unsigned i = 0; i < 2*sizeof(order); i++) {
         unsigned dest = i / 2;
         unsigned src = 1 + (list[dest]-1) + (i % 2);
         CuAssertIntEquals(t, src, Model.mixers[i].src);
         CuAssertIntEquals(t, dest, Model.mixers[i].dest);
     }
 
-    for(unsigned i = 0; i < sizeof(order); i++) {
+    for (unsigned i = 0; i < sizeof(order); i++) {
         unsigned templ = list[i]-1 + MIXERTEMPLATE_CYC3 + 1;
         unsigned max = list[i]-1 < NUM_OUT_CHANNELS ? list[i]-1 : 150;
         printf("%d: templ %d == %d limit %d == %d\n", i, templ, Model.templates[i], max, Model.limits[i].max);
     }
-    for(unsigned i = 0; i < sizeof(order); i++) {
+    for (unsigned i = 0; i < sizeof(order); i++) {
         unsigned templ = list[i]-1 + MIXERTEMPLATE_CYC3 + 1;
         unsigned max = list[i]-1 < NUM_OUT_CHANNELS ? list[i]-1 : 150;
         CuAssertIntEquals(t, max, Model.limits[i].max);

--- a/src/tests/test_pages_advanced_mixer.c
+++ b/src/tests/test_pages_advanced_mixer.c
@@ -1,0 +1,47 @@
+#include "CuTest.h"
+
+void TestMixerReorder(CuTest *t)
+{
+    u8 list[NUM_CHANNELS];
+    u8 order[] = {4, 1, 3, 6, 2, 5};
+    memset(&Model, 0, sizeof(Model));
+    for (unsigned i = 0; i < NUM_CHANNELS; i++) {
+        list[i] = i+1;
+    }
+    memcpy(list, order, sizeof(order));
+    for(unsigned i = 0; i < 2*sizeof(order); i++) {
+        Model.mixers[i].src = 1 + i;
+        Model.mixers[i].dest = i / 2;
+    }
+
+    reorder_mixers_by_list(list);
+    
+    for(unsigned i = 0; i < 2*sizeof(order); i++) {
+        unsigned dest = i / 2;
+        unsigned src = 1 + 2 * (list[dest]-1) + (i % 2);
+        CuAssertIntEquals(t, src, Model.mixers[i].src);
+        CuAssertIntEquals(t, dest, Model.mixers[i].dest);
+    }
+}
+
+void TestLimitsReorder(CuTest *t)
+{
+    u8 list[NUM_CHANNELS];
+    u8 order[] = {4, 1, 3, 6, 2, 5, NUM_OUT_CHANNELS+1, 7};
+    memset(&Model, 0, sizeof(Model));
+    for (unsigned i = 0; i < NUM_CHANNELS; i++) {
+        list[i] = i+1;
+        Model.limits[i].max = i;
+        Model.templates[i] = i;
+    }
+    memcpy(list, order, sizeof(order));
+
+    reorder_limits_by_list(list);
+    
+    for(unsigned i = 0; i < sizeof(order); i++) {
+        unsigned templ = list[i]-1;
+        unsigned max = templ < NUM_OUT_CHANNELS ? templ : 150;
+        CuAssertIntEquals(t, max, Model.limits[i].max);
+        CuAssertIntEquals(t, templ, Model.templates[i]);
+    }
+}

--- a/src/tests/test_pages_advanced_mixer.c
+++ b/src/tests/test_pages_advanced_mixer.c
@@ -1,46 +1,49 @@
 #include "CuTest.h"
 
-void TestMixerReorder(CuTest *t)
-{
-    u8 list[NUM_CHANNELS];
-    u8 order[] = {4, 1, 3, 6, 2, 5};
-    memset(&Model, 0, sizeof(Model));
-    for (unsigned i = 0; i < NUM_CHANNELS; i++) {
-        list[i] = i+1;
-    }
-    memcpy(list, order, sizeof(order));
-    for(unsigned i = 0; i < 2*sizeof(order); i++) {
-        Model.mixers[i].src = 1 + i;
-        Model.mixers[i].dest = i / 2;
-    }
-
-    reorder_mixers_by_list(list);
-    
-    for(unsigned i = 0; i < 2*sizeof(order); i++) {
-        unsigned dest = i / 2;
-        unsigned src = 1 + 2 * (list[dest]-1) + (i % 2);
-        CuAssertIntEquals(t, src, Model.mixers[i].src);
-        CuAssertIntEquals(t, dest, Model.mixers[i].dest);
-    }
-}
-
-void TestLimitsReorder(CuTest *t)
+void TestMixerPageReorder(CuTest *t)
 {
     u8 list[NUM_CHANNELS];
     u8 order[] = {4, 1, 3, 6, 2, 5, NUM_OUT_CHANNELS+1, 7};
     memset(&Model, 0, sizeof(Model));
     for (unsigned i = 0; i < NUM_CHANNELS; i++) {
         list[i] = i+1;
-        Model.limits[i].max = i;
-        Model.templates[i] = i;
+        Model.mixers[i].src = 1 + i;
+        Model.mixers[i].dest = i;
+        Model.mixers[i + NUM_CHANNELS].src = 2 + i;
+        Model.mixers[i + NUM_CHANNELS].dest = i;
+        // These template values are invalid but will be passed through and are easy to check
+        Model.templates[i] = MIXERTEMPLATE_CYC3 + 1 + i;
+        if (i < NUM_OUT_CHANNELS) {
+            Model.limits[i].max = i;
+        }
     }
     memcpy(list, order, sizeof(order));
+    list[16] = 8;  // list must be a 1:1 mapping
 
-    reorder_limits_by_list(list);
+    reorder_return_cb(list);
+
+    printf("%d %d\n", NUM_CHANNELS, NUM_OUT_CHANNELS+1);
     
+    for(unsigned i = 0; i < 2*sizeof(order); i++) {
+        unsigned dest = i / 2;
+        unsigned src = 1 + (list[dest]-1) + (i % 2);
+        printf("%d: src %d == %d   dest %d == %d\n", i, src, Model.mixers[i].src, dest, Model.mixers[i].dest);
+    }
+    for(unsigned i = 0; i < 2*sizeof(order); i++) {
+        unsigned dest = i / 2;
+        unsigned src = 1 + (list[dest]-1) + (i % 2);
+        CuAssertIntEquals(t, src, Model.mixers[i].src);
+        CuAssertIntEquals(t, dest, Model.mixers[i].dest);
+    }
+
     for(unsigned i = 0; i < sizeof(order); i++) {
-        unsigned templ = list[i]-1;
-        unsigned max = templ < NUM_OUT_CHANNELS ? templ : 150;
+        unsigned templ = list[i]-1 + MIXERTEMPLATE_CYC3 + 1;
+        unsigned max = list[i]-1 < NUM_OUT_CHANNELS ? list[i]-1 : 150;
+        printf("%d: templ %d == %d limit %d == %d\n", i, templ, Model.templates[i], max, Model.limits[i].max);
+    }
+    for(unsigned i = 0; i < sizeof(order); i++) {
+        unsigned templ = list[i]-1 + MIXERTEMPLATE_CYC3 + 1;
+        unsigned max = list[i]-1 < NUM_OUT_CHANNELS ? list[i]-1 : 150;
         CuAssertIntEquals(t, max, Model.limits[i].max);
         CuAssertIntEquals(t, templ, Model.templates[i]);
     }


### PR DESCRIPTION
This patch re-implements the page-reordering algorithm.
It trades of code-size and performance for reduced stack usage.

Original stack usage for reorder_return_cb was 5248 bytes
There are 3 parts:
eda187fe : breaks up the function into 2 parts, making testing easier.  this increases code size by 36 bytes and reduces worst-case stack usage to 2120
8a18b0d : re-implements the mixer-shuffle portion of the code.  This one increases code size by an additional 32 bytes (78 total), and reduces worst-case stack usage to 652
1b4aed00 : re-implements the limit and template shuffling.  This one increase code size further by  104 bytes (182 total) and reduces worst-case stack usage to 120

I don't really understand the massive stack usage drop in the 1st commit.  All that it does is break one function into 3 which should have parallelized the stack usage.  I'd expect the original to be ~ 2080(mixer) + 512(limits) + 26(templates) + ~100 (SetMixer function)=~2718.  Maybe the compiler did an optimization at the cost of stack size.  The other numbers all seem in line.

At the moment, it is clear to me that eda187fe is a good tradeoff. We can possibly even get the ROM growth back by sharing this function with the mixer-reorder page.  8a18b0d may be reasonable as well, but maybe not right now (since eda187fe already moves reorder_return_cb down to about position 20 in the worst-offenders list).  1b4aed00 seems to not be worth the tradefoff of rom growth to stack reduction.