### PR TITLE
Increase translated string count so devo12 can build again

### DIFF
--- a/src/config/language.c
+++ b/src/config/language.c
@@ -39,7 +39,7 @@ void CONFIG_EnableLanguage(int state) {(void)state;}
 static u16 fnv_16_str(const char *str);
 static char strings[8192];
 static u16 table_size;
-#define MAX_STRINGS 450
+#define MAX_STRINGS 475
 #define MAX_LINE 300
 
 /* tempstring[] must be at least long as line[], otherwise they are too small/big to fit in each other */


### PR DESCRIPTION
We probably need to be managing this on a per-tx basis, though it is hard to set precisely due to the chicken-egg issue of needing to build before we know how many strings are needed

Alternatively, we shold probably look at the string list and see if any can be pruned out