### PR TITLE
Revert langv2

### DIFF
--- a/src/config/language.c
+++ b/src/config/language.c
@@ -18,8 +18,8 @@
 #include "tx.h"
 #include "ini.h"
 
-#ifndef SUPPORT_LANG_V1
-#define SUPPORT_LANG_V1 1
+#ifndef SUPPORT_LANG_V2
+#define SUPPORT_LANG_V2 0
 #endif
 
 /* String long enough to hold every used string in the code
@@ -105,7 +105,6 @@ static unsigned fix_crlf(char *str)
     return len;
 }
 
-#if SUPPORT_LANG_V1
 static void ReadLangV1(FILE* fh)
 {
     struct str_map *lookup = lookupmap;
@@ -155,8 +154,8 @@ static void ReadLangV1(FILE* fh)
     }
     table_size = lookup - lookupmap;
 }
-#endif
 
+#if SUPPORT_LANG_V2
 static void ReadLangV2(FILE* fh)
 {
     u16 hash;
@@ -187,6 +186,7 @@ static void ReadLangV2(FILE* fh)
     }
     table_size = lookup - lookupmap;
 }
+#endif
 
 static int ReadLang(const char *file)
 {
@@ -199,7 +199,7 @@ static int ReadLang(const char *file)
     // first line of langauge name, ignore it
     fgets(tempstring, sizeof(tempstring), fh);
 
-#if SUPPORT_LANG_V1
+#if SUPPORT_LANG_V2
     // Try to detect the version
     if (fread(tempstring, 1, 1, fh) == 1)
     {
@@ -212,7 +212,7 @@ static int ReadLang(const char *file)
             ReadLangV2(fh);
     }
 #else
-    CONFIG_ReadLangV2(fh);
+    ReadLangV1(fh);
 #endif
 
     fclose(fh);

--- a/src/tests/test_language.c
+++ b/src/tests/test_language.c
@@ -37,13 +37,9 @@ void TestV1Language(CuTest *t)
     fclose(fh);
 
     ReadLang(name);
-#if SUPPORT_LANG_V1
     CuAssertTrue(t, table_size > 0);
     CuAssertTrue(t, lookupmap[0].hash < lookupmap[1].hash);
     CuAssertStrEquals(t, "abcd", _tr("test"));
     CuAssertStrEquals(t, "ko", _tr("ok"));
     CuAssertStrEquals(t, "ok1", _tr("ok1"));
-#else
-    CuAssertTrue(t, table_size == 0);
-#endif
 }

--- a/utils/extract_strings.pl
+++ b/utils/extract_strings.pl
@@ -18,7 +18,7 @@ sub main {
     my $elffile;
     my $count;
     my $po;
-    my $format = "v2";
+    my $format = "v1";
 
     $ENV{CROSS} ||= "";
     GetOptions("update" => \$update, "language=s" => \$lang, "fs=s" => \$fs,


### PR DESCRIPTION
Leave the code as it is but disable it from build. The new format prevent user to modify the translation file directly. Introduce the new format when we really need it later.