### PR TITLE
Ignore return code of upload coverage data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -186,7 +186,7 @@ script:
     if [[ "$MAKETARGET" == "test" ]]; then
         ./test.elf
         ../utils/coverage-summary.sh;
-        coveralls -r . -b . --gcov-options '\-lp' -E '.*/tests/test_.*' -E '.*/objs/';
+        coveralls -r . -b . --gcov-options '\-lp' -E '.*/tests/test_.*' -E '.*/objs/' || true;
     fi
 
 after_success:


### PR DESCRIPTION
The upload coverage data is broken in my private CI runs as I didn't enable coveralls. Ignore the return code of coveralls cmd to workaround this.