### PR TITLE
Add special Devo telemetry format

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,7 +21,7 @@
     - RadioLink AT9
   * Introduce a new format of localiztion file to save Flash space and speed up UI rendering.
   * Scanner to check the RF enviroment around.
-  * Enhence telemetry support by adding some new fields.
+  * Enhance telemetry support by adding some new fields.
 
 
 ## Minor Features / Bug Fixes
@@ -30,6 +30,7 @@
   * Support of Beken BK2421 / BK2423 support is removed.
   * Fix USBHID under OSX
   * Tx power setting shows power values of radio in use
+  * Support Walkera QR-X350 telemetry format
 
 
 ## New protocols

--- a/src/protocol/devo_cyrf6936.c
+++ b/src/protocol/devo_cyrf6936.c
@@ -51,7 +51,7 @@
 #define NUM_WAIT_LOOPS (100 / 5) //each loop is ~5us.  Do not wait more than 100us
 
 static const char * const devo_opts[] = {
-  _tr_noop("Telemetry"),  _tr_noop("On"), _tr_noop("Off"), NULL,
+  _tr_noop("Telemetry"), _tr_noop("Std"), _tr_noop("X350"), _tr_noop("Off"), NULL,
   NULL
 };
 
@@ -62,8 +62,9 @@ enum {
 
 ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
 
-#define TELEM_ON 0
-#define TELEM_OFF 1
+#define TELEM_STD  0
+#define TELEM_X350 1
+#define TELEM_OFF  2
 
 enum PktState {
     DEVO_BIND,
@@ -294,17 +295,31 @@ static void parse_telemetry_packet()
     */
     if (packet[0] == 0x32) {
         update = gpslongpkt;
-        Telemetry.gps.longitude = text_to_int(&packet[1], 3) * 3600000
-                                + text_to_int(&packet[4], 2) * 60000
-                                + text_to_int(&packet[7], 4) * 6;
+        if (Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_STD) {
+            // data is degrees decimal minutes
+            Telemetry.gps.longitude = text_to_int(&packet[1], 3) * 3600000
+                                    + text_to_int(&packet[4], 2) * 60000
+                                    + text_to_int(&packet[7], 4) * 6;
+        } else {
+            // data is decimal degrees
+            Telemetry.gps.longitude = text_to_int(&packet[1], 3) * 3600000
+                                    + text_to_int(&packet[4], 2) * 36000
+                                    + text_to_int(&packet[7], 4) * 36 / 10;
+        }
         if (packet[11] == 'W')
             Telemetry.gps.longitude *= -1;
     }
     if (packet[0] == 0x33) {
         update = gpslatpkt;
-        Telemetry.gps.latitude = text_to_int(&packet[1], 2) * 3600000
-                               + text_to_int(&packet[3], 2) * 60000
-                               + text_to_int(&packet[6], 4) * 6;
+        if (Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_STD) {
+            Telemetry.gps.latitude = text_to_int(&packet[1], 2) * 3600000
+                                   + text_to_int(&packet[3], 2) * 60000
+                                   + text_to_int(&packet[6], 4) * 6;
+        } else {
+            Telemetry.gps.latitude = text_to_int(&packet[1], 2) * 3600000
+                                   + text_to_int(&packet[3], 2) * 36000
+                                   + text_to_int(&packet[6], 4) * 36 / 10;
+        }
         if (packet[10] == 'S')
             Telemetry.gps.latitude *= -1;
     }
@@ -589,7 +604,7 @@ static void initialize()
         bind_counter = 0;
         cyrf_set_bound_sop_code();
     }
-    if (Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON) {
+    if (Model.proto_opts[PROTOOPTS_TELEMETRY] != TELEM_OFF) {
         CLOCK_StartTimer(2400, devo_telemetry_cb);
     } else {
         CLOCK_StartTimer(2400, devo_cb);
@@ -615,7 +630,7 @@ const void *DEVO_Cmds(enum ProtoCmds cmd)
             PROTOCOL_Init(0);  // only 1 prot_ops item, it is to enable/disable telemetry
             break;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
+            return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] != TELEM_OFF ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_TELEMETRYTYPE: 
             return (void *)(long) TELEM_DEVO;
         case PROTOCMD_CHANNELMAP:

--- a/src/protocol/devo_cyrf6936.c
+++ b/src/protocol/devo_cyrf6936.c
@@ -630,7 +630,7 @@ const void *DEVO_Cmds(enum ProtoCmds cmd)
             PROTOCOL_Init(0);  // only 1 prot_ops item, it is to enable/disable telemetry
             break;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] != TELEM_OFF ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
+            return (void *)(Model.proto_opts[PROTOOPTS_TELEMETRY] != TELEM_OFF ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_TELEMETRYTYPE: 
             return (void *)(long) TELEM_DEVO;
         case PROTOCMD_CHANNELMAP:


### PR DESCRIPTION
Change telemetry protocol option to support both standard (Devo) and QR-X350 telemetry formats.  The X350 sends lat/long as decimal degrees.  Standard format is degrees decimal minutes.

Fixes #627.