### PR TITLE
Make emulator single thread

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -89,7 +89,7 @@ int main() {
 
     // We need to wait until we've actually measured the ADC before proceeding
     while(! (priority_ready & (1 << LOW_PRIORITY)))
-        ;
+        PWR_Sleep();
 
     //Only do this after we've initialized all channel data so the saftey works
     PROTOCOL_InitModules();

--- a/src/target/common/emu/fltk.cpp
+++ b/src/target/common/emu/fltk.cpp
@@ -36,6 +36,7 @@
 #include "fltk_resample.h"
 
 bool changed = false;
+static bool singlethread = false;
 
 #define USE_OWN_PRINTF 0 //Disable sprintf mappingdue to need for %f
 //Windows
@@ -557,6 +558,11 @@ void _ALARMhandler(int sig) {
 
 void CLOCK_Init()
 {
+    singlethread = getenv("SINGLETHREAD") != NULL;
+
+    if (singlethread)
+        return;
+
     timer_callback = NULL;
     signal(SIGALRM, _ALARMhandler);
 #if 1  //Mac OSX doesn't support posix timers, but does support itimers
@@ -653,6 +659,8 @@ u32 CLOCK_getms()
 
 void PWR_Sleep() {
     Fl::wait(0.1);
+    if (singlethread)
+        ALARMhandler();
 }
 void LCD_ForceUpdate() {
     if (changed) {


### PR DESCRIPTION
Use the PWR_Sleep to call the timer route every 100ms. Since PWR_Sleep is noon on ARM platform. This change should be a noop for real TX.

The event loop on a modern PC is fast enough and timer route still has reasonable accuracy.

This removes platform dependent code and make my debug life much easier as emu become a single thread application.