### PR TITLE
Parse the string table from osx built-in objdump

### DIFF
--- a/utils/extract_strings.pl
+++ b/utils/extract_strings.pl
@@ -133,7 +133,7 @@ sub extract_target_strings {
         my $state = 0;
         foreach(@od) {
             my $orig = $_;
-            if(/section \.ro?data/) {
+            if(/section \.ro?data/ || /section __cstring/) {
                 $str = "";
                 $state = 1;
                 next;


### PR DESCRIPTION
OSX built-in objdump shows the string table as __string instead of rodata. the change make sure I can build localized file on OSX.