### PR TITLE
Cleanup USB stack to save some ROM

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -183,7 +183,7 @@ void wait_release()
 
 void USB_Connect()
 {
-    USB_Enable(0, 1);
+    MSC_Enable();
     //Disable USB Exit
     while(1) {
         if(PWR_CheckPowerSwitch())
@@ -192,6 +192,6 @@ void USB_Connect()
     wait_release();
     wait_press();
     wait_release();
-    USB_Disable();
+    MSC_Disable();
 }
 

--- a/src/pages/common/_usb_page.c
+++ b/src/pages/common/_usb_page.c
@@ -28,11 +28,11 @@ unsigned usb_cb(u32 button, unsigned flags, void *data)
         _draw_page(1);
         GUI_RefreshScreen();
         CONFIG_SaveModelIfNeeded();
-        USB_Enable(0, 1);
+        MSC_Enable();
         wait_release();
         wait_press();
         wait_release();
-        USB_Disable();
+        MSC_Disable();
         CONFIG_ReadModel(Transmitter.current_model);
         _draw_page(0);
     }

--- a/src/target.h
+++ b/src/target.h
@@ -225,12 +225,16 @@ void SSER_Initialize();
 void SSER_Stop();
 
 /* USB*/
-void USB_Enable(unsigned type, unsigned use_interrupt);
+void USB_Enable(unsigned use_interrupt);
 void USB_Disable();
 void USB_HandleISR();
 void USB_Connect();
+
 void HID_Enable();
 void HID_Disable();
+
+void MSC_Enable();
+void MSC_Disable();
 
 /* Filesystem */
 int FS_Mount(void *FAT, const char *drive);

--- a/src/target/at9/at9_stubs.c
+++ b/src/target/at9/at9_stubs.c
@@ -18,11 +18,7 @@
 #include <unistd.h>
 
 #include "common.h"
-//void USB_Enable(unsigned type, unsigned use_interrupt) {
-//    (void) type;
-//    (void)use_interrupt;
-//}
-//void USB_Disable() {}
+
 void init_err_handler() {}
 
 void SOUND_Init() {}

--- a/src/target/common/devo/msc2/usb_devo8.c
+++ b/src/target/common/devo/msc2/usb_devo8.c
@@ -24,6 +24,8 @@
 
 #define __IO volatile
 #include "usb_core.h"
+#include "usb_bot.h"
+#include "usb_istr.h"
 #define LE_WORD(x)		((x)&0xFF),((x)>>8)
 
 void USB_Init();
@@ -34,49 +36,22 @@ void (*pEpInt_OUT[7])(void) = {};
 const DEVICE_PROP *Device_Property;
 const USER_STANDARD_REQUESTS *User_Standard_Requests;
 
-extern void (*MSC_pEpInt_IN[7])(void);
-extern void (*MSC_pEpInt_OUT[7])(void);
 extern const DEVICE_PROP MSC_Device_Property;
 extern const USER_STANDARD_REQUESTS MSC_User_Standard_Requests;
 
-extern void (*HID_pEpInt_IN[7])(void);
-extern void (*HID_pEpInt_OUT[7])(void);
-extern const DEVICE_PROP HID_Device_Property;
-extern const USER_STANDARD_REQUESTS HID_User_Standard_Requests;
-
 void MSC_Init() {
-    memcpy(pEpInt_IN, MSC_pEpInt_IN, sizeof(pEpInt_IN));
-    memcpy(pEpInt_OUT, MSC_pEpInt_OUT, sizeof(pEpInt_OUT));
+    for (int i = 0; i < 7; i++) {
+        pEpInt_IN[i] = pEpInt_OUT[i] = NOP_Process;
+    }
+    pEpInt_IN[0] = EP1_IN_Callback;
+    pEpInt_OUT[1] = EP2_OUT_Callback;
+
     Device_Property = &MSC_Device_Property;
     User_Standard_Requests = &MSC_User_Standard_Requests;
 }
 
-#ifdef ENABLE_MODULAR
-void (*_HID_Init)() = NULL;
-#else
-extern void HID_Init();
-#endif
-#if 0
-void HID_Init() {
-    memcpy(pEpInt_IN, HID_pEpInt_IN, sizeof(pEpInt_IN));
-    memcpy(pEpInt_OUT, HID_pEpInt_OUT, sizeof(pEpInt_OUT));
-    Device_Property = &HID_Device_Property;
-    User_Standard_Requests = &HID_User_Standard_Requests;
-}
-#endif
-void USB_Enable(unsigned type, unsigned use_interrupt)
+void USB_Enable(unsigned use_interrupt)
 {
-    if (type == 0) {
-        //Mass Storage
-        MSC_Init();
-    } else if (type == 1) {
-#ifndef ENABLE_MODULAR
-        HID_Init();
-#else
-        if(_HID_Init)
-            _HID_Init();
-#endif
-    }
     gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_50_MHZ,
         GPIO_CNF_OUTPUT_PUSHPULL, GPIO10);
         gpio_set(GPIOB, GPIO10);
@@ -97,6 +72,17 @@ void USB_Disable()
 void USB_HandleISR()
 {
     USB_Istr();
+}
+
+void MSC_Enable()
+{
+    MSC_Init();
+    USB_Enable(1);
+}
+
+void MSC_Disable()
+{
+    USB_Disable();
 }
 
 /*

--- a/src/target/common/emu/stubs.c
+++ b/src/target/common/emu/stubs.c
@@ -34,11 +34,8 @@ void TxName(u8 *var, int len) {
     memcpy(var, model, len - 1);
     var[len-1] = 0;
 }
-void USB_Enable(unsigned type, unsigned use_interrupt) {
-    (void) type;
-    (void)use_interrupt;
-}
-void USB_Disable() {}
+void MSC_Enable() {}
+void MSC_Disable() {}
 void HID_Enable() {}
 void HID_Disable() {}
 void HID_Write(s8 *pkt, u8 size) {

--- a/src/target/test/test_stubs.c
+++ b/src/target/test/test_stubs.c
@@ -103,11 +103,8 @@ void TxName(u8 *var, int len) {
     memcpy(var, model, len - 1);
     var[len-1] = 0;
 }
-void USB_Enable(unsigned type, unsigned use_interrupt) {
-    (void) type;
-    (void)use_interrupt;
-}
-void USB_Disable() {}
+void MSC_Enable() {}
+void MSC_Disable() {}
 void HID_Enable() {}
 void HID_Disable() {}
 void HID_Write(s8 *pkt, u8 size) {

--- a/src/target/x9d/x9d_stubs.c
+++ b/src/target/x9d/x9d_stubs.c
@@ -18,11 +18,8 @@
 #include <unistd.h>
 
 #include "common.h"
-void USB_Enable(unsigned type, unsigned use_interrupt) {
-    (void) type;
-    (void)use_interrupt;
-}
-void USB_Disable() {}
+void MSC_Enable() {}
+void MSC_Disable() {}
 void HID_Enable() {}
 void HID_Disable() {}
 void HID_Write(s8 *pkt, u8 size) {


### PR DESCRIPTION
1. Split out USB_Enable from [MSC|HID]_Enable
2. Remove some duplicate code
3. remove the array EpInt_IN/OUT.