### PR TITLE
Remove MODULE_CALLTYPE on callback functions

### DIFF
--- a/src/protocol/bayang_nrf24l01.c
+++ b/src/protocol/bayang_nrf24l01.c
@@ -383,7 +383,7 @@ static void bay_init()
 
 
 
-MODULE_CALLTYPE static u16 bay_callback()
+static u16 bay_callback()
 {
     switch (phase) {
     case Bayang_INIT1:

--- a/src/protocol/bluefly_nrf24l01.c
+++ b/src/protocol/bluefly_nrf24l01.c
@@ -161,7 +161,6 @@ static void build_ch_data()
 #endif
 }
 
-MODULE_CALLTYPE
 static u16 bluefly_cb()
 {
     switch(counter1ms++) {

--- a/src/protocol/bugs3_a7105.c
+++ b/src/protocol/bugs3_a7105.c
@@ -549,7 +549,7 @@ static void increment_counts() {
 // FIFO config is one less than desired value
 #define FIFO_SIZE_RX      15
 #define FIFO_SIZE_TX      21
-MODULE_CALLTYPE
+
 static u16 bugs3_cb() {
     u16 packet_period = 0;
     u8 mode;

--- a/src/protocol/bugs3mini_nrf24l01.c
+++ b/src/protocol/bugs3mini_nrf24l01.c
@@ -345,7 +345,6 @@ static void update_telemetry() {
     }
 }
 
-MODULE_CALLTYPE
 static u16 bugs3mini_callback()
 {
     switch(phase) {

--- a/src/protocol/cflie_nrf24l01.c
+++ b/src/protocol/cflie_nrf24l01.c
@@ -783,7 +783,6 @@ static void update_telemetry_ackpkt()
     }
 }
 
-MODULE_CALLTYPE
 static u16 cflie_callback()
 {
     switch (phase) {

--- a/src/protocol/cg023_nrf24l01.c
+++ b/src/protocol/cg023_nrf24l01.c
@@ -265,7 +265,6 @@ static void cg023_init()
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x00);     // Set feature bits on
 }
 
-MODULE_CALLTYPE
 static u16 cg023_callback()
 {
     switch (phase) {

--- a/src/protocol/corona_cc2500.c
+++ b/src/protocol/corona_cc2500.c
@@ -311,7 +311,6 @@ static u16 CORONA_build_packet(void) {
   return packet_period;
 }
 
-MODULE_CALLTYPE
 static u16 corona_cb() {
   // Tune frequency if it has been changed
   if (fine != (s8)Model.proto_opts[PROTO_OPTS_FREQFINE]) {

--- a/src/protocol/cx10_nrf24l01.c
+++ b/src/protocol/cx10_nrf24l01.c
@@ -340,7 +340,6 @@ static void cx10_init()
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x00);     // Set feature bits on
 }
 
-MODULE_CALLTYPE
 static u16 cx10_callback()
 {
     switch (phase) {

--- a/src/protocol/devo_cyrf6936.c
+++ b/src/protocol/devo_cyrf6936.c
@@ -456,7 +456,6 @@ void DEVO_BuildPacket()
         pkt_num = 0;
 }
 
-MODULE_CALLTYPE
 static u16 devo_telemetry_cb()
 {
     int delay;
@@ -531,7 +530,6 @@ static u16 devo_telemetry_cb()
     return delay;
 }
 
-MODULE_CALLTYPE
 static u16 devo_cb()
 {
     if (txState == 0) {

--- a/src/protocol/dm002_nrf24l01.c
+++ b/src/protocol/dm002_nrf24l01.c
@@ -204,7 +204,6 @@ static void DM002_init()
     NRF24L01_SetPower(Model.tx_power);
 }
 
-MODULE_CALLTYPE
 static u16 dm002_callback()
 {
     switch(phase) {

--- a/src/protocol/dsm2_cyrf6936.c
+++ b/src/protocol/dsm2_cyrf6936.c
@@ -669,7 +669,6 @@ NO_INLINE static void parse_telemetry_packet()
 #ifndef MODULAR
 static u16 mixer_runtime;
 #endif
-MODULE_CALLTYPE
 static u16 dsm2_cb()
 {
 #define CH1_CH2_DELAY 4010  // Time between write of channel 1 and channel 2

--- a/src/protocol/e012_nrf24l01.c
+++ b/src/protocol/e012_nrf24l01.c
@@ -212,7 +212,6 @@ static void initialize_txid()
     }
 }
 
-MODULE_CALLTYPE
 static u16 e012_callback()
 {
     switch (phase) {

--- a/src/protocol/e015_nrf24l01.c
+++ b/src/protocol/e015_nrf24l01.c
@@ -213,7 +213,6 @@ static void send_packet(u8 bind)
     }
 }
 
-MODULE_CALLTYPE
 static u16 e015_callback()
 {
     switch (phase) {

--- a/src/protocol/esky150_nrf24l01.c
+++ b/src/protocol/esky150_nrf24l01.c
@@ -226,7 +226,6 @@ static void esky2_start_tx(BOOL bind_yes)
 //
 // For 7E, this module is loaded into RAM, we need to set __attribute__((__long_call__))
 //-------------------------------------------------------------------------------------------------
-MODULE_CALLTYPE
 static u16 esky2_tx_callback()
 {
 static s32 packet_sent = 0;

--- a/src/protocol/esky_nrf24l01.c
+++ b/src/protocol/esky_nrf24l01.c
@@ -283,8 +283,6 @@ static void send_packet(u8 bind)
     }
 }
 
-
-MODULE_CALLTYPE
 static u16 esky_callback()
 {
     switch (phase) {

--- a/src/protocol/flysky_a7105.c
+++ b/src/protocol/flysky_a7105.c
@@ -334,7 +334,6 @@ static void flysky_build_packet(u8 init)
     flysky_apply_extension_flags();
 }
 
-MODULE_CALLTYPE
 static u16 flysky_cb()
 {
     if (counter) {

--- a/src/protocol/fy326_nrf24l01.c
+++ b/src/protocol/fy326_nrf24l01.c
@@ -221,7 +221,6 @@ static void fy326_init()
     NRF24L01_WriteReg(NRF24L01_1D_FEATURE, 0x07);
 }
 
-MODULE_CALLTYPE
 static u16 fy326_callback()
 {
     u8 i;

--- a/src/protocol/gd00x_nrf24l01.c
+++ b/src/protocol/gd00x_nrf24l01.c
@@ -202,7 +202,6 @@ static void GD00X_initialize_txid()
     #endif
 }
 
-MODULE_CALLTYPE
 static u16 GD00X_callback()
 {
     if(phase == GD00X_BIND) {

--- a/src/protocol/gw008_nrf24l01.c
+++ b/src/protocol/gw008_nrf24l01.c
@@ -194,7 +194,6 @@ static void initialize_txid()
     txid[1] = lfsr >> 8;
 }
 
-MODULE_CALLTYPE
 static u16 gw008_callback()
 {
     switch(phase) {

--- a/src/protocol/h377_nrf24l01.c
+++ b/src/protocol/h377_nrf24l01.c
@@ -210,7 +210,6 @@ static void build_ch_data()
 
 }
 
-MODULE_CALLTYPE
 static u16 h377_cb()
 {    
     counter1ms++;

--- a/src/protocol/h8_3d_nrf24l01.c
+++ b/src/protocol/h8_3d_nrf24l01.c
@@ -386,7 +386,6 @@ static void h8_3d_init()
     NRF24L01_Activate(0x73);
 }
 
-MODULE_CALLTYPE
 static u16 h8_3d_callback()
 {
     switch (phase) {

--- a/src/protocol/hisky_nrf24l01.c
+++ b/src/protocol/hisky_nrf24l01.c
@@ -288,7 +288,6 @@ static void build_hk310_ch_data(u8 packet_type)
     }
 }
 
-MODULE_CALLTYPE
 static u16 hisky_cb()
 {
     counter1ms++;

--- a/src/protocol/hitec_cc2500.c
+++ b/src/protocol/hitec_cc2500.c
@@ -594,7 +594,6 @@ static u16 initHITEC()
     return 10000;
 }
 
-MODULE_CALLTYPE
 static u16 hitec_cb() {
   return ReadHitec();
 }

--- a/src/protocol/hm830_nrf24l01.c
+++ b/src/protocol/hm830_nrf24l01.c
@@ -322,9 +322,6 @@ static u16 handle_data()
     return 20000;
 }
 
-
-
-MODULE_CALLTYPE
 static u16 HM830_callback()
 {
     if ((phase & 0x7F) < HM830_DATA1)

--- a/src/protocol/hontai_nrf24l01.c
+++ b/src/protocol/hontai_nrf24l01.c
@@ -330,7 +330,6 @@ static void ht_init2()
     }
 }
 
-MODULE_CALLTYPE
 static u16 ht_callback()
 {
     switch (phase) {

--- a/src/protocol/hubsan_a7105.c
+++ b/src/protocol/hubsan_a7105.c
@@ -464,7 +464,6 @@ static void hubsan_update_telemetry()
     }
 }
 
-MODULE_CALLTYPE
 static u16 hubsan_cb()
 {
     static u8 txState = 0;

--- a/src/protocol/inav_nrf24l01.c
+++ b/src/protocol/inav_nrf24l01.c
@@ -739,7 +739,6 @@ static void inav_init(init_bind_t bind)
     set_hopping_channels();
 }
 
-MODULE_CALLTYPE
 static u16 inav_callback()
 {
     static u16 bind_counter;

--- a/src/protocol/j6pro_cyrf6936.c
+++ b/src/protocol/j6pro_cyrf6936.c
@@ -177,7 +177,6 @@ static void set_radio_channels()
     radio_ch[3] = radio_ch[0];
 }
 
-MODULE_CALLTYPE
 static u16 j6pro_cb()
 {
     switch(state) {

--- a/src/protocol/joysway_a7105.c
+++ b/src/protocol/joysway_a7105.c
@@ -172,7 +172,6 @@ static void flysky_build_packet()
     packet[15] = value;
 }
 
-MODULE_CALLTYPE
 static u16 joysway_cb()
 {
     u8 ch;

--- a/src/protocol/kn_nrf24l01.c
+++ b/src/protocol/kn_nrf24l01.c
@@ -264,7 +264,6 @@ static void kn_start_tx(BOOL bind_yes)
 //
 // For 7E, this module is loaded into RAM, we need to set __attribute__((__long_call__))
 //-------------------------------------------------------------------------------------------------
-MODULE_CALLTYPE
 static u16 kn_tx_callback()
 {
 static s32 packet_sent = 0;

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -368,8 +368,6 @@ static void mjxq_init2()
     }
 }
 
-
-MODULE_CALLTYPE
 static u16 mjxq_callback()
 {
     switch (phase) {

--- a/src/protocol/mt99xx_nrf24l01.c
+++ b/src/protocol/mt99xx_nrf24l01.c
@@ -340,7 +340,6 @@ static void initialize_txid()
     channel_offset = (((checksum_offset & 0xf0)>>4) + (checksum_offset & 0x0f)) % 8;
 }
 
-MODULE_CALLTYPE
 static u16 mt99xx_callback()
 {
     switch (state) {

--- a/src/protocol/ncc1701_nrf24l01.c
+++ b/src/protocol/ncc1701_nrf24l01.c
@@ -225,7 +225,6 @@ static void update_telemetry()
     TELEMETRY_SetUpdated(TELEM_FRSKY_RSSI);
 }
 
-MODULE_CALLTYPE
 static u16 ncc1701_callback()
 {
     switch(phase)

--- a/src/protocol/ppmout.c
+++ b/src/protocol/ppmout.c
@@ -65,7 +65,6 @@ static void build_data_pkt()
     pulses[Model.num_channels] = 50000;
 }
 
-MODULE_CALLTYPE
 static u16 ppmout_cb()
 {
     build_data_pkt();

--- a/src/protocol/pxxout.c
+++ b/src/protocol/pxxout.c
@@ -251,7 +251,6 @@ static enum {
 
 static u16 mixer_runtime;
 
-MODULE_CALLTYPE
 static u16 pxxout_cb()
 {
     switch (state) {

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -433,7 +433,6 @@ static void q303_init()
     NRF24L01_Activate(0x73);
 }
 
-MODULE_CALLTYPE
 static u16 q303_callback()
 {
     switch (phase) {

--- a/src/protocol/slt_nrf24l01.c
+++ b/src/protocol/slt_nrf24l01.c
@@ -386,7 +386,6 @@ void checkTxPower()
 #define SLT_V1_TIMING_BIND2     1000
 #define SLT_V2_TIMING_BIND1     6507
 #define SLT_V2_TIMING_BIND2     2112
-MODULE_CALLTYPE
 static u16 SLT_callback()
 {
     switch (phase)

--- a/src/protocol/symax_nrf24l01.c
+++ b/src/protocol/symax_nrf24l01.c
@@ -442,7 +442,6 @@ static void symax_init2()
     packet_counter = 0;
 }
 
-MODULE_CALLTYPE
 static u16 symax_callback()
 {
     switch (phase) {

--- a/src/protocol/testrf.c
+++ b/src/protocol/testrf.c
@@ -52,7 +52,6 @@ ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
 static unsigned char packet[16];
 #define BV(bit) (1 << bit)
 
-MODULE_CALLTYPE
 static u16 testrf_cb()
 {
     packet[0]++;

--- a/src/protocol/usbhid.c
+++ b/src/protocol/usbhid.c
@@ -69,7 +69,6 @@ static void build_data_pkt()
     packet[USBHID_ANALOG_CHANNELS] = digital;
 }
 
-MODULE_CALLTYPE
 static u16 usbhid_cb()
 {
     if(PrevXferComplete) {

--- a/src/protocol/v202_nrf24l01.c
+++ b/src/protocol/v202_nrf24l01.c
@@ -473,8 +473,6 @@ static void send_packet(u8 bind)
     }
 }
 
-
-MODULE_CALLTYPE
 static u16 v202_callback()
 {
     switch (phase) {

--- a/src/protocol/v911s_nrf24l01.c
+++ b/src/protocol/v911s_nrf24l01.c
@@ -223,7 +223,6 @@ static void V911S_initialize_txid()
     rf_ch_num=rand32(0xfefefefe)&0x03;          // 0-3
 }
 
-MODULE_CALLTYPE
 static u16 V911S_callback()
 {
     switch(phase) {

--- a/src/protocol/wfly_cyrf6936.c
+++ b/src/protocol/wfly_cyrf6936.c
@@ -189,7 +189,6 @@ static u16 WFLY_send_data_packet()
     return 1093;    // case 3
 }
 
-MODULE_CALLTYPE
 static u16 WFLY_callback()
 {
     u8 status,len,sum=0,check=0;

--- a/src/protocol/wk2x01.c
+++ b/src/protocol/wk2x01.c
@@ -478,7 +478,6 @@ void WK_BuildPacket_2401()
     pkt_num = (pkt_num + 1) % 12;
 }
 
-MODULE_CALLTYPE
 static u16 wk_cb()
 {
     if (txState == 0) {

--- a/src/protocol/yd717_nrf24l01.c
+++ b/src/protocol/yd717_nrf24l01.c
@@ -376,8 +376,6 @@ static void update_telemetry() {
 }
 #endif
 
-
-MODULE_CALLTYPE
 static u16 yd717_callback()
 {
     switch (phase) {


### PR DESCRIPTION
They are not needed. As GCC document states clearly that all the calls
through function pointer are always long-call.