### PR TITLE
Introduce GUI_Localize as string callback

### DIFF
--- a/src/gui/button.c
+++ b/src/gui/button.c
@@ -50,7 +50,12 @@ guiObject_t *GUI_CreateButton(guiButton_t *button, u16 x, u16 y, enum ButtonType
 
     // bug fix: must set a default font, otherwise language other than English might not be displayed in some dialogs
     button->desc.font = DEFAULT_FONT.font;
-    button->strCallback = strCallback;
+#if SUPPORT_MULTI_LANGUAGE
+    if (strCallback == GUI_Localize)
+        button->strCallback = _GUI_Localize;
+    else
+#endif
+        button->strCallback = strCallback;
     button->CallBack = CallBack;
     button->cb_data = cb_data;
     button->flags |= FLAG_ENABLE;

--- a/src/gui/gui.c
+++ b/src/gui/gui.c
@@ -830,6 +830,13 @@ void GUI_SelectionNotify(void (*notify_cb)(guiObject_t *obj))
 {
     select_notify = notify_cb;
 }
+
+const char* _GUI_Localize(struct guiObject *obj, const void* str)
+{
+    (void)obj;
+    return _tr((const char*)str);
+}
+
 #if HAS_TOUCH
 void GUI_ChangeSelectionOnTouch(int enable)
 {

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -480,4 +480,12 @@ void GUI_SelectionNotify(void (*notify_cb)(guiObject_t *obj));
 unsigned GUI_GetRemappedButtons();
 void GUI_ChangeSelectionOnTouch(int enable);
 int GUI_InTouch();
+
+#if SUPPORT_MULTI_LANGUAGE
+const char* _GUI_Localize(struct guiObject *obj, const void* str);
+#define GUI_Localize _GUI_Localize
+#else
+#define GUI_LocalizeString NULL
+#endif
+
 #endif /* GUI_H_ */

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -485,7 +485,7 @@ int GUI_InTouch();
 const char* _GUI_Localize(struct guiObject *obj, const void* str);
 #define GUI_Localize _GUI_Localize
 #else
-#define GUI_LocalizeString NULL
+#define GUI_Localize NULL
 #endif
 
 #endif /* GUI_H_ */

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -483,7 +483,7 @@ int GUI_InTouch();
 
 #if SUPPORT_MULTI_LANGUAGE
 const char* _GUI_Localize(struct guiObject *obj, const void* str);
-#define GUI_Localize _GUI_Localize
+#define GUI_Localize (void*)1
 #else
 #define GUI_Localize NULL
 #endif

--- a/src/gui/label.c
+++ b/src/gui/label.c
@@ -44,7 +44,12 @@ guiObject_t *GUI_CreateLabelBox(guiLabel_t *label, u16 x, u16 y, u16 width, u16 
     int underline = label->desc.style == LABEL_UNDERLINE;
     if ((width == 0 || height == 0) && ! underline)
         label->desc.style = LABEL_NO_BOX;
-    label->strCallback = strCallback;
+#if SUPPORT_MULTI_LANGUAGE
+    if (strCallback == GUI_Localize)
+        label->strCallback = _GUI_Localize;
+    else
+#endif
+        label->strCallback = strCallback;
     label->pressCallback = pressCallback;
     label->cb_data = data;
     if (! label->desc.font)

--- a/src/pages/128x64x1/about_page.c
+++ b/src/pages/128x64x1/about_page.c
@@ -34,8 +34,7 @@ void PAGE_AboutInit(int page)
 {
     (void)page;
     PAGE_ShowHeader(PAGE_GetName(PAGEID_ABOUT));
-
-    tempstring_cpy((const char *) _tr("Deviation FW version:"));
+ 
     GUI_CreateLabelBox(&gui->label[0], ROW_1_X, ROW_1_Y, LCD_WIDTH, LINE_HEIGHT, &DEFAULT_FONT, NULL, NULL, "www.deviationtx.com");
     GUI_CreateLabelBox(&gui->label[1], ROW_2_X, ROW_2_Y, LCD_WIDTH, LINE_HEIGHT, &DEFAULT_FONT, GUI_Localize, NULL, _tr_noop("Deviation FW version:"));
     GUI_CreateLabelBox(&gui->label[2], ROW_3_X, ROW_3_Y, LCD_WIDTH, LINE_HEIGHT, &TINY_FONT, GUI_Localize, NULL, _tr_noop(DeviationVersion));

--- a/src/pages/128x64x1/about_page.c
+++ b/src/pages/128x64x1/about_page.c
@@ -34,7 +34,7 @@ void PAGE_AboutInit(int page)
 {
     (void)page;
     PAGE_ShowHeader(PAGE_GetName(PAGEID_ABOUT));
- 
+
     GUI_CreateLabelBox(&gui->label[0], ROW_1_X, ROW_1_Y, LCD_WIDTH, LINE_HEIGHT, &DEFAULT_FONT, NULL, NULL, "www.deviationtx.com");
     GUI_CreateLabelBox(&gui->label[1], ROW_2_X, ROW_2_Y, LCD_WIDTH, LINE_HEIGHT, &DEFAULT_FONT, GUI_Localize, NULL, _tr_noop("Deviation FW version:"));
     GUI_CreateLabelBox(&gui->label[2], ROW_3_X, ROW_3_Y, LCD_WIDTH, LINE_HEIGHT, &TINY_FONT, GUI_Localize, NULL, _tr_noop(DeviationVersion));

--- a/src/pages/128x64x1/about_page.c
+++ b/src/pages/128x64x1/about_page.c
@@ -37,6 +37,6 @@ void PAGE_AboutInit(int page)
 
     tempstring_cpy((const char *) _tr("Deviation FW version:"));
     GUI_CreateLabelBox(&gui->label[0], ROW_1_X, ROW_1_Y, LCD_WIDTH, LINE_HEIGHT, &DEFAULT_FONT, NULL, NULL, "www.deviationtx.com");
-    GUI_CreateLabelBox(&gui->label[1], ROW_2_X, ROW_2_Y, LCD_WIDTH, LINE_HEIGHT, &DEFAULT_FONT, NULL, NULL, tempstring);
-    GUI_CreateLabelBox(&gui->label[2], ROW_3_X, ROW_3_Y, LCD_WIDTH, LINE_HEIGHT, &TINY_FONT, NULL, NULL, _tr_noop(DeviationVersion));
+    GUI_CreateLabelBox(&gui->label[1], ROW_2_X, ROW_2_Y, LCD_WIDTH, LINE_HEIGHT, &DEFAULT_FONT, GUI_Localize, NULL, _tr_noop("Deviation FW version:"));
+    GUI_CreateLabelBox(&gui->label[2], ROW_3_X, ROW_3_Y, LCD_WIDTH, LINE_HEIGHT, &TINY_FONT, GUI_Localize, NULL, _tr_noop(DeviationVersion));
 }

--- a/src/pages/128x64x1/advanced/mixer_curves.c
+++ b/src/pages/128x64x1/advanced/mixer_curves.c
@@ -59,7 +59,7 @@ void PAGE_EditCurvesInit(int page)
     edit->curve = *curve;
 
     GUI_CreateTextSelectPlate(&gui->name, NAME_X, 0, NAME_W, HEADER_HEIGHT, &TEXTSEL_FONT, NULL, set_curvename_cb, NULL);
-    GUI_CreateButtonPlateText(&gui->save, SAVE_X, 0, SAVE_W, HEADER_WIDGET_HEIGHT, &BUTTON_FONT , NULL, okcancel_cb, (void *)_tr("Save"));
+    GUI_CreateButtonPlateText(&gui->save, SAVE_X, 0, SAVE_W, HEADER_WIDGET_HEIGHT, &BUTTON_FONT , GUI_Localize, okcancel_cb, _tr_noop("Save"));
     // Draw a line
     if (UNDERLINE)
         GUI_CreateRect(&gui->rect, 0, HEADER_WIDGET_HEIGHT, LCD_WIDTH, 1, &DEFAULT_FONT);
@@ -68,19 +68,19 @@ void PAGE_EditCurvesInit(int page)
     u8 y = space;
 
     if (type >= CURVE_3POINT) {
-        GUI_CreateLabelBox(&gui->smoothlbl, LABEL_X, y, LABEL1_W, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Smooth"));
+        GUI_CreateLabelBox(&gui->smoothlbl, LABEL_X, y, LABEL1_W, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Smooth"));
         GUI_CreateTextSelectPlate(&gui->smooth, TEXTSEL1_X, y, TEXTSEL1_W, LINE_HEIGHT, &TEXTSEL_FONT, NULL, set_smooth_cb, NULL);
         y += space;
-        GUI_CreateLabelBox(&gui->pointlbl, LABEL_X, y , LABEL2_W, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Point"));
+        GUI_CreateLabelBox(&gui->pointlbl, LABEL_X, y , LABEL2_W, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Point"));
         GUI_CreateTextSelectPlate(&gui->point, TEXTSEL2_X, y, TEXTSEL2_W, LINE_HEIGHT, &TEXTSEL_FONT, NULL, set_pointnum_cb, NULL);
     } else if(type == CURVE_DEADBAND || type == CURVE_EXPO) {
-        GUI_CreateLabelBox(&gui->pointlbl, LABEL_X, y , LABEL_W, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Pos/Neg"));
+        GUI_CreateLabelBox(&gui->pointlbl, LABEL_X, y , LABEL_W, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Pos/Neg"));
         y += space;
         GUI_CreateTextSelectPlate(&gui->point, LABEL_X, y, LABEL_W, LINE_HEIGHT, &TEXTSEL_FONT, NULL, set_expopoint_cb, NULL);
     }
 
     y += space;
-    GUI_CreateLabelBox(&gui->valuelbl, LABEL_X, y , LABEL_W, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Value"));
+    GUI_CreateLabelBox(&gui->valuelbl, LABEL_X, y , LABEL_W, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Value"));
     y += VALUE_Y_OFFSET;
     GUI_CreateTextSelectPlate(&gui->value, VALUE_X, y, LABEL_W, LINE_HEIGHT, &TEXTSEL_FONT, NULL, set_value_cb, NULL);
 

--- a/src/pages/128x64x1/advanced/mixer_limits.c
+++ b/src/pages/128x64x1/advanced/mixer_limits.c
@@ -80,7 +80,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
             disp = set_limits_cb; value = &mp->limit->min;
             break;
         case ITEM_MAXLIMIT:
-            label = _tr_noop("Max Limit");        
+            label = _tr_noop("Max Limit");
             disp = set_limits_cb; value = &mp->limit->max;
             break;
         case ITEM_SCALEPOS:

--- a/src/pages/128x64x1/advanced/mixer_limits.c
+++ b/src/pages/128x64x1/advanced/mixer_limits.c
@@ -39,7 +39,7 @@ static void _show_titlerow()
 
     GUI_CreateLabelBox(&gui->title, TITLE_X, 0 , TITLE_W, HEADER_HEIGHT, &TITLE_FONT,
             MIXPAGE_ChanNameProtoCB, NULL, (void *)(long)mp->channel);
-    GUI_CreateButtonPlateText(&gui->revert, REVERT_X, 0, REVERT_W, HEADER_WIDGET_HEIGHT, &BUTTON_FONT, NULL, revert_cb, (void *)_tr("Revert"));
+    GUI_CreateButtonPlateText(&gui->revert, REVERT_X, 0, REVERT_W, HEADER_WIDGET_HEIGHT, &BUTTON_FONT, GUI_Localize, revert_cb, _tr_noop("Revert"));
 }
 
 static guiObject_t *getobj_cb(int relrow, int col, void *data)
@@ -53,34 +53,34 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 {
     (void)data;
     void * tgl = NULL;
-    void * label_cb = NULL;
+    void * label_cb = GUI_Localize;
     const void * label = NULL;
     void * disp = NULL;
     void * input_disp = NULL;
     void * value = NULL;
     switch(absrow) {
         case ITEM_REVERSE:
-            label = _tr("Reverse");
+            label = _tr_noop("Reverse");
             tgl = toggle_reverse_cb; disp = reverse_cb; value = (void *)((long)mp->channel);
             break;
         case ITEM_FAILSAFE:
-            label = _tr("Fail-safe");
+            label = _tr_noop("Fail-safe");
             tgl = toggle_failsafe_cb; disp = set_failsafe_cb;
             break;
         case ITEM_SAFETY:
-            label = _tr("Safety");
+            label = _tr_noop("Safety");
             tgl = sourceselect_cb; disp = set_source_cb; value = &mp->limit->safetysw; input_disp = set_input_source_cb;
             break;
         case ITEM_SAFEVAL:
-            label = _tr("Safe Val");
+            label = _tr_noop("Safe Val");
             disp = set_safeval_cb;
             break;
         case ITEM_MINLIMIT:
-            label = _tr("Min Limit");
+            label = _tr_noop("Min Limit");
             disp = set_limits_cb; value = &mp->limit->min;
             break;
         case ITEM_MAXLIMIT:
-            label = _tr("Max Limit");        
+            label = _tr_noop("Max Limit");        
             disp = set_limits_cb; value = &mp->limit->max;
             break;
         case ITEM_SCALEPOS:
@@ -92,11 +92,11 @@ static int row_cb(int absrow, int relrow, int y, void *data)
             disp = set_limitsscale_cb; value = &mp->limit->servoscale_neg;
             break;
         case ITEM_SUBTRIM:
-            label = _tr("Subtrim");
+            label = _tr_noop("Subtrim");
             disp = set_trimstep_cb; value = &mp->limit->subtrim;
             break;
         case ITEM_SPEED:
-            label = _tr("Speed");
+            label = _tr_noop("Speed");
             disp = set_limits_cb; value = &mp->limit->speed;
             break;
     }

--- a/src/pages/128x64x1/advanced/mixer_setup.c
+++ b/src/pages/128x64x1/advanced/mixer_setup.c
@@ -51,7 +51,7 @@ static void _show_titlerow()
     GUI_CreateLabelBox(&gui->chan, LABEL_X, 0 , TYPE_X - LABEL_X, HEADER_HEIGHT, &TITLE_FONT,
             MIXPAGE_ChanNameProtoCB, NULL, (void *)((long)mp->cur_mixer->dest));
     GUI_CreateTextSelectPlate(&gui->tmpl, TYPE_X, 0,  TYPE_W, HEADER_WIDGET_HEIGHT, &TEXTSEL_FONT, NULL, templatetype_cb, (void *)((long)mp->channel));
-    GUI_CreateButtonPlateText(&gui->save, SAVE_X, 0, SAVE_W, HEADER_WIDGET_HEIGHT, &BUTTON_FONT, NULL, okcancel_cb, (void *)_tr("Save"));
+    GUI_CreateButtonPlateText(&gui->save, SAVE_X, 0, SAVE_W, HEADER_WIDGET_HEIGHT, &BUTTON_FONT, GUI_Localize, okcancel_cb, _tr_noop("Save"));
 }
 
 static guiObject_t *simple_getobj_cb(int relrow, int col, void *data)
@@ -91,7 +91,7 @@ static int simple_row_cb(int absrow, int relrow, int y, void *data)
             value = set_number100_cb; data = &mp->mixer[0].offset;
             break;
     }
-    GUI_CreateLabelBox(&gui->label[relrow].lbl, LABEL_X, y, LABEL_W, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr(label));
+    GUI_CreateLabelBox(&gui->label[relrow].lbl, LABEL_X, y, LABEL_W, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop(label));
     GUI_CreateTextSourcePlate(&gui->value[relrow].ts, TEXTSEL_X, y + (LINES_PER_ROW - 1) * LINE_SPACE,
                          TEXTSEL_W, LINE_HEIGHT, &TEXTSEL_FONT,
                          tgl, value, input_value, data);
@@ -171,7 +171,7 @@ static int complex_row_cb(int absrow, int relrow, int y, void *data)
             break;
     }
     GUI_CreateLabelBox(&gui->label[relrow].lbl, LABEL_X, y, LABEL_W, LINE_HEIGHT,
-            &LABEL_FONT, NULL, NULL, _tr(label));
+            &LABEL_FONT, GUI_Localize, NULL, label);
     GUI_CreateTextSourcePlate(&gui->value[relrow].ts, TEXTSEL_X, y + (LINES_PER_ROW - 1) * LINE_SPACE,
                          TEXTSEL_W, LINE_HEIGHT, &TEXTSEL_FONT, tgl, value, input_value, data);
     if (absrow + COMMON_LAST == COMPLEX_SRC)
@@ -248,7 +248,7 @@ static int expo_row_cb(int absrow, int relrow, int y, void *data)
 {
     const char *label = NULL;
     int underline = 0;
-    void * label_cb = NULL;
+    void * label_cb = GUI_Localize;
     void *tgl = NULL;
     void *value = NULL;
     void *input_value = NULL;
@@ -262,21 +262,21 @@ static int expo_row_cb(int absrow, int relrow, int y, void *data)
 
     switch(absrow) {
         case COMMON_SRC:
-            label = _tr("Src");
+            label = _tr_noop("Src");
             tgl = sourceselect_cb; value = set_source_cb; data = &mp->mixer[0].src; input_value = set_input_source_cb;
             break;
         case COMMON_CURVE:
-            label = _tr("High-Rate");
+            label = _tr_noop("High-Rate");
             tgl = curveselect_cb; value = set_curvename_cb; data = &mp->mixer[0];
             break;
         case COMMON_SCALE:
-            label = (void *)0; label_cb = scalestring_cb;
+            label = NULL; label_cb = scalestring_cb;
             value = set_number100_cb; data = &mp->mixer[0].scalar;
             break;
         case EXPO_SWITCH1:
         case EXPO_SWITCH2:
             idx = (absrow == EXPO_SWITCH1) ? 1 : 2;
-            label = idx == 1 ? _tr("Switch1") : _tr("Switch2");
+            label = idx == 1 ? _tr_noop("Switch1") : _tr_noop("Switch2");
             underline = UNDERLINE;
             tgl = sourceselect_cb; value = set_drsource_cb; data = &mp->mixer[idx].sw; input_value = set_input_source_cb;
             break;

--- a/src/pages/128x64x1/datalog_page.c
+++ b/src/pages/128x64x1/datalog_page.c
@@ -83,7 +83,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 {
     (void)data;
     const void *lbl_data = NULL;
-    void *lbl_cb = NULL;
+    void *lbl_cb = GUI_Localize;
     void *but_press = NULL;
     const void *but_data = NULL;
     void *but_txt = NULL;
@@ -93,16 +93,16 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     void *selpress_cb = NULL;
 
     if (absrow == DL_ENABLE) {
-        lbl_cb = NULL; lbl_data = _tr("Enable");
+        lbl_data = _tr_noop("Enable");
         sel_cb = sourcesel_cb; sel_data = NULL; sel_input_cb = sourcesel_input_cb;
     } else if (absrow == DL_RESET) {
         lbl_data = NULL;
         but_press = reset_press_cb; but_txt = reset_str_cb;
     } else if (absrow == DL_RATE) {
-        lbl_cb = NULL; lbl_data = _tr("Rate");
+        lbl_data = _tr_noop("Rate");
         sel_cb = ratesel_cb; sel_data = NULL;
     } else if (absrow == DL_SELECT) {
-        lbl_cb = NULL; lbl_data = _tr("Select");
+        lbl_data = _tr_noop("Select");
         selpress_cb = select_press_cb; sel_cb = select_cb; sel_data = NULL;
     } else {
         long row = absrow-DL_SOURCE;

--- a/src/pages/128x64x1/model_config.c
+++ b/src/pages/128x64x1/model_config.c
@@ -54,36 +54,36 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     void *tgl = NULL;
     switch(absrow) {
         case ITEM_SWASHTYPE:
-            label = _tr("SwashType");
+            label = _tr_noop("SwashType");
             value = swash_val_cb;
             break;
         case ITEM_ELEINV:
-            label = _tr("ELE Inv");
+            label = _tr_noop("ELE Inv");
             tgl = swashinv_press_cb; value = swashinv_val_cb; data = (void *)1L;
             break;
         case ITEM_AILINV:
-            label = _tr("AIL Inv");
+            label = _tr_noop("AIL Inv");
             tgl = swashinv_press_cb; value = swashinv_val_cb; data = (void *)2L;
             break;
         case ITEM_COLINV:
-            label = _tr("COL Inv");
+            label = _tr_noop("COL Inv");
             tgl = swashinv_press_cb; value = swashinv_val_cb; data = (void *)4L;
             break;
         case ITEM_ELEMIX:
-            label = _tr("ELE Mix");
+            label = _tr_noop("ELE Mix");
             value = swashmix_val_cb; data = (void *)1L;
             break;
         case ITEM_AILMIX:
-            label = _tr("AIL Mix");
+            label = _tr_noop("AIL Mix");
             value = swashmix_val_cb; data = (void *)0L;
             break;
         case ITEM_COLMIX:
-            label = _tr("COL Mix");
+            label = _tr_noop("COL Mix");
             value = swashmix_val_cb; data = (void *)2L;
             break;
     }
     GUI_CreateLabelBox(&gui->label[relrow], LABEL_X, y,
-                LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, label);
+                LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, label);
     GUI_CreateTextSelectPlate(&gui->value[relrow], SELECT_X, y,
                 SELECT_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT, tgl, value, data);
     return 1;
@@ -118,7 +118,7 @@ static int row2_cb(int absrow, int relrow, int y, void *data)
         idx++;
     }
     GUI_CreateLabelBox(&gui->label[relrow], LABEL_X, y,
-            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr(proto_strs[pos]));
+            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, proto_strs[pos]);
     GUI_CreateTextSelectPlate(&gui->value[relrow], SELECT_X, y,
             SELECT_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT, NULL, proto_opt_cb, (void *)(long)absrow);
     return 1;
@@ -132,7 +132,7 @@ static int row3_cb(int absrow, int relrow, int y, void *data)
     void *ts_press = NULL;
     void *ts_data = NULL;
     char *label = NULL;
-    void *label_cmd = NULL;
+    void *label_cmd = GUI_Localize;
 
     switch (absrow) {
     case 0:
@@ -158,7 +158,7 @@ static int row3_cb(int absrow, int relrow, int y, void *data)
         break;
     }
     GUI_CreateLabelBox(&gui->label[relrow], LABEL_X, y,
-            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, label_cmd, NULL, label_cmd ? label : _tr(label));
+            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, label_cmd, NULL, label);
     GUI_CreateTextSourcePlate(&gui->value[relrow], SELECT_X, y,
             SELECT_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT, ts_press, ts, input_ts, ts_data);
     return 1;
@@ -193,7 +193,7 @@ static int row4_cb(int absrow, int relrow, int y, void *data)
         break;
     }
     GUI_CreateLabelBox(&gui->label[relrow], LABEL_X, y,
-            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr(label));
+            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, label);
     GUI_CreateTextSourcePlate(&gui->value[relrow], SELECT_X, y,
             SELECT_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT, ts_press, ts, input_ts, ts_data);
     return 1;

--- a/src/pages/128x64x1/model_page.c
+++ b/src/pages/128x64x1/model_page.c
@@ -132,7 +132,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     }
     if (label)
         GUI_CreateLabelBox(&gui->col1[relrow].label, LABEL_X, y,
-           LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr(label));
+           LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, label);
     if (ts_value) {
         GUI_CreateTextSelectPlate(but_txt ? &gui->col1[relrow].ts : &gui->col2[relrow].ts, ts_x, y,
             TEXTSEL_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT, ts_tgl, ts_value, NULL);

--- a/src/pages/128x64x1/standard/throhold_page.c
+++ b/src/pages/128x64x1/standard/throhold_page.c
@@ -38,11 +38,11 @@ void PAGE_ThroHoldInit(int page)
     PAGE_ShowHeader(_tr("Throttle hold"));
 
     u8 y = HEADER_HEIGHT + HEADER_OFFSET;
-    GUI_CreateLabelBox(&gui->enlbl, LABEL_X, y, LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Thr hold"));
+    GUI_CreateLabelBox(&gui->enlbl, LABEL_X, y, LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Thr hold"));
     GUI_CreateTextSelectPlate(&gui->en, FIELD_X, y, FIELD_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT, NULL, throhold_cb,  NULL);
 
     y += LINE_SPACE;
-    GUI_CreateLabelBox(&gui->valuelbl, LABEL_X, y, LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Hold position"));
+    GUI_CreateLabelBox(&gui->valuelbl, LABEL_X, y, LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Hold position"));
     GUI_CreateTextSelectPlate(&gui->value, FIELD_X, y, FIELD_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT, NULL, holdpostion_cb,  NULL);
 
     GUI_Select1stSelectableObj();

--- a/src/pages/128x64x1/standard/traveladj_page.c
+++ b/src/pages/128x64x1/standard/traveladj_page.c
@@ -58,8 +58,8 @@ void PAGE_TravelAdjInit(int page)
 {
     (void)page;
     PAGE_ShowHeader(("")); // draw a underline only
-    GUI_CreateLabelBox(&gui->dnlbl, HEADER1_X, 0, HEADER1_WIDTH, LINE_HEIGHT, &TITLE_FONT, NULL, NULL, _tr("Down"));
-    GUI_CreateLabelBox(&gui->uplbl, HEADER2_X, 0, HEADER2_WIDTH, LINE_HEIGHT, &TITLE_FONT, NULL, NULL, _tr("Up"));
+    GUI_CreateLabelBox(&gui->dnlbl, HEADER1_X, 0, HEADER1_WIDTH, LINE_HEIGHT, &TITLE_FONT, GUI_Localize, NULL, _tr_noop("Down"));
+    GUI_CreateLabelBox(&gui->uplbl, HEADER2_X, 0, HEADER2_WIDTH, LINE_HEIGHT, &TITLE_FONT, GUI_Localize, NULL, _tr_noop("Up"));
 
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,
                          LINE_SPACE, Model.num_channels, row_cb, NULL, NULL, NULL);

--- a/src/pages/128x64x1/timer_page.c
+++ b/src/pages/128x64x1/timer_page.c
@@ -59,13 +59,13 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     y += space;
     /*prem-timer reset */
     GUI_CreateLabelBox(&gui->resetpermlbl, LABEL_X, y,
-            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Reset"));
+            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Reset"));
     GUI_CreateButtonPlateText(&gui->resetperm, RESET_X, y,
             RESET_WIDTH, LINE_HEIGHT, &BUTTON_FONT, show_timerperm_cb, reset_timerperm_cb,(void *)(long)absrow);
     if(Model.mixer_mode != MIXER_STANDARD) {
         /* or Reset switch */
     	GUI_CreateLabelBox(&gui->resetlbl, LABEL_X, y,
-            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Reset sw"));
+            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Reset sw"));
     	GUI_CreateTextSourcePlate(&gui->resetsrc, TEXTSEL_X, y ,
             TEXTSEL_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT, toggle_resetsrc_cb, set_resetsrc_cb, set_input_rstsrc_cb, (void *)(long)absrow);
 	y += space;
@@ -73,7 +73,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     //Row 4
     GUI_CreateLabelBox(&gui->startlbl, LABEL_X, y,
             START_WIDTH, // bug fix: label width and height can't be 0, otherwise, the label couldn't be hidden dynamically
-            LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Start"));
+            LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Start"));
     GUI_CreateTextSelectPlate(&gui->start, TEXTSEL_X, y,
             TEXTSEL_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT, NULL, set_start_cb, (void *)(long)absrow);
 // don't include this in Devo7e due to memory restrictions

--- a/src/pages/128x64x1/toggle_select.c
+++ b/src/pages/128x64x1/toggle_select.c
@@ -81,7 +81,7 @@ static void show_iconsel_page(int SelectedIcon) {
 
     //Header
     PAGE_ShowHeader(INPUT_SourceNameAbbrevSwitch(tempstring, toggleinput));
-    GUI_CreateButtonPlateText(&gui->revert, REVERT_X, 0, REVERT_W, HEADER_WIDGET_HEIGHT, &BUTTON_FONT, NULL, revert_cb, (void *)_tr("Revert"));
+    GUI_CreateButtonPlateText(&gui->revert, REVERT_X, 0, REVERT_W, HEADER_WIDGET_HEIGHT, &BUTTON_FONT, GUI_Localize, revert_cb, _tr_noop("Revert"));
 
 #if SEPARATOR
     GUI_CreateRect(&gui->separator, SEPARATOR_X, HEADER_WIDGET_HEIGHT, 1, LCD_HEIGHT-HEADER_HEIGHT, &DEFAULT_FONT);

--- a/src/pages/128x64x1/trim_page.c
+++ b/src/pages/128x64x1/trim_page.c
@@ -67,10 +67,10 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 static void _show_page()
 {
     //PAGE_ShowHeader(_tr("Trim")); // no title for devo10
-    GUI_CreateLabelBox(&gui->inputlbl, 0, 0, TEXTSEL_X, HEADER_HEIGHT, &TITLE_FONT, NULL, NULL, _tr("Input"));
-    GUI_CreateLabelBox(&gui->steplbl, TEXTSEL_X, STEP_Y, TRIMPOS_X - TEXTSEL_X, LINE_HEIGHT, &TITLE_FONT, NULL, NULL, _tr("Step"));
+    GUI_CreateLabelBox(&gui->inputlbl, 0, 0, TEXTSEL_X, HEADER_HEIGHT, &TITLE_FONT, GUI_Localize, NULL, _tr_noop("Input"));
+    GUI_CreateLabelBox(&gui->steplbl, TEXTSEL_X, STEP_Y, TRIMPOS_X - TEXTSEL_X, LINE_HEIGHT, &TITLE_FONT, GUI_Localize, NULL, _tr_noop("Step"));
     // no enought space in Devo10, so just display trim + in the 1st page
-    GUI_CreateLabelBox(&gui->trimposlbl, TRIMPOS_X, STEP_Y, LCD_WIDTH - TRIMPOS_X, LINE_HEIGHT, &TITLE_FONT, NULL, NULL, _tr("Trim +"));
+    GUI_CreateLabelBox(&gui->trimposlbl, TRIMPOS_X, STEP_Y, LCD_WIDTH - TRIMPOS_X, LINE_HEIGHT, &TITLE_FONT, GUI_Localize, NULL, _tr_noop("Trim +"));
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,
                          LINE_SPACE, NUM_TRIMS, row_cb, getobj_cb, NULL, NULL);
     PAGE_SetScrollable(&gui->scrollable, &current_selected);
@@ -121,7 +121,7 @@ static int row2_cb(int absrow, int relrow, int y, void *data)
             break;
     }
     GUI_CreateLabelBox(&guit->label[relrow], LABEL2_X, y, LABEL2_WIDTH, LINE_HEIGHT,
-            &LABEL_FONT, NULL, NULL, _tr(label));
+            &LABEL_FONT, GUI_Localize, NULL, label);
     GUI_CreateTextSourcePlate(&guit->value[relrow], TEXTSEL2_X, y,
             TEXTSEL2_WIDTH, LINE_HEIGHT, &TEXTSEL_FONT,  NULL, value, input_value, data);
     return 1;
@@ -132,9 +132,9 @@ void PAGE_TrimEditInit(int page)
     struct Trim *trim = MIXER_GetAllTrims();
     tp->index = page;
     tp->trim = trim[tp->index];
-    GUI_CreateLabelBox(&guit->header, 0, 0, LABEL2_WIDTH, HEADER_HEIGHT, &TITLE_FONT, NULL, NULL, _tr("Edit"));
+    GUI_CreateLabelBox(&guit->header, 0, 0, LABEL2_WIDTH, HEADER_HEIGHT, &TITLE_FONT, GUI_Localize, NULL, _tr_noop("Edit"));
     GUI_CreateButtonPlateText(&guit->save, BUTTON2_X, BUTTON2_Y, BUTTON2_WIDTH, LINE_HEIGHT,
-            &BUTTON_FONT, NULL, okcancel_cb, (void *)_tr("Save"));
+            &BUTTON_FONT, GUI_Localize, okcancel_cb, _tr_noop("Save"));
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,
                          LINE_SPACE, ITEM_LAST, row2_cb, getobj2_cb, NULL, NULL);
     GUI_SetSelected(GUI_ShowScrollableRowOffset(&gui->scrollable, 0));

--- a/src/pages/128x64x1/tx_configure.c
+++ b/src/pages/128x64x1/tx_configure.c
@@ -193,11 +193,11 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     }
     if (title) {
         GUI_CreateLabelBox(&gui->title[relrow], TITLE_X_OFFSET, y,
-                TITLE_WIDTH, LINE_HEIGHT, &SECTION_FONT, NULL, NULL, _tr(title));
+                TITLE_WIDTH, LINE_HEIGHT, &SECTION_FONT, GUI_Localize, NULL, title);
         y += LINE_SPACE;
     }
     GUI_CreateLabelBox(&gui->label[relrow], LABEL_X_OFFSET, y,
-            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, NULL, NULL, _tr(label));
+            LABEL_WIDTH, LINE_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, label);
     if(but_str) {
         GUI_CreateButtonPlateText(&gui->value[relrow].but, x, y,
             TEXTSEL_X_WIDTH, LINE_HEIGHT, &BUTTON_FONT, but_str, tgl, data);

--- a/src/pages/128x64x1/voiceconfig_page.c
+++ b/src/pages/128x64x1/voiceconfig_page.c
@@ -56,8 +56,8 @@ void PAGE_VoiceconfigInit(int page)
 {
     (void)page;
     if ( !AUDIO_VoiceAvailable() ) {
-        GUI_CreateLabelBox(&gui->msg, MSG_X, MSG_Y, 0, 0, &LABEL_FONT, NULL, NULL,
-            _tr("External voice\ncurrently not\navailable"));
+        GUI_CreateLabelBox(&gui->msg, MSG_X, MSG_Y, 0, 0, &LABEL_FONT, GUI_Localize, NULL,
+            _tr_noop("External voice\ncurrently not\navailable"));
         return;
     }
     PAGE_ShowHeader(PAGE_GetName(PAGEID_VOICECFG));

--- a/src/pages/320x240x16/advanced/mixer_curves.c
+++ b/src/pages/320x240x16/advanced/mixer_curves.c
@@ -38,17 +38,17 @@ void PAGE_EditCurvesInit(int page)
     PAGE_CreateOkButton(LCD_WIDTH-56, 4, okcancel_cb);
     int y = 40;
     if (type >= CURVE_3POINT) {
-        GUI_CreateLabelBox(&gui->smoothlbl, 8, y, 96, 0, &LABEL_FONT, NULL, NULL, _tr("Smooth"));
+        GUI_CreateLabelBox(&gui->smoothlbl, 8, y, 96, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Smooth"));
         GUI_CreateTextSelect(&gui->smooth, 8, y+16, TEXTSELECT_96, NULL, set_smooth_cb, NULL);
         y += 40;
-        GUI_CreateLabelBox(&gui->pointlbl, 8, y, 96, 0, &LABEL_FONT, NULL, NULL, _tr("Point"));
+        GUI_CreateLabelBox(&gui->pointlbl, 8, y, 96, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Point"));
         GUI_CreateTextSelect(&gui->point, 8, y+16, TEXTSELECT_96, NULL, set_pointnum_cb, NULL);
     } else if(type == CURVE_DEADBAND || type == CURVE_EXPO) {
-        GUI_CreateLabelBox(&gui->pointlbl, 8, y, 96, 0, &LABEL_FONT, NULL, NULL, _tr("Pos/Neg"));
+        GUI_CreateLabelBox(&gui->pointlbl, 8, y, 96, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Pos/Neg"));
         GUI_CreateTextSelect(&gui->point, 8, y+16, TEXTSELECT_96, NULL, set_expopoint_cb, NULL);
     }
     y += 40;
-    GUI_CreateLabelBox(&gui->valuelbl, 8, y, 96, 0, &LABEL_FONT, NULL, NULL, _tr("Value"));
+    GUI_CreateLabelBox(&gui->valuelbl, 8, y, 96, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Value"));
     GUI_CreateTextSelect(&gui->value, 8, y+16, TEXTSELECT_96, NULL, set_value_cb, NULL);
     GUI_CreateXYGraph(&gui->graph, LCD_WIDTH-208-ADDITIONAL_H, 36, 200+ADDITIONAL_H, 200+ADDITIONAL_H,
                               CHAN_MIN_VALUE, CHAN_MIN_VALUE,

--- a/src/pages/320x240x16/advanced/mixer_limits.c
+++ b/src/pages/320x240x16/advanced/mixer_limits.c
@@ -30,27 +30,27 @@ static void _show_limits()
     int y = ROW1;
     int height = 20;
     //Row 1
-    GUI_CreateLabelBox(&gui->reverselbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Reverse"));
+    GUI_CreateLabelBox(&gui->reverselbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Reverse"));
     GUI_CreateTextSelect(&gui->reverse, COL2, y, TEXTSELECT_96, toggle_reverse_cb, reverse_cb, (void *)((long)mp->channel));
     y += height;
     //Row 2
-    GUI_CreateLabelBox(&gui->failsafelbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Fail-safe"));
+    GUI_CreateLabelBox(&gui->failsafelbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Fail-safe"));
     GUI_CreateTextSelect(&gui->failsafe, COL2, y, TEXTSELECT_96, toggle_failsafe_cb, set_failsafe_cb, NULL);
     y += height;
     //Row 3
-    GUI_CreateLabelBox(&gui->safetylbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Safety"));
+    GUI_CreateLabelBox(&gui->safetylbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Safety"));
     GUI_CreateTextSource(&gui->safety, COL2, y, TEXTSELECT_96, sourceselect_cb, set_source_cb, set_input_source_cb, &mp->limit->safetysw);
     y += height;
     //Row 4
-    GUI_CreateLabelBox(&gui->safevallbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Safe Val"));
+    GUI_CreateLabelBox(&gui->safevallbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Safe Val"));
     GUI_CreateTextSelect(&gui->safeval, COL2, y, TEXTSELECT_96, NULL, set_safeval_cb, NULL);
     y += height;
     //Row 5
-    GUI_CreateLabelBox(&gui->minlbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Min Limit"));
+    GUI_CreateLabelBox(&gui->minlbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Min Limit"));
     GUI_CreateTextSelect(&gui->min, COL2, y, TEXTSELECT_96, NULL, set_limits_cb, &mp->limit->min);
     y += height;
     //Row 6
-    GUI_CreateLabelBox(&gui->maxlbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Max Limit"));
+    GUI_CreateLabelBox(&gui->maxlbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Max Limit"));
     GUI_CreateTextSelect(&gui->max, COL2, y, TEXTSELECT_96, NULL, set_limits_cb, &mp->limit->max);
     y += height;
     //Row 5
@@ -61,19 +61,12 @@ static void _show_limits()
     GUI_CreateTextSelect(&gui->scale, COL2, y, TEXTSELECT_96, NULL, set_limitsscale_cb, &mp->limit->servoscale);
     y += height;
     //Row 6
-    GUI_CreateLabelBox(&gui->subtrimlbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Subtrim"));
+    GUI_CreateLabelBox(&gui->subtrimlbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Subtrim"));
     GUI_CreateTextSelect(&gui->subtrim, COL2, y, TEXTSELECT_96, NULL, set_trimstep_cb, &mp->limit->subtrim);
     y += height;
     //Row 7
-    GUI_CreateLabelBox(&gui->speedlbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Speed"));
+    GUI_CreateLabelBox(&gui->speedlbl, COL1, y, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Speed"));
     GUI_CreateTextSelect(&gui->speed, COL2, y, TEXTSELECT_96, NULL, set_limits_cb, &mp->limit->speed);
-}
-
-static const char * revert_str_cb(guiObject_t *obj, const void *data)
-{
-    (void)obj;
-    (void)data;
-    return _tr("Revert");
 }
 
 static void _show_titlerow()
@@ -85,7 +78,7 @@ static void _show_titlerow()
     };
     PAGE_ShowHeader(NULL);
     GUI_CreateLabelBox(&gui->title, TITLE_X, 10, TITLE_WIDTH, 12, &TITLE_FONT, MIXPAGE_ChanNameProtoCB, NULL, (void *)(long)mp->channel);
-    GUI_CreateButton(&gui->revert, BUTTON_X, 4, BUTTON_96, revert_str_cb, revert_cb, NULL);
+    GUI_CreateButton(&gui->revert, BUTTON_X, 4, BUTTON_96, GUI_Localize, revert_cb, _tr_noop("Revert"));
 }
 
 static inline guiObject_t *_get_obj(int idx, int objid) {

--- a/src/pages/320x240x16/advanced/mixer_setup.c
+++ b/src/pages/320x240x16/advanced/mixer_setup.c
@@ -56,11 +56,11 @@ static void _show_simple()
     const int space = 40;
     int y = 60;
     //Row 1
-    mp->firstObj = GUI_CreateLabelBox(&gui1->srclbl, COL1_TEXT, y, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Src"));
+    mp->firstObj = GUI_CreateLabelBox(&gui1->srclbl, COL1_TEXT, y, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Src"));
     GUI_CreateTextSource(&gui1->src, COL1_VALUE, y, TEXTSELECT_96, sourceselect_cb, set_source_cb, set_input_source_cb, &mp->mixer[0].src);
     y += space;
     //Row 2
-    GUI_CreateLabelBox(&gui1->curvelbl, COL1_TEXT, y, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Curve"));
+    GUI_CreateLabelBox(&gui1->curvelbl, COL1_TEXT, y, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Curve"));
     GUI_CreateTextSelect(&gui1->curve, COL1_VALUE, y, TEXTSELECT_96, curveselect_cb, set_curvename_cb, &mp->mixer[0]);
     y += space;
 
@@ -73,7 +73,7 @@ static void _show_simple()
     GUI_CreateTextSelect(&gui1->scale, COL1_VALUE, y, TEXTSELECT_96, NULL, set_number100_cb, &mp->mixer[0].scalar);
     y += space;
     //Row 4
-    GUI_CreateLabelBox(&gui1->offsetlbl, COL1_TEXT, y, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Offset"));
+    GUI_CreateLabelBox(&gui1->offsetlbl, COL1_TEXT, y, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Offset"));
     GUI_CreateTextSelect(&gui1->offset, COL1_VALUE, y, TEXTSELECT_96, NULL, set_number100_cb, &mp->mixer[0].offset);
 }
 
@@ -81,9 +81,9 @@ static void _show_expo_dr()
 {
     sync_mixers();
     //Row 1
-    mp->firstObj = GUI_CreateLabelBox(&gui2->srclbl, COL1_TEXT, 32, 96, 16, &NARROW_FONT, NULL, NULL, _tr("Src"));
-    GUI_CreateLabelBox(&gui2->sw1lbl, COL_EXP2, 32, 96, 16, &NARROW_FONT, NULL, NULL, _tr("Switch1"));
-    GUI_CreateLabelBox(&gui2->sw2lbl, COL_EXP3, 32, 96, 16, &NARROW_FONT, NULL, NULL, _tr("Switch2"));
+    mp->firstObj = GUI_CreateLabelBox(&gui2->srclbl, COL1_TEXT, 32, 96, 16, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Src"));
+    GUI_CreateLabelBox(&gui2->sw1lbl, COL_EXP2, 32, 96, 16, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Switch1"));
+    GUI_CreateLabelBox(&gui2->sw2lbl, COL_EXP3, 32, 96, 16, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Switch2"));
     //Row 2
     GUI_CreateTextSource(&gui2->src, COL1_TEXT, 48, TEXTSELECT_96, sourceselect_cb, set_source_cb,
                          set_input_source_cb, &mp->mixer[0].src);
@@ -92,16 +92,16 @@ static void _show_expo_dr()
     GUI_CreateTextSource(&gui2->sw2, COL_EXP3, 48, TEXTSELECT_96, sourceselect_cb, set_drsource_cb,
                          set_input_source_cb, &mp->mixer[2].sw);
     //Row 3
-    GUI_CreateLabelBox(&gui2->high, COL1_TEXT, 72, 96, 16, &NARROW_FONT, NULL, NULL, _tr("High-Rate"));
+    GUI_CreateLabelBox(&gui2->high, COL1_TEXT, 72, 96, 16, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("High-Rate"));
     GUI_CreateButton(&gui2->rate[0], COL_EXP2, 72, BUTTON_96x16, show_rate_cb, toggle_link_cb, (void *)0);
     GUI_CreateButton(&gui2->rate[1], COL_EXP3, 72, BUTTON_96x16, show_rate_cb, toggle_link_cb, (void *)1);
     //Row 4
     GUI_CreateTextSelect(&gui2->curvehi, COL1_TEXT, 96, TEXTSELECT_96, curveselect_cb, set_curvename_cb, &mp->mixer[0]);
     //The following 2 items are mutex.  One is always hidden
-    GUI_CreateLabelBox(&gui2->linked[0], COL_EXP2, 96, 96, 16, &NARROW_FONT, NULL, NULL, _tr("Linked"));
+    GUI_CreateLabelBox(&gui2->linked[0], COL_EXP2, 96, 96, 16, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Linked"));
     GUI_CreateTextSelect(&gui2->curve[0], COL_EXP2, 96, TEXTSELECT_96, curveselect_cb, set_curvename_cb, &mp->mixer[1]);
     //The following 2 items are mutex.  One is always hidden
-    GUI_CreateLabelBox(&gui2->linked[1], COL_EXP3, 96, 96, 16, &NARROW_FONT, NULL, NULL, _tr("Linked"));
+    GUI_CreateLabelBox(&gui2->linked[1], COL_EXP3, 96, 96, 16, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Linked"));
     GUI_CreateTextSelect(&gui2->curve[1], COL_EXP3, 96, TEXTSELECT_96, curveselect_cb, set_curvename_cb, &mp->mixer[2]);
     //Row 5
     GUI_CreateLabelBox(&gui2->scalelbl, COL1_TEXT, 122, COL_SCALEHI - COL1_TEXT, 0, &LABEL_FONT, scalestring_cb, NULL, (void *)0);
@@ -132,9 +132,9 @@ static void _show_complex(int page_change)
     (void)page_change;
     //Row 1
     if (! mp->firstObj) {
-        mp->firstObj = GUI_CreateLabelBox(&gui3->nummixlbl, COL1_TEXT, 40, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Mixers"));
+        mp->firstObj = GUI_CreateLabelBox(&gui3->nummixlbl, COL1_TEXT, 40, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Mixers"));
         GUI_CreateTextSelect(&gui3->nummix, COL1_VALUE, 40, TEXTSELECT_96, NULL, set_nummixers_cb, NULL);
-        GUI_CreateLabelBox(&gui3->pagelbl, COL2_TEXT, 40, COL2_VALUE - COL2_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Page"));
+        GUI_CreateLabelBox(&gui3->pagelbl, COL2_TEXT, 40, COL2_VALUE - COL2_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Page"));
         guiObject_t *obj = GUI_CreateTextSelect(&gui3->page, COL2_VALUE, 40, TEXTSELECT_96, reorder_cb, set_mixernum_cb, NULL);
         if (! GUI_GetSelected()) //Set the page button to be selected if nothinge else is yet
             GUI_SetSelected(obj);
@@ -142,23 +142,23 @@ static void _show_complex(int page_change)
         GUI_RemoveHierObjects((guiObject_t *)&gui3->swlbl);
     }
     //Row 2
-    GUI_CreateLabelBox(&gui3->swlbl, COL1_TEXT, 64, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Switch"));
+    GUI_CreateLabelBox(&gui3->swlbl, COL1_TEXT, 64, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Switch"));
     GUI_CreateTextSource(&gui3->sw, COL1_VALUE, 64, TEXTSELECT_96, sourceselect_cb, set_drsource_cb,
                          set_input_source_cb, &mp->cur_mixer->sw);
-    GUI_CreateLabelBox(&gui3->muxlbl, COL2_TEXT, 64, COL2_VALUE - COL2_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Mux"));
+    GUI_CreateLabelBox(&gui3->muxlbl, COL2_TEXT, 64, COL2_VALUE - COL2_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Mux"));
     GUI_CreateTextSelect(&gui3->mux, COL2_VALUE, 64, TEXTSELECT_96, NULL, set_mux_cb, NULL);
     //Row 3
-    GUI_CreateLabelBox(&gui3->srclbl, COL1_TEXT, 98, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Src"));
+    GUI_CreateLabelBox(&gui3->srclbl, COL1_TEXT, 98, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Src"));
     GUI_CreateTextSource(&gui3->src, COL1_VALUE, 98, TEXTSELECT_96, sourceselect_cb, set_source_cb,
                          set_input_source_cb, &mp->cur_mixer->src);
     //Row 4
-    GUI_CreateLabelBox(&gui3->curvelbl, COL1_TEXT, 122, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Curve"));
+    GUI_CreateLabelBox(&gui3->curvelbl, COL1_TEXT, 122, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Curve"));
     GUI_CreateTextSelect(&gui3->curve, COL1_VALUE, 122, TEXTSELECT_96, curveselect_cb, set_curvename_cb, mp->cur_mixer);
     //Row 5
     GUI_CreateLabelBox(&gui3->scalelbl, COL1_TEXT, 156, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, scalestring_cb, NULL, (void *)0);
     GUI_CreateTextSelect(&gui3->scale, COL1_VALUE, 156, TEXTSELECT_96, NULL, set_number100_cb, &mp->cur_mixer->scalar);
     //Row 6
-    GUI_CreateLabelBox(&gui3->offsetlbl, COL1_TEXT, 180, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, NULL, NULL, _tr("Offset"));
+    GUI_CreateLabelBox(&gui3->offsetlbl, COL1_TEXT, 180, COL1_VALUE - COL1_TEXT, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Offset"));
     GUI_CreateTextSelect(&gui3->offset, COL1_VALUE, 180, TEXTSELECT_96, NULL, set_number100_cb, &mp->cur_mixer->offset);
     GUI_CreateBarGraph(&gui3->bar, COL2_TEXT, 86, 10, 150,
                               CHAN_MIN_VALUE, CHAN_MAX_VALUE, BAR_VERTICAL,

--- a/src/pages/320x240x16/datalog_page.c
+++ b/src/pages/320x240x16/datalog_page.c
@@ -136,20 +136,20 @@ void PAGE_DatalogInit(int page)
     PAGE_ShowHeader(PAGE_GetName(PAGEID_DATALOG));
 
     //Col1
-    GUI_CreateLabelBox(&gui->enlbl, SCROLLABLE_X, row, 80, 18, &LABEL_FONT, NULL, NULL, _tr("Enable"));
+    GUI_CreateLabelBox(&gui->enlbl, SCROLLABLE_X, row, 80, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Enable"));
     GUI_CreateTextSource(&gui->en, SCROLLABLE_X + 78, row, TEXTSELECT_96, NULL, sourcesel_cb, sourcesel_input_cb, NULL);
     //Col2
     GUI_CreateButton(&gui->reset, SCROLLABLE_X + SCROLLABLE_WIDTH - 64, row, BUTTON_64x16, reset_str_cb, reset_press_cb, NULL);
     row += ROW_HEIGHT;
 
     //col1
-    GUI_CreateLabelBox(&gui->freqlbl, SCROLLABLE_X, row, 80, 18, &LABEL_FONT, NULL, NULL, _tr("Sample Rate"));
+    GUI_CreateLabelBox(&gui->freqlbl, SCROLLABLE_X, row, 80, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Sample Rate"));
     GUI_CreateTextSelect(&gui->freq, SCROLLABLE_X + 78, row, TEXTSELECT_96, NULL, ratesel_cb, NULL);
     //col2
     GUI_CreateLabelBox(&gui->remaining, SCROLLABLE_X + 184, row, SCROLLABLE_WIDTH-200, 18, &DEFAULT_FONT, remaining_str_cb, NULL, NULL);
     row += ROW_HEIGHT;
 
-    GUI_CreateLabelBox(&gui->selectlbl, SCROLLABLE_X, row, 80, 18, &LABEL_FONT, NULL, NULL, _tr("Select"));
+    GUI_CreateLabelBox(&gui->selectlbl, SCROLLABLE_X, row, 80, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Select"));
     GUI_CreateButton(&gui->all, SCROLLABLE_X + SCROLLABLE_WIDTH - 64 - 64 - 10, row, BUTTON_64x16, select_str_cb, select_press_cb, (void *)0L);
     GUI_CreateButton(&gui->none, SCROLLABLE_X + SCROLLABLE_WIDTH - 64, row, BUTTON_64x16, select_str_cb, select_press_cb, (void *)1L);
     row += ROW_HEIGHT;

--- a/src/pages/320x240x16/main_layout.c
+++ b/src/pages/320x240x16/main_layout.c
@@ -237,7 +237,7 @@ static void add_dlg_cb(guiObject_t *obj, const void *data)
         ADD_LBL_X,
         ADD_DIALOG_Y + 30,
         ADD_TS_X - ADD_LBL_X, 0,
-        &LABEL_FONT, NULL, NULL, _tr("Type"));
+        &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Type"));
     GUI_CreateTextSelect(&gui->dlgts[0],
         ADD_TS_X,
         ADD_DIALOG_Y + 30,
@@ -251,7 +251,7 @@ static void add_dlg_cb(guiObject_t *obj, const void *data)
         ADD_LBL_X,
         ADD_DIALOG_Y + 60,
         ADD_BUT_X - ADD_LBL_X, 0,
-        &LABEL_FONT, NULL, NULL, _tr("Template"));
+        &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Template"));
     GUI_CreateButton(&gui->dlgbut[1],
         ADD_BUT_X,
         ADD_DIALOG_Y + 60,
@@ -287,7 +287,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     int del_x = X + 15 + 110;
     int num_objs = 2;
     if (type == ELEM_MODELICO) {
-        GUI_CreateLabelBox(&gui->dlglbl[relrow], X, y, 115, LAYDLG_TEXT_HEIGHT, &LABEL_FONT, NULL, NULL, _tr("Model"));
+        GUI_CreateLabelBox(&gui->dlglbl[relrow], X, y, 115, LAYDLG_TEXT_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Model"));
     } else {
         GUI_CreateLabelBox(&gui->dlglbl[relrow], X, y, 10, 16, &LABEL_FONT, label_cb, NULL, (void *)(long)(absrow));
         GUI_CreateTextSelect(&gui->dlgts[relrow], X + 15, y, TEXTSELECT_96, NULL, dlgts_cb, (void *)elemidx);

--- a/src/pages/320x240x16/model_config.c
+++ b/src/pages/320x240x16/model_config.c
@@ -38,25 +38,25 @@ void PAGE_ModelConfigInit(int page)
     PAGE_ShowHeader(Model.type == 0 ? _tr("Helicopter") : _tr("Airplane"));
     if (Model.type == 0) {
         u8 i = ROW1;
-        GUI_CreateLabelBox(&gui->swashlbl, COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("SwashType"));
+        GUI_CreateLabelBox(&gui->swashlbl, COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("SwashType"));
         GUI_CreateTextSelect(&gui->swash, COL2, i - 1, TEXTSELECT_96, NULL, swash_val_cb, NULL);
         i+=28;
-        GUI_CreateLabelBox(&gui->invlbl[0], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("ELE Inv"));
+        GUI_CreateLabelBox(&gui->invlbl[0], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("ELE Inv"));
         GUI_CreateTextSelect(&gui->inv[0], COL2, i - 1, TEXTSELECT_96, swashinv_press_cb, swashinv_val_cb, (void *)1);
         i+=22;
-        GUI_CreateLabelBox(&gui->invlbl[1], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("AIL Inv"));
+        GUI_CreateLabelBox(&gui->invlbl[1], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("AIL Inv"));
         GUI_CreateTextSelect(&gui->inv[1], COL2, i - 1, TEXTSELECT_96, swashinv_press_cb, swashinv_val_cb, (void *)2);
         i+=22;
-        GUI_CreateLabelBox(&gui->invlbl[2], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("COL Inv"));
+        GUI_CreateLabelBox(&gui->invlbl[2], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("COL Inv"));
         GUI_CreateTextSelect(&gui->inv[2], COL2, i - 1, TEXTSELECT_96, swashinv_press_cb, swashinv_val_cb, (void *)4);
         i+=28;
-        GUI_CreateLabelBox(&gui->mixlbl[0], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("ELE Mix"));
+        GUI_CreateLabelBox(&gui->mixlbl[0], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("ELE Mix"));
         GUI_CreateTextSelect(&gui->mix[0], COL2, i - 1, TEXTSELECT_96, NULL, swashmix_val_cb, (void *)1);
         i+=22;
-        GUI_CreateLabelBox(&gui->mixlbl[1], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("AIL Mix"));
+        GUI_CreateLabelBox(&gui->mixlbl[1], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("AIL Mix"));
         GUI_CreateTextSelect(&gui->mix[1], COL2, i - 1, TEXTSELECT_96, NULL, swashmix_val_cb, (void *)0);
         i+=22;
-        GUI_CreateLabelBox(&gui->mixlbl[2], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("COL Mix"));
+        GUI_CreateLabelBox(&gui->mixlbl[2], COL1, i, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("COL Mix"));
         GUI_CreateTextSelect(&gui->mix[2], COL2, i - 1, TEXTSELECT_96, NULL, swashmix_val_cb, (void *)2);
     }
 }
@@ -72,7 +72,7 @@ void PAGE_ModelProtoInit(int page)
     while(idx < NUM_PROTO_OPTS) {
         if(proto_strs[pos] == NULL)
             break;
-        GUI_CreateLabelBox(&gui->protolbl[idx], COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr(proto_strs[pos]));
+        GUI_CreateLabelBox(&gui->protolbl[idx], COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, proto_strs[pos]);
         GUI_CreateTextSelect(&gui->proto[idx], COL2, row, TEXTSELECT_96, NULL, proto_opt_cb, (void *)idx);
         while(proto_strs[++pos])
             ;
@@ -93,17 +93,17 @@ void PAGE_TrainConfigInit(int page)
                     : _tr("PPMIn Cfg (Extend)"));
     int row = ROW1;
     if (PPMin_Mode() != PPM_IN_SOURCE) {
-        GUI_CreateLabelBox(&gui->trainswlbl, COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Trainer Sw"));
+        GUI_CreateLabelBox(&gui->trainswlbl, COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Trainer Sw"));
         GUI_CreateTextSource(&gui->trainsw, COL2, row, TEXTSELECT_96, sourceselect_cb, set_source_cb, set_input_source_cb, &Model.train_sw);
     } else {
-        GUI_CreateLabelBox(&gui->numchlbl, COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Num Channels"));
+        GUI_CreateLabelBox(&gui->numchlbl, COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Num Channels"));
         GUI_CreateTextSelect(&gui->numch, COL2, row, TEXTSELECT_96, NULL, set_train_cb, (void *)0L);
     }
     row += 20;
-    GUI_CreateLabelBox(&gui->centerpwlbl, COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Center PW"));
+    GUI_CreateLabelBox(&gui->centerpwlbl, COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Center PW"));
     GUI_CreateTextSelect(&gui->centerpw, COL2, row, TEXTSELECT_96, NULL, set_train_cb, (void *)1L);
     row += 20;
-    GUI_CreateLabelBox(&gui->deltapwlbl, COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, NULL, NULL, _tr("Delta PW"));
+    GUI_CreateLabelBox(&gui->deltapwlbl, COL1, row, LABEL_WIDTH, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Delta PW"));
     GUI_CreateTextSelect(&gui->deltapw, COL2, row, TEXTSELECT_96, NULL, set_train_cb, (void *)2L);
     row += 20;
  

--- a/src/pages/320x240x16/model_page.c
+++ b/src/pages/320x240x16/model_page.c
@@ -59,39 +59,39 @@ void PAGE_ModelInit(int page)
         LABEL_WIDTH = (COL2 - COL1),
     };
     row = ROW1;
-    GUI_CreateLabelBox(&gui->filelbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, NULL, NULL, _tr("File"));
+    GUI_CreateLabelBox(&gui->filelbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("File"));
     GUI_CreateTextSelect(&gui->file, COL2, row, TEXTSELECT_96, file_press_cb, file_val_cb, NULL);
 
 #if HAS_STANDARD_GUI
     row+= 20;
-    GUI_CreateLabelBox(&gui->guilbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, NULL, NULL, _tr("Mixer GUI"));
+    GUI_CreateLabelBox(&gui->guilbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Mixer GUI"));
     GUI_CreateTextSelect(&gui->guits, COL2, row, TEXTSELECT_96, NULL, _mixermode_cb, NULL);
 #endif
 
     row += 20;
-    GUI_CreateLabelBox(&gui->namelbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, NULL, NULL, _tr("Model name"));  // use the same naming convention for devo8 and devo10
+    GUI_CreateLabelBox(&gui->namelbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Model name"));  // use the same naming convention for devo8 and devo10
     GUI_CreateButton(&gui->name, COL2, row, BUTTON_96x16, show_text_cb, _changename_cb, Model.name);
     GUI_CreateButton(&gui->icon, COL3, row, BUTTON_64x16, show_text_cb, changeicon_cb, _tr("Icon"));
 
     row += 20;
-    GUI_CreateLabelBox(&gui->typelbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, NULL, NULL, _tr("Model type"));
+    GUI_CreateLabelBox(&gui->typelbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Model type"));
     GUI_CreateTextSelect(&gui->type, COL2, row, TEXTSELECT_96, type_press_cb, type_val_cb, NULL);
 
     row += 24;
-    GUI_CreateLabelBox(&gui->ppmlbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, NULL, NULL, _tr("PPM In"));
+    GUI_CreateLabelBox(&gui->ppmlbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("PPM In"));
     GUI_CreateTextSelect(&gui->ppm, COL2, row, TEXTSELECT_96, ppmin_press_cb, ppmin_select_cb, NULL);
 
     row += 20;
-    GUI_CreateLabelBox(&gui->protolbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, NULL, NULL, _tr("Protocol"));
+    GUI_CreateLabelBox(&gui->protolbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Protocol"));
     GUI_CreateTextSelect(&gui->proto, COL2, row, TEXTSELECT_96, proto_press_cb, protoselect_cb, NULL);
 
     row += 20;
-    GUI_CreateLabelBox(&gui->numchlbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, NULL, NULL, _tr("# Channels"));
+    GUI_CreateLabelBox(&gui->numchlbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("# Channels"));
     GUI_CreateTextSelect(&gui->numch, COL2, row, TEXTSELECT_96, NULL, numchanselect_cb, NULL);
 
 
     row += 24;
-    GUI_CreateLabelBox(&gui->pwrlbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, NULL, NULL, _tr("Tx power"));
+    GUI_CreateLabelBox(&gui->pwrlbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Tx power"));
     GUI_CreateTextSelect(&gui->pwr, COL2, row, TEXTSELECT_96, NULL, powerselect_cb, NULL);
 
     row += 20;
@@ -99,7 +99,7 @@ void PAGE_ModelInit(int page)
         strlcpy(mp->fixed_id, _tr("None"), sizeof(mp->fixed_id));
     else
         sprintf(mp->fixed_id, "%d", (int)Model.fixed_id);
-    GUI_CreateLabelBox(&gui->fixedidlbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, NULL, NULL, _tr("Fixed ID"));
+    GUI_CreateLabelBox(&gui->fixedidlbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Fixed ID"));
     GUI_CreateButton(&gui->fixedid, COL2, row, BUTTON_96x16, show_text_cb, fixedid_cb, mp->fixed_id);
     GUI_CreateButton(&gui->bind, COL3, row, BUTTON_64x16, show_bindtext_cb, bind_cb, NULL);
     configure_bind_button();

--- a/src/pages/320x240x16/set_timer_page.c
+++ b/src/pages/320x240x16/set_timer_page.c
@@ -83,19 +83,19 @@ static void _show_settimer_page(u8 index)
     };
 
     // actual value
-    firstObj = GUI_CreateLabel(&guiset->oldlbl, XLEFT, YOLD, NULL, DEFAULT_FONT, (void *)_tr("actual value"));
+    firstObj = GUI_CreateLabel(&guiset->oldlbl, XLEFT, YOLD, GUI_Localize, DEFAULT_FONT, _tr_noop("actual value"));
     GUI_CreateLabelBox(&guiset->oldvalue, XLEFT, YOLD + 16, 128, 30, &BIGBOX_FONT, timer_value_str_cb, NULL, (void *)OLD_TIMER);
 
     // value to add or set
-    GUI_CreateLabel(&guiset->addlbl, XLEFT, YNEW, NULL, DEFAULT_FONT, (void *)_tr("value to add or set"));
+    GUI_CreateLabel(&guiset->addlbl, XLEFT, YNEW, GUI_Localize, DEFAULT_FONT, _tr_noop("value to add or set"));
     GUI_CreateLabelBox(&guiset->addvalue, XLEFT, YNEW + 16, 128, 30, &BIGBOX_FONT, timer_value_str_cb, NULL, (void *)ADD_TIMER);
 
     // select boxes
-    GUI_CreateLabel(&guiset->hourlbl, XUNIT, YUNIT + 1, NULL, DEFAULT_FONT, (void *)_tr("Hour"));
+    GUI_CreateLabel(&guiset->hourlbl, XUNIT, YUNIT + 1, GUI_Localize, DEFAULT_FONT, _tr_noop("Hour"));
     GUI_CreateTextSelect(&guiset->hoursel, XVAL, YUNIT, TEXTSELECT_64, NULL, _timer_new_str_cb, (void *)TIMER_HOURS);
-    GUI_CreateLabel(&guiset->minutelbl, XUNIT, YUNIT + YDIFF + 1, NULL, DEFAULT_FONT, (void *)_tr("Minute"));
+    GUI_CreateLabel(&guiset->minutelbl, XUNIT, YUNIT + YDIFF + 1, GUI_Localize, DEFAULT_FONT, _tr_noop("Minute"));
     GUI_CreateTextSelect(&guiset->minutesel, XVAL, YUNIT + YDIFF, TEXTSELECT_64, NULL, _timer_new_str_cb, (void *)TIMER_MINUTES);
-    GUI_CreateLabel(&guiset->secondlbl, XUNIT, YUNIT + YDIFF + YDIFF + 1, NULL, DEFAULT_FONT, (void *)_tr("Second"));
+    GUI_CreateLabel(&guiset->secondlbl, XUNIT, YUNIT + YDIFF + YDIFF + 1, GUI_Localize, DEFAULT_FONT, _tr_noop("Second"));
     GUI_CreateTextSelect(&guiset->secondsel, XVAL, YUNIT + YDIFF + YDIFF, TEXTSELECT_64, NULL, _timer_new_str_cb, (void *)TIMER_SECONDS);
 
     // add / set buttons
@@ -103,6 +103,6 @@ static void _show_settimer_page(u8 index)
     GUI_CreateButton(&guiset->setbtn, XSET, YBTN, BUTTON_64x16, timer_value_str_cb, add_set_button_cb, (void *)SET_BUTTON);
 
     // resulting value
-    GUI_CreateLabel(&guiset->newlbl, XLEFT, YRES, NULL, DEFAULT_FONT, (void *)_tr("resulting value"));
+    GUI_CreateLabel(&guiset->newlbl, XLEFT, YRES, GUI_Localize, DEFAULT_FONT, _tr_noop("resulting value"));
     GUI_CreateLabelBox(&guiset->newvalue, XLEFT, YRES + 16, 128, 30, &BIGBOX_FONT, timer_value_str_cb, NULL, (void *)NEW_TIMER);
 }

--- a/src/pages/320x240x16/standard/curves_page.c
+++ b/src/pages/320x240x16/standard/curves_page.c
@@ -122,9 +122,9 @@ static void show_page(CurvesMode _curve_mode, int page)
 
     set_cur_mixer();
     /* Row 1 */
-    GUI_CreateLabelBox(&gui->modelbl, COL_LBL, LINE1, COL_TEXT - COL_LBL, 16, &LABEL_FONT, NULL, NULL, _tr("Mode"));
+    GUI_CreateLabelBox(&gui->modelbl, COL_LBL, LINE1, COL_TEXT - COL_LBL, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Mode"));
     GUI_CreateTextSelect(&gui->mode, COL_TEXT, LINE1-1, TEXTSELECT_128, NULL, set_mode_cb, (void *)(long)curve_mode);
-    GUI_CreateLabelBox(&gui->holdlbl, COL_LBL, LINE2, COL_TEXT - COL_LBL, 16, &LABEL_FONT, NULL, NULL, _tr("Enabled"));
+    GUI_CreateLabelBox(&gui->holdlbl, COL_LBL, LINE2, COL_TEXT - COL_LBL, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Enabled"));
     GUI_CreateTextSelect(&gui->hold, COL_TEXT, LINE2-1, TEXTSELECT_64, NULL, set_holdstate_cb, NULL);
     GUI_CreateLabelBox(&gui->holdsw, COL_SWITCH, LINE2, LCD_WIDTH - COL_SWITCH, 16, &DEFAULT_FONT, holdsw_str_cb, NULL, NULL);
     if (pit_mode != PITTHROMODE_HOLD)

--- a/src/pages/320x240x16/standard/drexp_page.c
+++ b/src/pages/320x240x16/standard/drexp_page.c
@@ -56,7 +56,7 @@ void PAGE_DrExpInit(int page)
         return;
     }
     /* Row 1 */
-    GUI_CreateLabelBox(&gui->srclbl, COL1, ROW1, COL2 - COL1, 16, &LABEL_FONT, NULL, NULL, _tr("Src"));
+    GUI_CreateLabelBox(&gui->srclbl, COL1, ROW1, COL2 - COL1, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Src"));
     GUI_CreateTextSelect(&gui->src, COL2, ROW1, TEXTSELECT_64, NULL, set_type_cb, NULL);
     /* Row 2 */
     GUI_CreateLabelBox(&gui->mode[0], COL3, ROW2, 96, 16, &LABEL_FONT, NULL, NULL, STDMIX_ModeName(PITTHROMODE_NORMAL));

--- a/src/pages/320x240x16/standard/gyrosense_page.c
+++ b/src/pages/320x240x16/standard/gyrosense_page.c
@@ -61,7 +61,7 @@ void PAGE_GyroSenseInit(int page)
     gyro_output = mp->mixer_ptr[0]->dest;
     convert_output_to_percentile();
     /* Row 1 */
-    GUI_CreateLabelBox(&gui->chanlbl, COL1, ROW1, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("Channel"));
+    GUI_CreateLabelBox(&gui->chanlbl, COL1, ROW1, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Channel"));
     GUI_CreateTextSelect(&gui->chan, COL2, ROW1, TEXTSELECT_128, NULL, gyro_output_cb, NULL);
 
     /* Row 2 */

--- a/src/pages/320x240x16/standard/swash_page.c
+++ b/src/pages/320x240x16/standard/swash_page.c
@@ -37,22 +37,22 @@ void PAGE_SwashInit(int page)
     get_swash();
     /* Row 1 */
     int row = 40 + ((LCD_HEIGHT - 240) / 2);
-    GUI_CreateLabelBox(&gui->typelbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("SwashType"));
+    GUI_CreateLabelBox(&gui->typelbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("SwashType"));
     GUI_CreateTextSelect(&gui->type, COL2, row, TEXTSELECT_96, NULL, swash_val_cb, NULL);
 
     /* Row 2 */
     row += ROW_SPACE;
-    GUI_CreateLabelBox(&gui->lbl[0], COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("ELE Mix"));
+    GUI_CreateLabelBox(&gui->lbl[0], COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("ELE Mix"));
     GUI_CreateTextSelect(&gui->mix[0], COL2, row, TEXTSELECT_96, NULL, swashmix_val_cb, (void *)1L);
 
     /* Row 3 */
     row += ROW_SPACE;
-    GUI_CreateLabelBox(&gui->lbl[1], COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("AIL Mix"));
+    GUI_CreateLabelBox(&gui->lbl[1], COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("AIL Mix"));
     GUI_CreateTextSelect(&gui->mix[1], COL2, row, TEXTSELECT_96, NULL, swashmix_val_cb, (void *)0);
 
     /* Row 4 */
     row += ROW_SPACE;
-    GUI_CreateLabelBox(&gui->lbl[2], COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("PIT Mix"));
+    GUI_CreateLabelBox(&gui->lbl[2], COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("PIT Mix"));
     GUI_CreateTextSelect(&gui->mix[2], COL2, row, TEXTSELECT_96, NULL, swashmix_val_cb, (void *)2);
 
     update_swashmixes();

--- a/src/pages/320x240x16/standard/switchassign_page.c
+++ b/src/pages/320x240x16/standard/switchassign_page.c
@@ -43,28 +43,28 @@ void PAGE_SwitchAssignInit(int page)
 
     /* Row 1 */
     int row = 40 + ((LCD_HEIGHT - 240) / 2);
-    GUI_CreateLabelBox(&gui->modelbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("Fly mode"));
+    GUI_CreateLabelBox(&gui->modelbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Fly mode"));
     GUI_CreateTextSelect(&gui->mode, COL2, row, TEXTSELECT_128, NULL, switch_cb2, (void *)(long)SWITCHFUNC_FLYMODE);
 
     /* Row 2 */
     row += ROW_SPACE;
-    GUI_CreateLabelBox(&gui->tholdlbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("Thr hold"));
+    GUI_CreateLabelBox(&gui->tholdlbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Thr hold"));
     GUI_CreateTextSelect(&gui->thold, COL2, row, TEXTSELECT_128, NULL, switch_cb2, (void *)(long)SWITCHFUNC_HOLD);
 
     /* Row 3 */
     row += ROW_SPACE;
-    GUI_CreateLabelBox(&gui->gyrolbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("Gyro sense"));
+    GUI_CreateLabelBox(&gui->gyrolbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Gyro sense"));
     GUI_CreateTextSelect(&gui->gyro, COL2, row, TEXTSELECT_128, NULL, switch_cb2, (void *)(long)SWITCHFUNC_GYROSENSE);
     row += ROW_SPACE;
-    GUI_CreateLabelBox(&gui->draillbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("D/R&Exp -AIL"));
+    GUI_CreateLabelBox(&gui->draillbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("D/R&Exp -AIL"));
     GUI_CreateTextSelect(&gui->drail, COL2, row, TEXTSELECT_128, NULL, switch_cb2, (void *)(long)SWITCHFUNC_DREXP_AIL);
 
     row += ROW_SPACE;
-    GUI_CreateLabelBox(&gui->drelelbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("D/R&Exp -ELE"));
+    GUI_CreateLabelBox(&gui->drelelbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("D/R&Exp -ELE"));
     GUI_CreateTextSelect(&gui->drele, COL2, row, TEXTSELECT_128, NULL, switch_cb2, (void *)(long)SWITCHFUNC_DREXP_ELE);
 
     row += ROW_SPACE;
-    GUI_CreateLabelBox(&gui->drrudlbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL,  _tr("D/R&Exp -RUD"));
+    GUI_CreateLabelBox(&gui->drrudlbl, COL1, row, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL,  _tr_noop("D/R&Exp -RUD"));
     GUI_CreateTextSelect(&gui->drrud, COL2, row, TEXTSELECT_128, NULL, switch_cb2, (void *)(long)SWITCHFUNC_DREXP_RUD);
 }
 #endif //HAS_STANDARD_GUI

--- a/src/pages/320x240x16/standard/throhold_page.c
+++ b/src/pages/320x240x16/standard/throhold_page.c
@@ -46,10 +46,10 @@ void PAGE_ThroHoldInit(int page)
     };
     PAGE_ShowHeader(NULL);
     PAGE_ShowHeader_SetLabel(STDMIX_TitleString, SET_TITLE_DATA(PAGEID_THROHOLD, SWITCHFUNC_HOLD));
-    GUI_CreateLabelBox(&gui->enlbl, COL1, ROW1, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("Thr hold"));
+    GUI_CreateLabelBox(&gui->enlbl, COL1, ROW1, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Thr hold"));
     GUI_CreateTextSelect(&gui->en, COL2, ROW1, TEXTSELECT_128, toggle_thold_cb, throhold_cb,  NULL);
 
-    GUI_CreateLabelBox(&gui->valuelbl, COL1, ROW2, LABEL_WIDTH, 16, &LABEL_FONT, NULL, NULL, _tr("Hold position"));
+    GUI_CreateLabelBox(&gui->valuelbl, COL1, ROW2, LABEL_WIDTH, 16, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Hold position"));
     GUI_CreateTextSelect(&gui->value, COL2, ROW2, TEXTSELECT_128, NULL, holdpostion_cb,  NULL);
 }
 #endif //HAS_STANDARD_GUI

--- a/src/pages/320x240x16/standard/traveladj_page.c
+++ b/src/pages/320x240x16/standard/traveladj_page.c
@@ -65,8 +65,8 @@ void PAGE_TravelAdjInit(int page)
                         : 0;
     mp->firstObj = NULL;
     GUI_CreateScrollbar(&gui->scrollbar, LCD_WIDTH - 16, 32, LCD_HEIGHT-32, mp->max_scroll+1, NULL, STDMIX_ScrollCB, show_page);
-    GUI_CreateLabelBox(&gui->dnlbl, 90 + ((LCD_WIDTH - 320) / 2), 36 + ((LCD_HEIGHT - 240) / 2),  96, 16, &NARROW_FONT, NULL, NULL, _tr("Down"));
-    GUI_CreateLabelBox(&gui->uplbl, 196 + ((LCD_WIDTH - 320) / 2), 36 + ((LCD_HEIGHT - 240) / 2),  96, 16, &NARROW_FONT, NULL, NULL, _tr("Up"));
+    GUI_CreateLabelBox(&gui->dnlbl, 90 + ((LCD_WIDTH - 320) / 2), 36 + ((LCD_HEIGHT - 240) / 2),  96, 16, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Down"));
+    GUI_CreateLabelBox(&gui->uplbl, 196 + ((LCD_WIDTH - 320) / 2), 36 + ((LCD_HEIGHT - 240) / 2),  96, 16, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Up"));
     show_page(page);
 }
 #endif //HAS_STANDARD_GUI

--- a/src/pages/320x240x16/timer_page.c
+++ b/src/pages/320x240x16/timer_page.c
@@ -57,16 +57,16 @@ static int row_cb(int absrow, int relrow, int y, void *data)
         //Row 3
         row+=20;
         /* Reset Perm timer*/
-        GUI_CreateLabelBox(&gui->resetpermlbl[i], COL1, row, COL2-COL1, 18, &LABEL_FONT, NULL, NULL, _tr("Reset"));
+        GUI_CreateLabelBox(&gui->resetpermlbl[i], COL1, row, COL2-COL1, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Reset"));
         GUI_CreateButton(&gui->resetperm[i], COL2, row, BUTTON_96x16, show_timerperm_cb, reset_timerperm_cb, (void *)(long)timer_num);
         if(Model.mixer_mode != MIXER_STANDARD) {
             /* or Reset switch */
-            GUI_CreateLabelBox(&gui->resetlbl[i], COL1, row, COL2-COL1, 18, &LABEL_FONT, NULL, NULL, _tr("Reset sw"));
+            GUI_CreateLabelBox(&gui->resetlbl[i], COL1, row, COL2-COL1, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Reset sw"));
             GUI_CreateTextSource(&gui->resetsrc[i],  COL2, row, TEXTSELECT_96, toggle_resetsrc_cb, set_resetsrc_cb, set_input_rstsrc_cb, (void *)(long)timer_num);
             row+=20;
         }
         //Row 4
-        GUI_CreateLabelBox(&gui->startlbl[i], COL1, row, COL2-COL1, 18, &LABEL_FONT, NULL, NULL, _tr("Start"));
+        GUI_CreateLabelBox(&gui->startlbl[i], COL1, row, COL2-COL1, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Start"));
         GUI_CreateTextSelect(&gui->start[i], COL2, row, TEXTSELECT_96, NULL, set_start_cb, (void *)(long)timer_num);
         if(Model.mixer_mode == MIXER_STANDARD)
             row += 20;

--- a/src/pages/320x240x16/toggle_select.c
+++ b/src/pages/320x240x16/toggle_select.c
@@ -113,17 +113,17 @@ static void show_iconsel_page(int SelectedIcon)
     if(num_positions < 2)
         num_positions = 2;
 
-    GUI_CreateLabelBox(&gui->togglelabel[0], 94, 50, 30, 14, &LABEL_FONT, NULL, NULL, _tr("Pos 0"));
+    GUI_CreateLabelBox(&gui->togglelabel[0], 94, 50, 30, 14, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Pos 0"));
     img = TGLICO_GetImage(Model.pagecfg2.elem[tp->tglidx].extra[0]);
     GUI_CreateImageOffset(&gui->toggleicon[0], 124, 40, TOGGLEICON_WIDTH, TOGGLEICON_HEIGHT, img.x_off, img.y_off, img.file,
              SelectedIcon == 0 ? tglico_reset_cb : tglico_setpos_cb, (void *)0L);
 
-    GUI_CreateLabelBox(&gui->togglelabel[1], 174, 50, 30, 14, &LABEL_FONT, NULL, NULL, _tr("Pos 1"));
+    GUI_CreateLabelBox(&gui->togglelabel[1], 174, 50, 30, 14, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Pos 1"));
     img = TGLICO_GetImage(Model.pagecfg2.elem[tp->tglidx].extra[1]);
     GUI_CreateImageOffset(&gui->toggleicon[1], 204, 40, TOGGLEICON_WIDTH, TOGGLEICON_HEIGHT, img.x_off, img.y_off, img.file,
              SelectedIcon == 1 ? tglico_reset_cb : tglico_setpos_cb, (void *)1L);
     if (num_positions == 3) {
-        GUI_CreateLabelBox(&gui->togglelabel[2], 254, 50, 30, 14, &LABEL_FONT, NULL, NULL, _tr("Pos 2"));
+        GUI_CreateLabelBox(&gui->togglelabel[2], 254, 50, 30, 14, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Pos 2"));
         img = TGLICO_GetImage(Model.pagecfg2.elem[tp->tglidx].extra[2]);
         GUI_CreateImageOffset(&gui->toggleicon[2], 284, 40, TOGGLEICON_WIDTH, TOGGLEICON_HEIGHT, img.x_off, img.y_off, img.file,
              SelectedIcon == 2 ? tglico_reset_cb : tglico_setpos_cb, (void *)2L);

--- a/src/pages/320x240x16/trim_page.c
+++ b/src/pages/320x240x16/trim_page.c
@@ -64,10 +64,10 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 static void _show_page()
 {
     PAGE_ShowHeader(PAGE_GetName(PAGEID_TRIM));
-    GUI_CreateLabelBox(&gui->inplbl, PCOL1, PROW1, 64, 15, &NARROW_FONT, NULL, NULL, _tr("Input"));
-    GUI_CreateLabelBox(&gui->neglbl, PCOL2, PROW1, 64, 15, &NARROW_FONT, NULL, NULL, _tr("Trim -"));
-    GUI_CreateLabelBox(&gui->poslbl, PCOL3, PROW1, 64, 15, &NARROW_FONT, NULL, NULL, _tr("Trim +"));
-    GUI_CreateLabelBox(&gui->steplbl, PCOL4, PROW1, 108, 15, &NARROW_FONT, NULL, NULL, _tr("Trim Step"));
+    GUI_CreateLabelBox(&gui->inplbl, PCOL1, PROW1, 64, 15, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Input"));
+    GUI_CreateLabelBox(&gui->neglbl, PCOL2, PROW1, 64, 15, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Trim -"));
+    GUI_CreateLabelBox(&gui->poslbl, PCOL3, PROW1, 64, 15, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Trim +"));
+    GUI_CreateLabelBox(&gui->steplbl, PCOL4, PROW1, 108, 15, &NARROW_FONT, GUI_Localize, NULL, _tr_noop("Trim Step"));
 
     GUI_CreateScrollable(&gui->scrollable,
          PCOL1, PROW2,  LCD_WIDTH - 2 * PCOL1, NUM_TRIM_ROWS * 24 - 8,
@@ -97,20 +97,20 @@ void PAGE_TrimEditInit(int page)
     };
 
     //Row 1
-    GUI_CreateLabelBox(&gui_ed->srclbl, COL1, ROW1, COL2-COL1, 0, &LABEL_FONT, NULL, NULL, _tr("Input"));
+    GUI_CreateLabelBox(&gui_ed->srclbl, COL1, ROW1, COL2-COL1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Input"));
     GUI_CreateTextSource(&gui_ed->src, COL2, ROW1, TEXTSELECT_96, NULL, set_source_cb, set_input_source_cb, &tp->trim.src);
     //Row 2
-    GUI_CreateLabelBox(&gui_ed->steplbl, COL1, ROW2, COL2-COL1, 0, &LABEL_FONT, NULL, NULL, _tr("Trim Step"));
+    GUI_CreateLabelBox(&gui_ed->steplbl, COL1, ROW2, COL2-COL1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Trim Step"));
     GUI_CreateTextSelect(&gui_ed->step, COL2, ROW2, TEXTSELECT_96, NULL,
                          set_trimstep_cb, (void *)(long)(tp->index + 0x100)); //0x100: Use tp->trim
     //Row 3
-    GUI_CreateLabelBox(&gui_ed->neglbl, COL1, ROW3, COL2-COL1, 0, &LABEL_FONT, NULL, NULL, _tr("Trim -"));
+    GUI_CreateLabelBox(&gui_ed->neglbl, COL1, ROW3, COL2-COL1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Trim -"));
     GUI_CreateTextSelect(&gui_ed->neg, COL2, ROW3, TEXTSELECT_96, NULL, set_trim_cb, &tp->trim.neg);
     //Row 4
-    GUI_CreateLabelBox(&gui_ed->poslbl, COL1, ROW4, COL2-COL1, 0, &LABEL_FONT, NULL, NULL, _tr("Trim +"));
+    GUI_CreateLabelBox(&gui_ed->poslbl, COL1, ROW4, COL2-COL1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Trim +"));
     GUI_CreateTextSelect(&gui_ed->pos, COL2, ROW4, TEXTSELECT_96, NULL, set_trim_cb, &tp->trim.pos);
     //Row 5
-    GUI_CreateLabelBox(&gui_ed->swlbl, COL1, ROW5, COL2-COL1, 0, &LABEL_FONT, NULL, NULL, _tr("Switch"));
+    GUI_CreateLabelBox(&gui_ed->swlbl, COL1, ROW5, COL2-COL1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Switch"));
     GUI_CreateTextSource(&gui_ed->sw, COL2, ROW5, TEXTSELECT_96, NULL, set_switch_cb, set_input_switch_cb, &tp->trim.sw);
 }
 

--- a/src/pages/320x240x16/tx_configure.c
+++ b/src/pages/320x240x16/tx_configure.c
@@ -192,7 +192,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
         GUI_CreateLabelBox(&gui3->head3_1, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, GUI_Localize, NULL, _tr_noop("Timer settings"));
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui3->prealertlbl, col1, row, col2 - col1, 0, &LABEL_FONT, NGUI_Localize NULL,  _tr_noop("Prealert time"));
+        GUI_CreateLabelBox(&gui3->prealertlbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL,  _tr_noop("Prealert time"));
         GUI_CreateTextSelect(&gui3->prealert, col2, row, TEXTSELECT_96,NULL, prealert_time_cb, (void *)0L);
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
@@ -201,7 +201,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
                 &Transmitter.countdown_timer_settings.prealert_interval);
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui3->timeuplbl, col1, row, col2 - col1, 0, &LABEL_FONT,GUI_LocalizeL, NULL,_tr_noop("Timeup interval"));
+        GUI_CreateLabelBox(&gui3->timeuplbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Timeup interval"));
         GUI_CreateTextSelect(&gui3->timeup, col2, row, TEXTSELECT_96, NULL, timer_interval_cb,
                 &Transmitter.countdown_timer_settings.timeup_interval);
         row += space + 3;

--- a/src/pages/320x240x16/tx_configure.c
+++ b/src/pages/320x240x16/tx_configure.c
@@ -98,33 +98,33 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 #if HAS_EXTENDED_AUDIO
         row -= (LCD_WIDTH == 320 ? 0 : 8);
 #endif
-        GUI_CreateLabelBox(&gui1->head1_1, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, NULL, NULL, _tr("Generic settings"));
+        GUI_CreateLabelBox(&gui1->head1_1, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, GUI_Localize, NULL, _tr_noop("Generic settings"));
 
 #if SUPPORT_MULTI_LANGUAGE
         row += space;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui1->langlbl, col1, row+ADDROW, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Language"));
+        GUI_CreateLabelBox(&gui1->langlbl, col1, row+ADDROW, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Language"));
         GUI_CreateButton(&gui1->lang, col2, row, BUTTON_WIDE, langstr_cb, lang_select_cb, NULL);
 #endif
 
         row += space + ADDSPACE ;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui1->modelbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Stick mode"));
+        GUI_CreateLabelBox(&gui1->modelbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Stick mode"));
         GUI_CreateTextSelect(&gui1->mode, col2, row, TEXTSELECT_96, NULL, modeselect_cb, NULL);
         row += space + (ADDSPACE-1) / 2;
         if (HAS_TOUCH) {
             if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-            GUI_CreateLabelBox(&gui1->touchlbl, col1, row+ADDROW, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Touch screen"));
+            GUI_CreateLabelBox(&gui1->touchlbl, col1, row+ADDROW, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Touch screen"));
             GUI_CreateButton(&gui1->touchcalib, col2, row, BUTTON_WIDE, calibratestr_cb, press_cb, (void *)CALIB_TOUCH);
         }
         row += space + ADDSPACE;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui1->sticklbl, col1, row+ADDROW, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Sticks"));
+        GUI_CreateLabelBox(&gui1->sticklbl, col1, row+ADDROW, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Sticks"));
         GUI_CreateButton(&gui1->stickcalib, col2, row, BUTTON_WIDE, calibratestr_cb, press_cb, (void *)CALIB_STICK);
 #if HAS_RTC
         row += space + ADDSPACE;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui1->clocklbl, col1, row+ADDROW, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Clock"));
+        GUI_CreateLabelBox(&gui1->clocklbl, col1, row+ADDROW, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Clock"));
         GUI_CreateButton(&gui1->clock, col2, row, BUTTON_WIDE, clockstr_cb, press_cb, (void *)SET_CLOCK);
         row += space + ADDSPACE;
 #else
@@ -135,35 +135,35 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     if (page_num == 1 || LCD_WIDTH == 480) {
 #if HAS_EXTENDED_AUDIO
         row -= (LCD_WIDTH == 320 ? 8 : 4);
-        GUI_CreateLabelBox(&gui2->head2_1, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, NULL, NULL, _tr("Audio settings"));
+        GUI_CreateLabelBox(&gui2->head2_1, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, GUI_Localize, NULL, _tr_noop("Audio settings"));
 #else
-        GUI_CreateLabelBox(&gui2->head2_1, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, NULL, NULL, _tr("Buzzer settings"));
+        GUI_CreateLabelBox(&gui2->head2_1, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, GUI_Localize, NULL, _tr_noop("Buzzer settings"));
 #endif
         row += space;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->power_alarmlbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Power On alarm"));
+        GUI_CreateLabelBox(&gui2->power_alarmlbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Power On alarm"));
         GUI_CreateTextSelect(&gui2->power_alarm, col2, row, TEXTSELECT_96, NULL, poweralarm_select_cb, NULL);
         row += space;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->battalrmlbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Battery alarm"));
+        GUI_CreateLabelBox(&gui2->battalrmlbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Battery alarm"));
         GUI_CreateTextSelect(&gui2->battalrm, col2, row, TEXTSELECT_96, NULL, batalarm_select_cb, NULL);
         row += space;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->battalrmintvllbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Alarm interval"));
+        GUI_CreateLabelBox(&gui2->battalrmintvllbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Alarm interval"));
         GUI_CreateTextSelect(&gui2->battalrmintvl, col2, row, TEXTSELECT_96, NULL, batalarmwarn_select_cb, NULL);
         row += space;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->buzzlbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Buzz volume"));
+        GUI_CreateLabelBox(&gui2->buzzlbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Buzz volume"));
         GUI_CreateTextSelect(&gui2->buzz, col2, row, TEXTSELECT_96, NULL, _buzz_vol_cb, (void *)&Transmitter.volume);
 #if HAS_EXTENDED_AUDIO
         row += space;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->audiolbl, col1, row, 0, 0, &DEFAULT_FONT, NULL, NULL, _tr("Audio volume"));
+        GUI_CreateLabelBox(&gui2->audiolbl, col1, row, 0, 0, &DEFAULT_FONT, GUI_Localize, NULL, _tr_noop("Audio volume"));
         GUI_CreateTextSelect(&gui2->audio, col2, row, TEXTSELECT_96, NULL, _audio_vol_cb, (void *)&Transmitter.audio_vol);
 #endif
         row += space;
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->musicshutdbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Power-down alert"));
+        GUI_CreateLabelBox(&gui2->musicshutdbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Power-down alert"));
         GUI_CreateTextSelect(&gui2->music_shutdown, col2, row, TEXTSELECT_96, NULL, _music_shutdown_cb, (void *)&Transmitter.music_shutdown);
 #if HAS_EXTENDED_AUDIO
         row += space;
@@ -171,62 +171,62 @@ static int row_cb(int absrow, int relrow, int y, void *data)
         row += space + 8;
 #endif
         if (row+12 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->head2_2, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, NULL, NULL, _tr("LCD settings"));
+        GUI_CreateLabelBox(&gui2->head2_2, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, GUI_Localize, NULL, _tr_noop("LCD settings"));
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->backlightlbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Backlight"));
+        GUI_CreateLabelBox(&gui2->backlightlbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Backlight"));
         GUI_CreateTextSelect(&gui2->backlight, col2, row, TEXTSELECT_96, NULL, backlight_select_cb, NULL);
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->dimtimelbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Dimmer time"));
+        GUI_CreateLabelBox(&gui2->dimtimelbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Dimmer time"));
         GUI_CreateTextSelect(&gui2->dimtime, col2, row, TEXTSELECT_96, NULL, auto_dimmer_time_cb, NULL);
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui2->dimtgtlbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Dimmer target"));
+        GUI_CreateLabelBox(&gui2->dimtgtlbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Dimmer target"));
         GUI_CreateTextSelect(&gui2->dimtgt, col2, row, TEXTSELECT_96, NULL, common_select_cb,
                 (void *)&Transmitter.auto_dimmer.backlight_dim_value);
         row += space + 0;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
     }
     if (page_num == 2 || LCD_WIDTH == 480) {
-        GUI_CreateLabelBox(&gui3->head3_1, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, NULL, NULL, _tr("Timer settings"));
+        GUI_CreateLabelBox(&gui3->head3_1, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, GUI_Localize, NULL, _tr_noop("Timer settings"));
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui3->prealertlbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL,  _tr("Prealert time"));
+        GUI_CreateLabelBox(&gui3->prealertlbl, col1, row, col2 - col1, 0, &LABEL_FONT, NGUI_Localize NULL,  _tr_noop("Prealert time"));
         GUI_CreateTextSelect(&gui3->prealert, col2, row, TEXTSELECT_96,NULL, prealert_time_cb, (void *)0L);
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui3->preintvllbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Prealert interval"));
+        GUI_CreateLabelBox(&gui3->preintvllbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Prealert interval"));
         GUI_CreateTextSelect(&gui3->preintvl, col2, row, TEXTSELECT_96, NULL, timer_interval_cb,
                 &Transmitter.countdown_timer_settings.prealert_interval);
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui3->timeuplbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL,_tr("Timeup interval"));
+        GUI_CreateLabelBox(&gui3->timeuplbl, col1, row, col2 - col1, 0, &LABEL_FONT,GUI_LocalizeL, NULL,_tr_noop("Timeup interval"));
         GUI_CreateTextSelect(&gui3->timeup, col2, row, TEXTSELECT_96, NULL, timer_interval_cb,
                 &Transmitter.countdown_timer_settings.timeup_interval);
         row += space + 3;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui3->head3_2, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, NULL, NULL, _tr("Telemetry settings"));
+        GUI_CreateLabelBox(&gui3->head3_2, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, GUI_Localize, NULL, _tr_noop("Telemetry settings"));
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui3->templbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Temperature"));
+        GUI_CreateLabelBox(&gui3->templbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Temperature"));
         GUI_CreateTextSelect(&gui3->temp, col2, row, TEXTSELECT_96, NULL, units_cb, (void *)1L);
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui3->lengthlbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Length"));
+        GUI_CreateLabelBox(&gui3->lengthlbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Length"));
         GUI_CreateTextSelect(&gui3->length, col2, row, TEXTSELECT_96, NULL, units_cb, (void *)0L);
         row += space;
         if (row+8 >= LCD_HEIGHT) { row = 40; col1 = COL3; col2 = COL4; }
-        GUI_CreateLabelBox(&gui3->telemivllbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Alert interval"));
+        GUI_CreateLabelBox(&gui3->telemivllbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Alert interval"));
         GUI_CreateTextSelect(&gui3->telemivl, col2, row, TEXTSELECT_96, NULL, telem_interval_cb,
                 &Transmitter.telem_alert_interval);
 
 #if HAS_VIBRATINGMOTOR
         if(Transmitter.extra_hardware & VIBRATING_MOTOR) {
             row += space + 3;
-            GUI_CreateLabelBox(&gui3->head3_3, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, NULL, NULL, _tr("Vibration settings"));
+            GUI_CreateLabelBox(&gui3->head3_3, col1, row, col2 + BUTTON_WIDTH - col1, 0, &SECTION_FONT, GUI_Localize, NULL, _tr_noop("Vibration settings"));
             row += space;
-            GUI_CreateLabelBox(&gui3->viblbl, col1, row, col2 - col1, 0, &LABEL_FONT, NULL, NULL, _tr("Vibration:"));
+            GUI_CreateLabelBox(&gui3->viblbl, col1, row, col2 - col1, 0, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Vibration:"));
             GUI_CreateTextSelect(&gui3->vib, col2, row, TEXTSELECT_96,
                                  _vibration_test_cb, _vibration_state_cb, (void *)&Transmitter.vibration_state);
         }
@@ -282,7 +282,7 @@ void PAGE_TouchInit(int page)
 {
     (void)page;
     //PAGE_ShowHeader_ExitOnly("Touch Calibrate", okcancel_cb); //Can't do this while calibrating
-    GUI_CreateLabelBox(&guic->title, 40, 10, LCD_WIDTH - 40, 14, &TITLE_FONT, NULL, NULL, _tr("Touch Calibrate"));
+    GUI_CreateLabelBox(&guic->title, 40, 10, LCD_WIDTH - 40, 14, &TITLE_FONT, GUI_Localize, NULL, _tr_noop("Touch Calibrate"));
     GUI_CreateLabelBox(&guic->msg, XCOORD - 5, YCOORD + 32 - 5, 11, 11, &SMALLBOX_FONT, NULL, NULL, "");
     GUI_CreateLabelBox(&guic->msg1, (LCD_WIDTH - 100) /2, (LCD_HEIGHT - 20)/2, 100, 20, &NARROW_FONT, show_msg_cb, NULL, NULL);
     memset(&cp->coords, 0, sizeof(cp->coords));

--- a/src/pages/320x240x16/voiceconfig_page.c
+++ b/src/pages/320x240x16/voiceconfig_page.c
@@ -48,8 +48,8 @@ void PAGE_VoiceconfigInit(int page)
     PAGE_ShowHeader(PAGE_GetName(PAGEID_VOICECFG));
 
     if ( !AUDIO_VoiceAvailable() ) {
-        GUI_CreateLabelBox(&gui->msg, 20, 80, 280, 100, &NARROW_FONT, NULL, NULL,
-            _tr("External voice\ncurrently not\navailable"));
+        GUI_CreateLabelBox(&gui->msg, 20, 80, 280, 100, &NARROW_FONT, GUI_Localize, NULL,
+            _tr_noop("External voice\ncurrently not\navailable"));
         return;
     }
     

--- a/src/pages/text/splash_page.c
+++ b/src/pages/text/splash_page.c
@@ -34,7 +34,7 @@ void PAGE_SplashInit(int page)
     }
     PAGE_SetActionCB(_action_cb);
 
-    GUI_CreateLabelBox(&gui->splash_text, 3*ITEM_SPACE, 4*LINE_HEIGHT, 0, 0, &MODELNAME_FONT, NULL, NULL, _tr("Deviation"));
+    GUI_CreateLabelBox(&gui->splash_text, 3*ITEM_SPACE, 4*LINE_HEIGHT, 0, 0, &MODELNAME_FONT, GUI_Localize, NULL, _tr_noop("Deviation"));
     GUI_CreateLabelBox(&gui->version, 0, 7*LINE_HEIGHT, 0, 0, &DEFAULT_FONT, NULL, NULL, DeviationVersion);
 }
 


### PR DESCRIPTION
In the localize build, GUI_Localize is a wrapper to _tr. In non-localized build, it is NULL, which results the same behavior as today.

This removes the assumption on that _tr returns a memory as static memory region. So _tr function is called every time we need the localized string.