### PR TITLE
 Move rtcflags into time and date format variables

### DIFF
--- a/src/config/tx.c
+++ b/src/config/tx.c
@@ -153,11 +153,11 @@ static int ini_handler(void* user, const char* section, const char* name, const 
         }
     #if HAS_RTC
         if (MATCH_KEY(TIME_FORMAT)) {
-            t->rtcflags = (t->rtcflags & ~TIMEFMT) | (atoi(value) & TIMEFMT);
+            t->rtc_timeformat = atoi(value);
             return 1;
         }
         if (MATCH_KEY(DATE_FORMAT)) {
-            t->rtcflags = (t->rtcflags & ~DATEFMT) | ((atoi(value) << 4) & DATEFMT);
+            t->rtc_dateformat = atoi(value);
             return 1;
         }
     #endif
@@ -278,8 +278,8 @@ void CONFIG_WriteTx()
     fprintf(fh, "%s=%d\n", BATT_WARNING_INTERVAL, Transmitter.batt_warning_interval);
     fprintf(fh, "%s=%d\n", SPLASH_DELAY, Transmitter.splash_delay);
 #if HAS_RTC
-    fprintf(fh, "%s=%d\n", TIME_FORMAT, Transmitter.rtcflags & TIMEFMT);
-    fprintf(fh, "%s=%d\n", DATE_FORMAT, (Transmitter.rtcflags & DATEFMT) >> 4);
+    fprintf(fh, "%s=%d\n", TIME_FORMAT, Transmitter.rtc_timeformat);
+    fprintf(fh, "%s=%d\n", DATE_FORMAT, Transmitter.rtc_dateformat);
 #endif
     for(i = 0; i < INP_HAS_CALIBRATION; i++) {
         fprintf(fh, "[%s%d]\n", SECTION_CALIBRATE, i+1);

--- a/src/config/tx.h
+++ b/src/config/tx.h
@@ -46,8 +46,6 @@ enum ExtraHardware {
 
 // bitmap for rtcflags:
 #define CLOCK12HR 0x01  //0b00000001
-#define TIMEFMT   0x0F  //0b00001111
-#define DATEFMT   0xF0  //0b11110000
 
 struct Transmitter {
     u8 current_model;
@@ -74,9 +72,11 @@ struct Transmitter {
     u8 volume;
     u8 module_poweramp;
     u8 vibration_state; // for future vibration on/off support
-    u8 padding_1[1];
 #if HAS_RTC
-    u8 rtcflags;    // bit0: clock12hr, bit1-3: time format, bit4-7 date format (see pages/320x240x16/rtc_config.c)
+    u8 rtc_timeformat;    // bit0: clock12hr, bit1-3: time format
+    u8 rtc_dateformat;    // bit0-3 date format (see pages/320x240x16/rtc_config.c)
+#else
+    u8 padding_1[1];
 #endif
 
     #ifdef HAS_MORE_THAN_32_INPUTS

--- a/src/pages/320x240x16/rtc_config.c
+++ b/src/pages/320x240x16/rtc_config.c
@@ -95,7 +95,7 @@ const char *rtc_show_val_cb(guiObject_t *obj, const void *data)
             break;
         case HOUR: {
             u32 value = RTC_GetTimeValue(time) / 3600;
-            if (Transmitter.rtcflags & CLOCK12HR) {
+            if (Transmitter.rtc_timeformat & CLOCK12HR) {
                 u8 hour = value % 12;
                 if (hour == 0)
                     hour = 12;
@@ -179,11 +179,11 @@ const char *rtc_select_format_cb(guiObject_t *obj, int dir, void *data)
 {
     (void)obj;
     if ((long)data == ACTTIME) {
-        u8 index = Transmitter.rtcflags & TIMEFMT;
+        u8 index = Transmitter.rtc_timeformat;
         u8 changed;
         index = GUI_TextSelectHelper(index, 0, RTC_GetNumberTimeFormats() - 1, dir, 1, 1, &changed);
         if (changed) {
-            Transmitter.rtcflags = (Transmitter.rtcflags & (0xff ^ TIMEFMT)) | (index & TIMEFMT);
+            Transmitter.rtc_timeformat = index;
             GUI_Redraw(&gui->acttime);
             GUI_Redraw(&gui->newtime);
             for (u8 i=0; i<sizeof(order); i++)
@@ -195,11 +195,11 @@ const char *rtc_select_format_cb(guiObject_t *obj, int dir, void *data)
         return timeformats[index];
     }
     if ((long)data == ACTDATE) {
-        u8 index = (Transmitter.rtcflags & DATEFMT) >> 4;
+        u8 index = Transmitter.rtc_dateformat;
         u8 changed;
         index = GUI_TextSelectHelper(index, 0, RTC_GetNumberDateFormats() - 1, dir, 1, 1, &changed);
         if (changed) {
-            Transmitter.rtcflags = (Transmitter.rtcflags & (0xff ^ DATEFMT)) | ((index << 4) & DATEFMT);
+            Transmitter.rtc_dateformat = index;
             GUI_Redraw(&gui->actdate);
             GUI_Redraw(&gui->newdate);
             // reorder spinbuttons to date format
@@ -221,7 +221,7 @@ void _show_page()
     GUI_CreateTextSelect(&gui->dateformat, XL(128), 56, TEXTSELECT_128, NULL, rtc_select_format_cb, (void *)ACTDATE);
     GUI_CreateTextSelect(&gui->timeformat, XR(128), 56, TEXTSELECT_128, NULL, rtc_select_format_cb, (void *)ACTTIME);
 
-    RTC_GetDateFormattedOrder((Transmitter.rtcflags & DATEFMT) >> 4, &order[0], &order[1], &order[2]); // initial ordering
+    RTC_GetDateFormattedOrder(Transmitter.rtc_dateformat, &order[0], &order[1], &order[2]); // initial ordering
 
     for (long i=0; i<6; i++) {
         GUI_CreateLabel(&gui->label[i], X(i/3, 32) + ((i%3 == 2) ? 67 : 0) - ((i%3 == 0) ? 67 : 0), 84, rtc_text_cb, DEFAULT_FONT, (void *)i);
@@ -274,7 +274,7 @@ static const char *rtc_val_cb(guiObject_t *obj, int dir, void *data)
             sprintf(tempstring, "%4d", Rtc.value[idx]);
         else if (idx == HOUR) {
             u8 tmp = Rtc.value[HOUR];
-            if (Transmitter.rtcflags & CLOCK12HR) {
+            if (Transmitter.rtc_timeformat & CLOCK12HR) {
                 tmp %= 12;
                 if (tmp == 0)
                     tmp = 12;

--- a/src/pages/320x240x16/rtc_config.c
+++ b/src/pages/320x240x16/rtc_config.c
@@ -221,7 +221,7 @@ void _show_page()
     GUI_CreateTextSelect(&gui->dateformat, XL(128), 56, TEXTSELECT_128, NULL, rtc_select_format_cb, (void *)ACTDATE);
     GUI_CreateTextSelect(&gui->timeformat, XR(128), 56, TEXTSELECT_128, NULL, rtc_select_format_cb, (void *)ACTTIME);
 
-    RTC_GetDateFormattedOrder(Transmitter.rtc_dateformat, &order[0], &order[1], &order[2]); // initial ordering
+    RTC_GetDateFormattedOrder(Transmitter.rtc_dateformat, &order[0], &order[1], &order[2]);  // initial ordering
 
     for (long i=0; i<6; i++) {
         GUI_CreateLabel(&gui->label[i], X(i/3, 32) + ((i%3 == 2) ? 67 : 0) - ((i%3 == 0) ? 67 : 0), 84, rtc_text_cb, DEFAULT_FONT, (void *)i);

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -82,7 +82,7 @@ int _RTC_GetMinute(u32 value)
 int _RTC_GetHour(u32 value)
 {
     value /= 3600;
-    if (Transmitter.rtcflags & CLOCK12HR) {
+    if (Transmitter.rtc_timeformat & CLOCK12HR) {
        value %= 12;
        if (value == 0)
            value = 12;
@@ -166,7 +166,7 @@ const char *timeformats[] = { /*"default",*/ "hh:mm:ss", "hh:mm:ss am/pm" };
 void RTC_GetTimeFormatted(char *str, u32 time)
 {
     // which format to use?
-    unsigned format = Transmitter.rtcflags & TIMEFMT;
+    unsigned format = Transmitter.rtc_timeformat;
     // make sure that the number is correct; use default otherwise
     if (format >= sizeof(timeformats) / sizeof(timeformats[0])) format = 0;
     switch (format) {
@@ -187,7 +187,7 @@ const char *dateformats[] = { "YYYY-MM-DD", "MM/DD/YYYY", "DD.MM.YYYY", "Mon DD 
 void RTC_GetDateFormatted(char *str, u32 date)
 {
     // which format to use?
-    unsigned format = (Transmitter.rtcflags & DATEFMT) >> 4;
+    unsigned format = Transmitter.rtc_dateformat;
     // make sure that the number is correct; use default otherwise
     if (format >= sizeof(dateformats) / sizeof(dateformats[0])) format = 0;
     _RTC_SetDayStart(date);
@@ -220,7 +220,7 @@ void RTC_GetDateFormatted(char *str, u32 date)
 void RTC_GetMonthFormatted(char *str, unsigned month)
 {
     // which format to use?
-    unsigned format = (Transmitter.rtcflags & DATEFMT) >> 4;
+    unsigned format = Transmitter.rtc_dateformat;
     // make sure that the number is correct; use default otherwise
     if (format >= sizeof(dateformats) / sizeof(dateformats[0])) format = 0;
     switch (format) {


### PR DESCRIPTION
No reason to combine the flags. The memory save is zero but the ROM waste is noticeable. This also make the tx configuration code hard to convert to data driven mode.