### PR TITLE
Fix regression on toggle icon on f12e-XMS

### DIFF
--- a/src/target/devof12e/lcd.c
+++ b/src/target/devof12e/lcd.c
@@ -49,7 +49,7 @@ void LCD_PrintCharXY(unsigned int x, unsigned int y, u32 c)
 {
     c = TW8816_map_char(c);
 #if SUPPORT_MULTI_LANGUAGE
-    if (c > 0x300) {
+    if (c > 0x300 + LOC_CHAR_STARTS) {
         if (height == 0) {
             open_font(FontName);
             height = get_height();


### PR DESCRIPTION
the range from 0x300 - 0x350 is reserved for icons.