### PR TITLE
Enable nightlies to upload/download from transifex and push to github.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -172,6 +172,10 @@ script:
         git add src/fs/language
         git commit -m "`utils/get_altered_languages.py 'Updating translations from Transifex'`"
         git push origin HEAD:$TRAVIS_BRANCH > /dev/null 2>&1 && echo "Successfully uploaded new translations to Github."
+        # check if we've already built a nightly from the current commit
+        if ! utils/needs_nightly_rebuild.py; then
+            travis_terminate 0
+        fi
     fi
   - cd src
   - make -j2 $MAKETARGET

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ matrix:
 #Do not define 'global' env vars here.  They cannot be used with API builds
     fast_finish: true
     include:
-      - stage: deploy
+      - stage: nightly
+        env: MAKETARGET="zips winzips"
+      - stage: release
         env: MAKETARGET="zips winzips"
       - stage: build
         env: MAKETARGET=lint
@@ -20,10 +22,15 @@ matrix:
       - env: MAKETARGET=test
 
 stages:
-    - name: deploy
-      if: type IN (api, cron)
+    - name: release
+      if: type = api AND branch =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+    - name: nightly
+      if: type IN (api, cron) and branch = "master"
     - name: build
-      if: type NOT IN (api, cron)
+      if: type NOT IN (api, cron) AND NOT commit_message =~ /^Updating translations from Transifex \(Languages:/
+      # Do not rebuild if last commit was from Transifex...we already built in the previous commit
+
+
 
 dist: trusty
 
@@ -48,6 +55,8 @@ git:
 
 before_install:
   # We'll put env variables global to all builds here
+  # Disable python SSL warnings (only needed for trusty)
+  - export PYTHONWARNINGS="ignore:A true SSLContext object is not available,ignore:An HTTPS request has been made"
   - export GITHUB_TOKEN='789c538d758e0a718c8ae537b7f6656776e20d768de18d546014e20876e1898933cd94648f75e06117e20000b71f080d'
   # TRAVIS does not override the TRAVIS_COMMIT_MSG with the 'message' value passed via the API (travis issue #10184)
   - source <(curl -s -L "https://api.travis-ci.org/repos/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID" | python -c 'import sys, json; a = json.load(sys.stdin); print "export TRAVIS_COMMIT_MSG=\"" + a.get("message","").replace("\"", "\\\"") + "\""')
@@ -123,10 +132,22 @@ install:
        export MPG123_DIR=$HOME/mpg123-w32
      fi
    - |
-     if [[ "$TRAVIS_EVENT_TYPE" == "api" || "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+     if [[ $TRAVIS_BUILD_STAGE_NAME == "Nightly" || $TRAVIS_BUILD_STAGE_NAME == "Release" ]]; then
+         pip install --user urllib3==1.23 transifex-client
          openssl aes-256-cbc -K $encrypted_54cd4d6ff016_key -iv $encrypted_54cd4d6ff016_iv -in install_nightlies.tar.enc -out install_nightlies.tar -d
          tar -xf install_nightlies.tar;
          rm -f install_nightlies.tar
+     fi
+   - |
+     if [[ $TRAVIS_BUILD_STAGE_NAME == "Nightly" ]]; then
+         echo "[https://www.transifex.com]" > .transifexrc;
+         echo "hostname = https://www.transifex.com" >> .transifexrc;
+         echo "password = $TX_PASSWD" >> .transifexrc;
+         echo "username = api" >> .transifexrc
+         git config --global user.email "travis@travis-ci.org";
+         git config --global user.name "Travis CI";
+         git config --global credential.helper store;
+         echo "https://$GH_TOKEN:x-oauth-basic@github.com" >> ~/.git-credentials
      fi
 
 before_script:
@@ -134,6 +155,24 @@ before_script:
   - arm-none-eabi-gcc --version 2> /dev/null | true
 
 script: 
+  - |
+    if [[ $TRAVIS_BUILD_STAGE_NAME == "Nightly" ]]; then
+        # 'make language' changes order randomly.  Needs to be consistent before enabling this
+        pushd src; make language; popd;
+        if [[ `git diff src/fs/language/| grep -E -v '^(diff|index|---|\+\+\+|@@|-#|\+#| |$)'` == "" ]]; then
+            # Do not update if only comments have changed
+            echo "Only comment-changes found in deviation.po.  Ignoring"
+            git checkout -- src/fs/language/
+        else
+        #    tx push -s
+            git diff
+        fi
+        tx pull -f -a
+        ./utils/clean_transifex_merge.py src/fs/language/locale
+        git add src/fs/language
+        git commit -m "`utils/get_altered_languages.py 'Updating translations from Transifex'`"
+        git push origin HEAD:$TRAVIS_BRANCH > /dev/null 2>&1 && echo "Successfully uploaded new translations to Github."
+    fi
   - cd src
   - make -j2 $MAKETARGET
   - |
@@ -149,11 +188,11 @@ script:
 
 after_success:
   - |
-    if [[ $TRAVIS_BUILD_STAGE_NAME != "Deploy" ]]; then
+    if [[ $TRAVIS_BUILD_STAGE_NAME == "Build" ]]; then
         travis_terminate 0
     fi
   - |
-    if [[ $TRAVIS_EVENT_TYPE == "api" && $TRAVIS_BRANCH != "master" ]]; then
+    if [[ $TRAVIS_BUILD_STAGE_NAME == "Release" ]]; then
         export RELEASE_VERSION=$(echo $TRAVIS_BRANCH | egrep -o '[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+');
         if [[ "$RELEASE_VERSION" != "" && "$TRAVIS_BRANCH" == "v$RELEASE_VERSION" ]]; then
             echo "Releasing $RELEASE_VERSION";

--- a/utils/clean_transifex_merge.py
+++ b/utils/clean_transifex_merge.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 
-cmd = ['git', 'diff']
+cmd = ['git', 'diff', '--relative']
 if len(sys.argv) > 1:
     cmd += sys.argv[1:]
 
@@ -25,7 +25,7 @@ for line in lines:
         changes = 0
         filename = os.path.sep.join(line.split(" ")[-1].split(os.path.sep)[1:]) # FIXME: This is not x-platform clean
     if line.startswith(('-', '+')) and not line.startswith(('---', '+++')):
-        if '"POT-Creation-Date: ' not in line:
+        if not any(line[1:].startswith(x) for x in ['"POT-Creation-Date: ', '"Last-Translator: ', '#']):
             changes += 1
 
 

--- a/utils/extract_strings.pl
+++ b/utils/extract_strings.pl
@@ -108,7 +108,7 @@ sub get_strings {
 }
 
 sub extract_all_strings {
-    my @lines = `/usr/bin/find . -name "*.[hc]" | grep -v libopencm3 | xargs xgettext -o - --omit-header -k --keyword=_tr --keyword=_tr_noop --no-wrap`;
+    my @lines = `/usr/bin/find . -name "*.[hc]" | grep -v libopencm3 | sort | xargs xgettext -o - --omit-header -k --keyword=_tr --keyword=_tr_noop --no-wrap`;
     my $idx = 0;
     my %strings = (__ORDER__ => [] );  # Crude Tie::IxHash implementation
     #Read all strings and put into a hash that maps the containing file to the string

--- a/utils/get_altered_languages.py
+++ b/utils/get_altered_languages.py
@@ -14,10 +14,16 @@ lines = [line.rstrip() for line in res.stdout]
 languages = {}
 
 pat = re.compile(r'locale/deviation\.(.+)\.po$')
+english = False
 for line in lines:
+    if re.search(r'deviation.po$', line):
+        english = True
     match = pat.search(line)
     if match:
         languages[match.group(1)] = 1
-if languages:
-    msg += " (Languages: " + " ".join(sorted(languages.keys())) + ")"
+lang = sorted(languages.keys())
+if english:
+    lang.insert(0, "en")
+if lang:
+    msg += " (Languages: " + " ".join(lang) + ")"
 print msg

--- a/utils/needs_nightly_rebuild.py
+++ b/utils/needs_nightly_rebuild.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+import urllib
+import urllib2
+import sys
+import os
+import json
+import subprocess
+
+TRAVIS = os.environ.get('TRAVIS')
+TRAVIS_REPO_SLUG = os.environ.get('TRAVIS_REPO_SLUG')
+TRAVIS_BRANCH = os.environ.get('TRAVIS_BRANCH')
+
+def main():
+    if not TRAVIS or not TRAVIS_REPO_SLUG:
+        print "Not a Travis environment.  No rebuild needed"
+        sys.exit(1)
+    sha = subprocess.check_output(['git', 'rev-parse', 'HEAD']).rstrip()
+    if not sha:
+        print "Could not determine current git commit.  No rebuild needed"
+        sys.exit(1)
+    builds_url = ('https://api.travis-ci.org/repo/'
+                  + urllib.quote_plus(TRAVIS_REPO_SLUG)
+                  + "/builds?limit=5&state=passed&branch.name="
+                  + TRAVIS_BRANCH
+                  + "&event_type=")
+
+    headers = {"Travis-API-Version": 3}
+    for event in ['cron']:  # 'api'  Only checking cron jobs.  api jobs will force a rebuild
+        url = builds_url + event
+        try:
+            request = urllib2.Request(url, None, headers)
+            res = urllib2.urlopen(request)
+            raise_for_status(url, res)
+            data = json.loads(res.read())
+        except:
+            print "Couldn't fetch build data.  Assuming rebuild needed"
+            sys.exit(0)
+        if not data or not isinstance(data.get('builds'), list):
+            print "Couldn't parse build data.  Assuming rebuild needed"
+            sys.exit(0)
+        if any(build['commit']['sha'] == sha for build in data['builds']):
+            print "Found previous nightly build for {}.  Skipping rebuild".format(sha[:8])
+            sys.exit(1)
+    print "No nightly builds matched {}.  Assuming rebuild needed".format(sha[:8])
+
+def raise_for_status(url, response):
+    """Raise exception on URL error"""
+    if response.getcode() < 200 or response.getcode() >= 300:
+        sys.stderr.write(response.read())
+        sys.stderr.write('\n')
+        raise Exception('Request for %s failed: %s' % (url, response.getcode()))
+
+main()


### PR DESCRIPTION
Similar functionality to deviation-manual.  When a nightly build is triggered:
* rebuild strings
* upload strings to transifex (only if there are non-comment changes)
* download strings from transifex
* remove any comment-only changes
* push changes to github
* don't re-trigger build on pushed translation changes