### PR TITLE
Use the array type for strings

### DIFF
--- a/src/config/model.c
+++ b/src/config/model.c
@@ -41,12 +41,12 @@ const char * const RADIO_TX_POWER_VAL[TXPOWER_LAST] =
 #define WRITE_FULL_MODEL 0
 static u8 auto_map;
 
-const char *MODEL_NAME = "name";
-const char *MODEL_ICON = "icon";
-const char *MODEL_TYPE = "type";
-const char *MODEL_TEMPLATE = "template";
-const char *MODEL_AUTOMAP = "automap";
-const char *MODEL_MIXERMODE = "mixermode";
+const char MODEL_NAME[] = "name";
+const char MODEL_ICON[] = "icon";
+const char MODEL_TYPE[] = "type";
+const char MODEL_TEMPLATE[] = "template";
+const char MODEL_AUTOMAP[] = "automap";
+const char MODEL_MIXERMODE[] = "mixermode";
 
 /* Section: Radio */
 static const char SECTION_RADIO[]   = "radio";

--- a/src/config/model.h
+++ b/src/config/model.h
@@ -17,10 +17,10 @@
 #endif
 
 /* INI file consts */
-extern const char *MODEL_NAME;
-extern const char *MODEL_ICON;
-extern const char *MODEL_TYPE;
-extern const char *MODEL_TEMPLATE;
+extern const char MODEL_NAME[];
+extern const char MODEL_ICON[];
+extern const char MODEL_TYPE[];
+extern const char MODEL_TEMPLATE[];
 #define UNKNOWN_ICON ("media/noicon" IMG_EXT)
 
 //This cannot be computed, and must be manually updated

--- a/src/inputs.c
+++ b/src/inputs.c
@@ -111,7 +111,7 @@
 #define BUTNAME_ENTER       _tr("Enter")
 #define BUTNAME_EXIT        _tr("Exit")
 
-const char *tx_stick_names[4] = {
+const char * const tx_stick_names[4] = {
     _tr_noop("RIGHT_H"),
     _tr_noop("LEFT_V"),
     _tr_noop("RIGHT_V"),

--- a/src/mixer.h
+++ b/src/mixer.h
@@ -93,7 +93,7 @@ struct Curve {
 };
 
 //The followingis defined bythe target
-extern const char *tx_stick_names[4];
+extern const char *const tx_stick_names[4];
 
 enum TemplateType {
     MIXERTEMPLATE_NONE,


### PR DESCRIPTION
This makes sure the variables are only in ROM not in RAM.