### PR TITLE
Fix TestCalcChannels to be order independent

### DIFF
--- a/src/mixer.c
+++ b/src/mixer.c
@@ -61,6 +61,7 @@ static s32 get_trim(unsigned src);
 // for calculation of MUX_DELAY and ApplyLimits
 // Period depends on protocol for protocols that run mixer manually
 static u32 mixer_period;
+static u32 prev_calcchannels_ms;
 
 static void MIXER_CreateCyclicOutput(volatile s32 *raw, s32 *cyclic);
 
@@ -175,10 +176,9 @@ int MIXER_GetCachedInputs(s32 *cache, unsigned threshold)
 
 void MIXER_CalcChannels()
 {
-    static u32 prev_run;
     u32 now = CLOCK_getms();
-    mixer_period = now - prev_run;
-    prev_run = now;
+    mixer_period = now - prev_calcchannels_ms;
+    prev_calcchannels_ms = now;
 
     //We retain this array so that we can refer to the prevous values in the next iteration
     int i;

--- a/src/tests/test_mixer.c
+++ b/src/tests/test_mixer.c
@@ -136,6 +136,10 @@ void TestCalcChannels(CuTest *t)
 {
     memset(&Model, 0, sizeof(Model));
     memset((s32 *)raw, 0, sizeof(raw));
+    Transmitter.mode = MODE_4;
+    for (int i = 1; i <= NUM_TX_INPUTS; i++) {
+        TEST_CHAN_SetChannelValue(i, (i + 1) * 200);
+    }
     for (int i = 0; i < 4; i++) {
         TEST_CHAN_SetChannelValue(i, (i + 1) * 200);
         Model.mixers[i].src = i + 1;


### PR DESCRIPTION
The CalcChannels test was not properly initializing all its needed inputs
Also, remove static variable for MIXER_CalcChannels as it cannot be controlled via tests