### PR TITLE
Fix modal tracking bug introduced in PR #543

### DIFF
--- a/src/pages/128x64x1/debuglog_page.c
+++ b/src/pages/128x64x1/debuglog_page.c
@@ -33,6 +33,7 @@ void PAGE_DebuglogInit(int page)
 {
     (void)page;
     PAGE_ShowHeader(PAGE_GetName(PAGEID_DEBUGLOG));
+    PAGE_SetModal(0);
 
     find_line_ends();
     GUI_CreateScrollable(&gui->scrollable,

--- a/src/pages/128x64x1/main_page.c
+++ b/src/pages/128x64x1/main_page.c
@@ -66,6 +66,7 @@ void PAGE_MainInit(int page)
     TGLICO_LoadFonts();
     memset(mp, 0, sizeof(struct main_page));// Bug fix: must initialize this structure to avoid unpredictable issues in the PAGE_MainEvent
     memset(gui, 0, sizeof(struct mainpage_obj));
+    PAGE_SetModal(0);
     PAGE_SetActionCB(_action_cb);
     next_scan = CLOCK_getms()+BATTERY_SCAN_MSEC;
 

--- a/src/pages/128x64x1/model_page.c
+++ b/src/pages/128x64x1/model_page.c
@@ -149,6 +149,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 void PAGE_ModelInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     memset(gui, 0, sizeof(struct modelpage_obj));
     mp->file_state = 0;
     mp->last_txpower = Model.tx_power;

--- a/src/pages/128x64x1/model_page.c
+++ b/src/pages/128x64x1/model_page.c
@@ -175,7 +175,6 @@ static void _changename_done_cb(guiObject_t *obj, void *data)  // devo8 doesn't 
         //Save model info here so it shows up on the model page
         CONFIG_SaveModelIfNeeded();
     }
-    PAGE_SetModal(0);
     PAGE_ModelInit(-1);
 }
 

--- a/src/pages/128x64x1/model_page.c
+++ b/src/pages/128x64x1/model_page.c
@@ -175,6 +175,7 @@ static void _changename_done_cb(guiObject_t *obj, void *data)  // devo8 doesn't 
         //Save model info here so it shows up on the model page
         CONFIG_SaveModelIfNeeded();
     }
+    PAGE_SetModal(0);
     PAGE_ModelInit(-1);
 }
 

--- a/src/pages/128x64x1/standard/common_standard.c
+++ b/src/pages/128x64x1/standard/common_standard.c
@@ -58,6 +58,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 
 void STANDARD_Init(const struct page_defs *page_defs)
 {
+    PAGE_SetModal(0);
     PAGE_RemoveAllObjects();
     PAGE_ShowHeader(_tr(page_defs->title));
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,

--- a/src/pages/128x64x1/standard/curves_page.c
+++ b/src/pages/128x64x1/standard/curves_page.c
@@ -88,6 +88,7 @@ static void press_cb(guiObject_t *obj, void *data)
 static void show_page(CurvesMode _curve_mode, int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     memset(mp, 0, sizeof(*mp));
     curve_mode = _curve_mode;
     int count;

--- a/src/pages/128x64x1/standard/drexp_page.c
+++ b/src/pages/128x64x1/standard/drexp_page.c
@@ -73,6 +73,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 void PAGE_DrExpInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     // draw a underline only:
     GUI_CreateRect(&gui->rect, 0, HEADER_WIDGET_HEIGHT, LCD_WIDTH, 1, &DEFAULT_FONT);
     memset(mp, 0, sizeof(*mp));

--- a/src/pages/128x64x1/standard/gyrosense_page.c
+++ b/src/pages/128x64x1/standard/gyrosense_page.c
@@ -39,6 +39,7 @@ enum {
 void PAGE_GyroSenseInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     memset(mp, 0, sizeof(*mp));
     int expected = INPUT_NumSwitchPos(mapped_std_channels.switches[SWITCHFUNC_GYROSENSE]);
     int count = STDMIX_GetMixers(mp->mixer_ptr, mapped_std_channels.aux2, GYROMIXER_COUNT);

--- a/src/pages/128x64x1/standard/swash_page.c
+++ b/src/pages/128x64x1/standard/swash_page.c
@@ -37,6 +37,7 @@ enum {
 void PAGE_SwashInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     get_swash();
     PAGE_ShowHeaderWithSize(_tr("SwashType"), LABEL_WIDTH, HEADER_HEIGHT);
     GUI_CreateTextSelectPlate(&gui->type, FIELD_X, 0, FIELD_WIDTH, HEADER_WIDGET_HEIGHT, &TEXTSEL_FONT, NULL, swash_val_cb, NULL); // FIXME: need a special value for header button/textsels

--- a/src/pages/128x64x1/standard/switchassign_page.c
+++ b/src/pages/128x64x1/standard/switchassign_page.c
@@ -74,6 +74,7 @@ void PAGE_SwitchAssignInit(int page)
 {
     (void)page;
     PAGE_SetActionCB(_action_cb);
+    PAGE_SetModal(0);
     refresh_switches();
 
     PAGE_ShowHeader(_tr("Press ENT to change"));

--- a/src/pages/128x64x1/standard/throhold_page.c
+++ b/src/pages/128x64x1/standard/throhold_page.c
@@ -35,6 +35,8 @@ enum {
 void PAGE_ThroHoldInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
+
     PAGE_ShowHeader(_tr("Throttle hold"));
 
     u8 y = HEADER_HEIGHT + HEADER_OFFSET;

--- a/src/pages/128x64x1/standard/traveladj_page.c
+++ b/src/pages/128x64x1/standard/traveladj_page.c
@@ -57,6 +57,8 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 void PAGE_TravelAdjInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
+
     PAGE_ShowHeader(("")); // draw a underline only
     GUI_CreateLabelBox(&gui->dnlbl, HEADER1_X, 0, HEADER1_WIDTH, LINE_HEIGHT, &TITLE_FONT, GUI_Localize, NULL, _tr_noop("Down"));
     GUI_CreateLabelBox(&gui->uplbl, HEADER2_X, 0, HEADER2_WIDTH, LINE_HEIGHT, &TITLE_FONT, GUI_Localize, NULL, _tr_noop("Up"));

--- a/src/pages/128x64x1/telemconfig_page.c
+++ b/src/pages/128x64x1/telemconfig_page.c
@@ -74,6 +74,7 @@ void PAGE_TelemconfigInit(int page)
     (void)page;
     //if (page < 0)
     //    page = current_selected;
+    PAGE_SetModal(0);
     if (telem_state_check() == 0) {
         GUI_CreateLabelBox(&gui->msg, MSG_X, MSG_Y, 0, 0, &DEFAULT_FONT, NULL, NULL, tempstring);
         OBJ_SET_USED(&gui->value, 0);  // A indication not allow to scroll up/down

--- a/src/pages/128x64x1/telemtest_page.c
+++ b/src/pages/128x64x1/telemtest_page.c
@@ -442,6 +442,7 @@ void PAGE_ShowTelemetryAlarm()
 void PAGE_TelemtestInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     PAGE_SetActionCB(_action_cb);
     if (telem_state_check() == 0) {
         current_page = telemetry_off;

--- a/src/pages/128x64x1/tx_configure.c
+++ b/src/pages/128x64x1/tx_configure.c
@@ -212,6 +212,7 @@ void PAGE_TxConfigureInit(int page)
 {
     (void)page;
     cp->enable = CALIB_NONE;
+    PAGE_SetModal(0);
     PAGE_ShowHeader(_tr("Configure"));
 
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,

--- a/src/pages/128x64x1/voiceconfig_page.c
+++ b/src/pages/128x64x1/voiceconfig_page.c
@@ -55,6 +55,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
 void PAGE_VoiceconfigInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     if ( !AUDIO_VoiceAvailable() ) {
         GUI_CreateLabelBox(&gui->msg, MSG_X, MSG_Y, 0, 0, &LABEL_FONT, GUI_Localize, NULL,
             _tr_noop("External voice\ncurrently not\navailable"));

--- a/src/pages/320x240x16/main_page.c
+++ b/src/pages/320x240x16/main_page.c
@@ -50,6 +50,7 @@ void PAGE_MainInit(int page)
     (void)page;
     memset(mp, 0, sizeof(struct main_page));
     memset(gui, 0, sizeof(*gui));
+    PAGE_SetModal(0);
     BUTTON_RegisterCallback(&mp->action,
           CHAN_ButtonMask(BUT_ENTER)
           | CHAN_ButtonMask(BUT_EXIT)

--- a/src/pages/320x240x16/model_page.c
+++ b/src/pages/320x240x16/model_page.c
@@ -115,7 +115,6 @@ static void _changename_done_cb(guiObject_t *obj, void *data)
         //Save model info here so it shows up on the model page
         CONFIG_SaveModelIfNeeded();
     }
-    PAGE_SetModal(0);
     PAGE_ModelInit(0);
 }
 

--- a/src/pages/320x240x16/model_page.c
+++ b/src/pages/320x240x16/model_page.c
@@ -115,6 +115,7 @@ static void _changename_done_cb(guiObject_t *obj, void *data)
         //Save model info here so it shows up on the model page
         CONFIG_SaveModelIfNeeded();
     }
+    PAGE_SetModal(0);
     PAGE_ModelInit(0);
 }
 

--- a/src/pages/320x240x16/model_page.c
+++ b/src/pages/320x240x16/model_page.c
@@ -49,6 +49,7 @@ void PAGE_ModelInit(int page)
     mp->last_mixermode = Model.mixer_mode;
     mp->last_txpower = Model.tx_power;
     mp->file_state = 0;
+    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_MODEL));
 
     enum {

--- a/src/pages/320x240x16/pages.c
+++ b/src/pages/320x240x16/pages.c
@@ -66,7 +66,6 @@ void PAGE_ChangeByID(enum PageID id, s8 menuPage)
     if (HAS_TOUCH) {
         GUI_ChangeSelectionOnTouch(1);
     }
-    PAGE_SetModal(0);
     ActionCB = default_button_action_cb;
     pages[cur_page].init(menuPage);
     if (page_scrollable) {

--- a/src/pages/320x240x16/rtc_config.c
+++ b/src/pages/320x240x16/rtc_config.c
@@ -60,6 +60,7 @@ struct Rtc {
 void PAGE_RTCInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_RTC));
     u32 time = RTC_GetValue();
     u32 timevalue = RTC_GetTimeValue(time);

--- a/src/pages/320x240x16/telemconfig_page.c
+++ b/src/pages/320x240x16/telemconfig_page.c
@@ -35,6 +35,7 @@ void PAGE_TelemconfigInit(int page)
         LABEL_WIDTH = (COL2 - COL1),
     };
     const u8 row_height = 25;
+    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_TELEMCFG));
 
     if (telem_state_check() == 0) {

--- a/src/pages/320x240x16/telemtest_page.c
+++ b/src/pages/320x240x16/telemtest_page.c
@@ -172,6 +172,7 @@ void PAGE_ShowTelemetryAlarm()
 void PAGE_TelemtestInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_TELEMMON));
     if (telem_state_check() == 0) {
         GUI_CreateLabelBox(&gui->msg, 20, 80, 280, 100, &NARROW_FONT, NULL, NULL, tempstring);

--- a/src/pages/320x240x16/tx_configure.c
+++ b/src/pages/320x240x16/tx_configure.c
@@ -240,6 +240,7 @@ void PAGE_TxConfigureInit(int page)
 {
     (void)page;
     cp->enable = CALIB_NONE;
+    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_TXCFG));
     GUI_CreateScrollable(&gui->scrollable, 0, 32, LCD_WIDTH, LCD_HEIGHT-32,
                      LCD_HEIGHT-32, MAX_PAGE+1, row_cb, NULL, NULL, NULL);

--- a/src/pages/320x240x16/voiceconfig_page.c
+++ b/src/pages/320x240x16/voiceconfig_page.c
@@ -43,6 +43,7 @@ void PAGE_VoiceconfigInit(int page)
 {
     (void)page;
     int init_y = 40;
+    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(PAGEID_VOICECFG));
 
     if ( !AUDIO_VoiceAvailable() ) {

--- a/src/pages/common/_menus.c
+++ b/src/pages/common/_menus.c
@@ -45,6 +45,7 @@ static int menu_get_next_rowidx(unsigned *i)
 
 void _menu_init(int page)
 {
+    PAGE_SetModal(0);
     PAGE_ShowHeader(PAGE_GetName(page));
 
     unsigned idx = 0;

--- a/src/pages/common/_model_page.c
+++ b/src/pages/common/_model_page.c
@@ -94,6 +94,7 @@ static void fixedid_done_cb(guiObject_t *obj, void *data)
         Model.fixed_id = atoi(mp->fixed_id);
     }
     GUI_RemoveObj(obj);
+    PAGE_SetModal(0);
     PAGE_ModelInit(-1); // must be -1 for devo10 to get back to correct page
 }
 static void fixedid_cb(guiObject_t *obj, const void *data)

--- a/src/pages/common/_model_page.c
+++ b/src/pages/common/_model_page.c
@@ -94,7 +94,6 @@ static void fixedid_done_cb(guiObject_t *obj, void *data)
         Model.fixed_id = atoi(mp->fixed_id);
     }
     GUI_RemoveObj(obj);
-    PAGE_SetModal(0);
     PAGE_ModelInit(-1); // must be -1 for devo10 to get back to correct page
 }
 static void fixedid_cb(guiObject_t *obj, const void *data)

--- a/src/pages/common/_range_page.c
+++ b/src/pages/common/_range_page.c
@@ -32,6 +32,7 @@ void RANGE_test(int start) {
 
 void PAGE_RangeInit(int page) {
     (void)page;
+    PAGE_SetModal(0);
     memset(mp, 0, sizeof(&mp));
     mp->old_power = Model.tx_power;
     _draw_page(PROTOCOL_HasPowerAmp(Model.protocol) 

--- a/src/pages/common/_scanner_page.c
+++ b/src/pages/common/_scanner_page.c
@@ -118,6 +118,7 @@ void PAGE_ScannerInit(int page)
     (void)page;
     memset(sp, 0, sizeof(struct scanner_page));
 
+    PAGE_SetModal(0);
     _draw_page(1);
 }
 

--- a/src/pages/common/_usb_page.c
+++ b/src/pages/common/_usb_page.c
@@ -42,6 +42,7 @@ unsigned usb_cb(u32 button, unsigned flags, void *data)
 void PAGE_USBInit(int page)
 {
     (void)page;
+    PAGE_SetModal(0);
     _draw_page(0);
     BUTTON_RegisterCallback(&up->action, CHAN_ButtonMask(BUT_ENTER), BUTTON_PRESS | BUTTON_RELEASE | BUTTON_PRIORITY, usb_cb, NULL);
 }


### PR DESCRIPTION
After commit b7e1da19 if the model name or fixed id submenus are used the model config page can no longer be exited with EXT and ENT doesn't work to enter protocol options.  Seems like the modal flag is used to keep track of being in these submenus.