### PR TITLE
No need install libc-i386

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ addons:
     update: false
     packages:
       - build-essential
-      - libc6-i386
       - mingw32
       - mingw32-binutils
       - mingw32-runtime


### PR DESCRIPTION
After compiler upgrade, the new GCC is a 64bit application instead of a 32bit like GCC 4.8. Remove the package libc6-i386.