### PR TITLE
Change protocol entry function to return uintptr_t

### DIFF
--- a/src/protocol/assan_nrf24l01.c
+++ b/src/protocol/assan_nrf24l01.c
@@ -261,22 +261,22 @@ void initASSAN(u8 bind)
     CLOCK_StartTimer(50000, ASSAN_callback);
 }
 
-const void *ASSAN_Cmds(enum ProtoCmds cmd)
+uintptr_t ASSAN_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initASSAN(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)0L;
+            return (NRF24L01_Reset() ? 1L : -1L);
+        case PROTOCMD_CHECK_AUTOBIND: return 0L;
         case PROTOCMD_BIND:  initASSAN(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 8L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return (void*)0L;
+        case PROTOCMD_NUMCHAN: return  8L;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8L;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return 0L;
         case PROTOCMD_CHANNELMAP: return AETRG;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         default: break;
     }
     return 0;

--- a/src/protocol/bayang_nrf24l01.c
+++ b/src/protocol/bayang_nrf24l01.c
@@ -506,7 +506,7 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, bay_callback);
 }
 
-const void *Bayang_Cmds(enum ProtoCmds cmd)
+uintptr_t Bayang_Cmds(enum ProtoCmds cmd)
 {
     switch (cmd) {
     case PROTOCMD_INIT:
@@ -515,27 +515,26 @@ const void *Bayang_Cmds(enum ProtoCmds cmd)
     case PROTOCMD_DEINIT:
     case PROTOCMD_RESET:
         CLOCK_StopTimer();
-        return (void *) (NRF24L01_Reset()? 1L : -1L);
+        return (NRF24L01_Reset()? 1 : -1);
     case PROTOCMD_CHECK_AUTOBIND:
-        return (void *) 1L;     // always Autobind
+        return 1;     // always Autobind
     case PROTOCMD_BIND:
         initialize();
         return 0;
     case PROTOCMD_NUMCHAN:
-        return (void *) 12L;
+        return 12;
     case PROTOCMD_DEFAULT_NUMCHAN:
-        return (void *) 12L;
+        return 12;
     case PROTOCMD_CURRENT_ID:
-        return Model.fixed_id ? (void *) ((unsigned long) Model.
-                                          fixed_id) : 0;
+        return Model.fixed_id;
     case PROTOCMD_GETOPTIONS:
-        return bay_opts;
+        return (uintptr_t)bay_opts;
     case PROTOCMD_TELEMETRYSTATE:
-        return (void *) (long) (Model.proto_opts[PROTOOPTS_TELEMETRY] ==
+        return (Model.proto_opts[PROTOOPTS_TELEMETRY] ==
                                 TELEM_ON ? PROTO_TELEM_ON :
                                 PROTO_TELEM_OFF);
     case PROTOCMD_TELEMETRYTYPE:
-        return (void *)(long) TELEM_DSM;
+        return TELEM_DSM;
     case PROTOCMD_CHANNELMAP:
         return AETRG;
     default:

--- a/src/protocol/bluefly_nrf24l01.c
+++ b/src/protocol/bluefly_nrf24l01.c
@@ -261,20 +261,20 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(1000, bluefly_cb);
 }
 
-const void *BlueFly_Cmds(enum ProtoCmds cmd)
+uintptr_t BlueFly_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT: initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)0L; //Never Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)6L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 6;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/bluefly_nrf24l01.c
+++ b/src/protocol/bluefly_nrf24l01.c
@@ -269,7 +269,7 @@ uintptr_t BlueFly_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 0;  // Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
         case PROTOCMD_NUMCHAN: return 6;
         case PROTOCMD_DEFAULT_NUMCHAN: return 6;

--- a/src/protocol/bugs3_a7105.c
+++ b/src/protocol/bugs3_a7105.c
@@ -711,24 +711,24 @@ static void initialize(u8 bind) {
     CLOCK_StartTimer(100, bugs3_cb);
 }
 
-const void *BUGS3_Cmds(enum ProtoCmds cmd)
+uintptr_t BUGS3_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT: initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(A7105_Reset() ? 1L : -1L);
+            return (A7105_Reset() ? 1 : -1);
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)10L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)10L;
+        case PROTOCMD_NUMCHAN: return 10;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 10;
         case PROTOCMD_CURRENT_ID: return 0;
         case PROTOCMD_GETOPTIONS:
-            return bugs3_opts;
+            return (uintptr_t)bugs3_opts;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)(PROTO_TELEM_ON);
+            return PROTO_TELEM_ON;
         case PROTOCMD_TELEMETRYTYPE:
-            return (void *)(long) TELEM_FRSKY;
+            return TELEM_FRSKY;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/bugs3mini_nrf24l01.c
+++ b/src/protocol/bugs3mini_nrf24l01.c
@@ -438,24 +438,24 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(INITIAL_WAIT, bugs3mini_callback);
 }
 
-const void *BUGS3MINI_Cmds(enum ProtoCmds cmd)
+uintptr_t BUGS3MINI_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
+            return (NRF24L01_Reset() ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND: return 0;
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)10L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)10L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return bugs3mini_opts;
+        case PROTOCMD_NUMCHAN: return 10;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 10;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)bugs3mini_opts;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long) PROTO_TELEM_ON;
+            return PROTO_TELEM_ON;
         case PROTOCMD_TELEMETRYTYPE:
-            return (void *)(long) TELEM_FRSKY;
+            return TELEM_FRSKY;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/cflie_nrf24l01.c
+++ b/src/protocol/cflie_nrf24l01.c
@@ -883,7 +883,7 @@ static void initialize()
     CLOCK_StartTimer(delay, cflie_callback);
 }
 
-const void *CFlie_Cmds(enum ProtoCmds cmd)
+uintptr_t CFlie_Cmds(enum ProtoCmds cmd)
 {
     // dbgprintf("CFlie_Cmds %d\n", cmd);
     switch(cmd) {
@@ -892,23 +892,23 @@ const void *CFlie_Cmds(enum ProtoCmds cmd)
             CLOCK_StopTimer();
             NRF24L01_WriteReg(NRF24L01_00_CONFIG, 0);
             return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)0L; // never Autobind // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 0; // never Autobind // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN:
             switch(Model.proto_opts[PROTOOPTS_CRTP_MODE]) {
                 case CRTP_MODE_CPPM:
-                    return (void *)12L;  // A, E, R, T, up to 8 additional aux channels
+                    return 12;  // A, E, R, T, up to 8 additional aux channels
                 case CRTP_MODE_RPYT:
                 default:
-                    return (void *)5L; // A, E, R, T, + or x mode
+                    return 5; // A, E, R, T, + or x mode
             }
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)5L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return cflie_opts;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 5;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)cflie_opts;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_OFF ? PROTO_TELEM_OFF : PROTO_TELEM_ON);
+            return (Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_OFF ? PROTO_TELEM_OFF : PROTO_TELEM_ON);
         case PROTOCMD_TELEMETRYTYPE: 
-            return (void *)(long) TELEM_DSM;
+            return TELEM_DSM;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/cflie_nrf24l01.c
+++ b/src/protocol/cflie_nrf24l01.c
@@ -892,15 +892,15 @@ uintptr_t CFlie_Cmds(enum ProtoCmds cmd)
             CLOCK_StopTimer();
             NRF24L01_WriteReg(NRF24L01_00_CONFIG, 0);
             return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return 0; // never Autobind // always Autobind
-        case PROTOCMD_BIND:  initialize(); return 0;
+        case PROTOCMD_CHECK_AUTOBIND: return 0;  // never Autobind
+        case PROTOCMD_BIND: initialize(); return 0;
         case PROTOCMD_NUMCHAN:
             switch(Model.proto_opts[PROTOOPTS_CRTP_MODE]) {
                 case CRTP_MODE_CPPM:
                     return 12;  // A, E, R, T, up to 8 additional aux channels
                 case CRTP_MODE_RPYT:
                 default:
-                    return 5; // A, E, R, T, + or x mode
+                    return 5;  // A, E, R, T, + or x mode
             }
         case PROTOCMD_DEFAULT_NUMCHAN: return 5;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;

--- a/src/protocol/cg023_nrf24l01.c
+++ b/src/protocol/cg023_nrf24l01.c
@@ -326,21 +326,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, cg023_callback);
 }
 
-const void *CG023_Cmds(enum ProtoCmds cmd)
+uintptr_t CG023_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 9L; // A, E, T, R, light, flip, photo, video, headless
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)9L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return cg023_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  9; // A, E, T, R, light, flip, photo, video, headless
+        case PROTOCMD_DEFAULT_NUMCHAN: return 9;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)cg023_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/cg023_nrf24l01.c
+++ b/src/protocol/cg023_nrf24l01.c
@@ -334,9 +334,9 @@ uintptr_t CG023_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
-        case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return  9; // A, E, T, R, light, flip, photo, video, headless
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
+        case PROTOCMD_BIND: initialize(); return 0;
+        case PROTOCMD_NUMCHAN: return 9;  // A, E, T, R, light, flip, photo, video, headless
         case PROTOCMD_DEFAULT_NUMCHAN: return 9;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return (uintptr_t)cg023_opts;

--- a/src/protocol/corona_cc2500.c
+++ b/src/protocol/corona_cc2500.c
@@ -362,20 +362,20 @@ static void initialize(u8 bind)
   CLOCK_StartTimer(10, corona_cb);
 }
 
-const void *Corona_Cmds(enum ProtoCmds cmd)
+uintptr_t Corona_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(CC2500_Reset() ? 1L : -1L);
+            return (CC2500_Reset() ? 1 : -1);
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)8L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return (void *)((long)Model.fixed_id);
-        case PROTOCMD_GETOPTIONS: return corona_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 8;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)corona_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -348,21 +348,21 @@ static void initialize()
     CLOCK_StartTimer(1000, serial_cb);
 }
 
-const void * CRSF_Cmds(enum ProtoCmds cmd)
+uintptr_t CRSF_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT: UART_Stop(); UART_Initialize(); return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L;
+        case PROTOCMD_CHECK_AUTOBIND: return 1;
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)16L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-	case PROTOCMD_CHANNELMAP: return UNCHG;
+        case PROTOCMD_NUMCHAN: return 16;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CHANNELMAP: return UNCHG;
 #if HAS_EXTENDED_TELEMETRY
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)PROTO_TELEM_ON;
+            return PROTO_TELEM_ON;
         case PROTOCMD_TELEMETRYTYPE:
-            return (void *)(long) TELEM_CRSF;
+            return TELEM_CRSF;
 #endif
         default: break;
     }

--- a/src/protocol/cx10_nrf24l01.c
+++ b/src/protocol/cx10_nrf24l01.c
@@ -479,9 +479,9 @@ uintptr_t CX10_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
-        case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return  12; // A, E, T, R, flight mode, enable flip, photo, video, headless, RTH, X and Y calibration
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
+        case PROTOCMD_BIND: initialize(); return 0;
+        case PROTOCMD_NUMCHAN: return 12;  // A, E, T, R, flight mode, enable flip, photo, video, headless, RTH, X and Y calibration
         case PROTOCMD_DEFAULT_NUMCHAN: return 5;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return (uintptr_t)cx10_opts;

--- a/src/protocol/cx10_nrf24l01.c
+++ b/src/protocol/cx10_nrf24l01.c
@@ -471,21 +471,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, cx10_callback);
 }
 
-const void *CX10_Cmds(enum ProtoCmds cmd)
+uintptr_t CX10_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 12L; // A, E, T, R, flight mode, enable flip, photo, video, headless, RTH, X and Y calibration
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)5L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return cx10_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  12; // A, E, T, R, flight mode, enable flip, photo, video, headless, RTH, X and Y calibration
+        case PROTOCMD_DEFAULT_NUMCHAN: return 5;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)cx10_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/devo_cyrf6936.c
+++ b/src/protocol/devo_cyrf6936.c
@@ -615,28 +615,28 @@ static void initialize()
     devo_start();
 }
 
-const void *DEVO_Cmds(enum ProtoCmds cmd)
+uintptr_t DEVO_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(CYRF_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return Model.fixed_id ? 0 : (void *)1L;
+            return (CYRF_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return Model.fixed_id ? 0 : 1;
         case PROTOCMD_BIND:  devo_bind(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)12L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID:  return (void *)((unsigned long)fixed_id);
+        case PROTOCMD_NUMCHAN: return 12;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID:  return fixed_id;
         case PROTOCMD_GETOPTIONS:
-            return devo_opts;
+            return (uintptr_t)devo_opts;
         case PROTOCMD_SETOPTIONS:
             devo_start();  // only 1 prot_ops item, it is to enable/disable telemetry
             break;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(Model.proto_opts[PROTOOPTS_TELEMETRY] != TELEM_OFF ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
+            return (Model.proto_opts[PROTOOPTS_TELEMETRY] != TELEM_OFF ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_TELEMETRYTYPE: 
-            return (void *)(long) TELEM_DEVO;
+            return TELEM_DEVO;
         case PROTOCMD_CHANNELMAP:
             return EATRG;
         default: break;

--- a/src/protocol/dm002_nrf24l01.c
+++ b/src/protocol/dm002_nrf24l01.c
@@ -266,8 +266,8 @@ uintptr_t DM002_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
-        case PROTOCMD_BIND:  initialize(); return 0;
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
+        case PROTOCMD_BIND: initialize(); return 0;
         case PROTOCMD_NUMCHAN: return 10;
         case PROTOCMD_DEFAULT_NUMCHAN: return 10;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;

--- a/src/protocol/dm002_nrf24l01.c
+++ b/src/protocol/dm002_nrf24l01.c
@@ -258,21 +258,21 @@ static void initialize()
     CLOCK_StartTimer(DM002_INITIAL_WAIT, dm002_callback);
 }
 
-const void *DM002_Cmds(enum ProtoCmds cmd)
+uintptr_t DM002_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 10L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)10L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return (void*)0L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 10;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 10;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return 0;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/dsm2_cyrf6936.c
+++ b/src/protocol/dsm2_cyrf6936.c
@@ -893,30 +893,30 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(10000, dsm2_cb);
 }
 
-const void *DSM2_Cmds(enum ProtoCmds cmd)
+uintptr_t DSM2_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(CYRF_Reset() ? 1L : -1L);
+            return (CYRF_Reset() ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)12L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)7L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
+        case PROTOCMD_NUMCHAN: return 12;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 7;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS:
-            return dsm_opts;
+            return (uintptr_t)dsm_opts;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
+            return (Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_TELEMETRYTYPE: 
-            return (void *)(long) TELEM_DSM;
+            return TELEM_DSM;
         case PROTOCMD_CHANNELMAP:
             return TAERG;
         default: break;
     }
-    return NULL;
+    return 0;
 }
 
 #endif

--- a/src/protocol/e012_nrf24l01.c
+++ b/src/protocol/e012_nrf24l01.c
@@ -245,21 +245,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, e012_callback);
 }
 
-const void *E012_Cmds(enum ProtoCmds cmd)
+uintptr_t E012_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 10L; // A, E, T, R, n/a , flip, n/a, n/a, headless, RTH
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)10L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return (void *)0L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 10; // A, E, T, R, n/a , flip, n/a, n/a, headless, RTH
+        case PROTOCMD_DEFAULT_NUMCHAN: return 10;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return 0;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/e012_nrf24l01.c
+++ b/src/protocol/e012_nrf24l01.c
@@ -253,9 +253,9 @@ uintptr_t E012_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
-        case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return 10; // A, E, T, R, n/a , flip, n/a, n/a, headless, RTH
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
+        case PROTOCMD_BIND: initialize(); return 0;
+        case PROTOCMD_NUMCHAN: return 10;  // A, E, T, R, n/a , flip, n/a, n/a, headless, RTH
         case PROTOCMD_DEFAULT_NUMCHAN: return 10;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return 0;

--- a/src/protocol/e015_nrf24l01.c
+++ b/src/protocol/e015_nrf24l01.c
@@ -286,9 +286,9 @@ uintptr_t E015_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
-        case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return  10;
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
+        case PROTOCMD_BIND: initialize(); return 0;
+        case PROTOCMD_NUMCHAN: return 10;
         case PROTOCMD_DEFAULT_NUMCHAN: return 10;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return 0;

--- a/src/protocol/e015_nrf24l01.c
+++ b/src/protocol/e015_nrf24l01.c
@@ -278,21 +278,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, e015_callback);
 }
 
-const void *E015_Cmds(enum ProtoCmds cmd)
+uintptr_t E015_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 10L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)10L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return (void *)0L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  10;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 10;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return 0;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/esky150_nrf24l01.c
+++ b/src/protocol/esky150_nrf24l01.c
@@ -167,7 +167,7 @@ static u8 flags;
 //================================================================================================
 // Public Functions
 //================================================================================================
-const void *ESKY150_Cmds(enum ProtoCmds cmd)
+uintptr_t ESKY150_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:
@@ -176,22 +176,22 @@ const void *ESKY150_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)((NRF24L01_Reset()) ? 1L : -1L);
+            return ((NRF24L01_Reset()) ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND:
-            return (void *)0L; // Never Autobind
+            return 0; // Never Autobind
         case PROTOCMD_BIND:
         	esky2_start_tx(STARTBIND_YES);
 			return 0;
         case PROTOCMD_NUMCHAN:
-            return (void *)7L; // T, A, E, R, FMODE, AUX1, AUX2
+            return 7; // T, A, E, R, FMODE, AUX1, AUX2
         case PROTOCMD_DEFAULT_NUMCHAN:
-            return (void *)4L;
+            return 4;
         case PROTOCMD_CURRENT_ID: 
-            return (Model.fixed_id) ? (void *)Model.fixed_id : 0;
+            return (Model.fixed_id) ? Model.fixed_id : 0;
         case PROTOCMD_GETOPTIONS: 
-            return ESKY2_PROTOCOL_OPTIONS;
+            return (uintptr_t)ESKY2_PROTOCOL_OPTIONS;
         case PROTOCMD_TELEMETRYSTATE: 
-            return (void *)PROTO_TELEM_UNSUPPORTED;
+            return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP:
             return TAERG;
         default: break;

--- a/src/protocol/esky150_nrf24l01.c
+++ b/src/protocol/esky150_nrf24l01.c
@@ -171,19 +171,19 @@ uintptr_t ESKY150_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:
-        	esky2_start_tx((Model.proto_opts[PROTOOPTS_STARTBIND] == STARTBIND_YES));
+            esky2_start_tx((Model.proto_opts[PROTOOPTS_STARTBIND] == STARTBIND_YES));
             return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return ((NRF24L01_Reset()) ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND:
-            return 0; // Never Autobind
+            return 0;  // Never Autobind
         case PROTOCMD_BIND:
-        	esky2_start_tx(STARTBIND_YES);
-			return 0;
+            esky2_start_tx(STARTBIND_YES);
+            return 0;
         case PROTOCMD_NUMCHAN:
-            return 7; // T, A, E, R, FMODE, AUX1, AUX2
+            return 7;  // T, A, E, R, FMODE, AUX1, AUX2
         case PROTOCMD_DEFAULT_NUMCHAN:
             return 4;
         case PROTOCMD_CURRENT_ID: 

--- a/src/protocol/esky_nrf24l01.c
+++ b/src/protocol/esky_nrf24l01.c
@@ -352,9 +352,9 @@ uintptr_t ESKY_Cmds(enum ProtoCmds cmd)
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT: return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 0;  // Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return 6; // AETRGP
+        case PROTOCMD_NUMCHAN: return 6;  // AETRGP
         case PROTOCMD_DEFAULT_NUMCHAN: return 6;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;

--- a/src/protocol/esky_nrf24l01.c
+++ b/src/protocol/esky_nrf24l01.c
@@ -347,18 +347,17 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(50000, esky_callback);
 }
 
-const void *ESKY_Cmds(enum ProtoCmds cmd)
+uintptr_t ESKY_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT: return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)0L; //Never Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 6L; // AETRGP
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
-        // TODO: return id correctly
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_TELEMETRYSTATE: return (void *) PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 6; // AETRGP
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/flysky_a7105.c
+++ b/src/protocol/flysky_a7105.c
@@ -430,22 +430,22 @@ static void initialize(u8 bind) {
     CLOCK_StartTimer(2400, flysky_cb);
 }
 
-const void *FLYSKY_Cmds(enum ProtoCmds cmd)
+uintptr_t FLYSKY_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(A7105_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return Model.fixed_id ? 0 : (void *)1L;
+            return (A7105_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return Model.fixed_id ? 0 : 1;
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)12L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return (void *)((unsigned long)id);
+        case PROTOCMD_NUMCHAN: return 12;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID: return id;
         case PROTOCMD_GETOPTIONS:
-            return flysky_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+            return (uintptr_t)flysky_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/flysky_afhds2a_a7105.c
+++ b/src/protocol/flysky_afhds2a_a7105.c
@@ -628,27 +628,27 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(50000, afhds2a_cb);
 }
 
-const void *AFHDS2A_Cmds(enum ProtoCmds cmd)
+uintptr_t AFHDS2A_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(A7105_Reset() ? 1L : -1L);
+            return (A7105_Reset() ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND: return 0;
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)14L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
+        case PROTOCMD_NUMCHAN: return 14;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS:
             if( Model.proto_opts[PROTOOPTS_SERVO_HZ] < 50 || Model.proto_opts[PROTOOPTS_SERVO_HZ] > 400)
                 Model.proto_opts[PROTOOPTS_SERVO_HZ] = 50;
-            return afhds2a_opts;
+            return (uintptr_t)afhds2a_opts;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long) PROTO_TELEM_ON;
+            return PROTO_TELEM_ON;
         case PROTOCMD_TELEMETRYTYPE:
-            return (void *)(long) TELEM_FRSKY;
+            return TELEM_FRSKY;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/fq777_nrf24l01.c
+++ b/src/protocol/fq777_nrf24l01.c
@@ -327,21 +327,21 @@ void initFQ777(void)
     CLOCK_StartTimer(INITIAL_WAIT, fq777_callback);
 }
 
-const void *FQ777_Cmds(enum ProtoCmds cmd)
+uintptr_t FQ777_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initFQ777(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initFQ777(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 10L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)10L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return fq777_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 10;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 10;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)fq777_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/fq777_nrf24l01.c
+++ b/src/protocol/fq777_nrf24l01.c
@@ -335,8 +335,8 @@ uintptr_t FQ777_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
-        case PROTOCMD_BIND:  initFQ777(); return 0;
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
+        case PROTOCMD_BIND: initFQ777(); return 0;
         case PROTOCMD_NUMCHAN: return 10;
         case PROTOCMD_DEFAULT_NUMCHAN: return 10;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;

--- a/src/protocol/frsky1way_cc2500.c
+++ b/src/protocol/frsky1way_cc2500.c
@@ -332,21 +332,21 @@ static void initialize(int bind)
     CLOCK_StartTimer(10000, frsky_cb);
 }
 
-const void *FRSKY1WAY_Cmds(enum ProtoCmds cmd)
+uintptr_t FRSKY1WAY_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(CC2500_Reset() ? 1L : -1L);
+            return (CC2500_Reset() ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)8L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return frsky_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 8;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)frsky_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/frsky2way_cc2500.c
+++ b/src/protocol/frsky2way_cc2500.c
@@ -507,25 +507,25 @@ static void initialize(int bind)
 #endif
 }
 
-const void *FRSKY2WAY_Cmds(enum ProtoCmds cmd)
+uintptr_t FRSKY2WAY_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)8L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
+        case PROTOCMD_NUMCHAN: return 8;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS:
-            return frsky_opts;
+            return (uintptr_t)frsky_opts;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)(Model.proto_opts[PROTO_OPTS_TELEM] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
+            return (Model.proto_opts[PROTO_OPTS_TELEM] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_RESET:
         case PROTOCMD_DEINIT:
             CLOCK_StopTimer();
-            return (void *)(CC2500_Reset() ? 1L : -1L);
+            return (CC2500_Reset() ? 1 : -1);
         case PROTOCMD_TELEMETRYTYPE: 
-            return (void *)(long) TELEM_FRSKY;
+            return TELEM_FRSKY;
         case PROTOCMD_TELEMETRYRESET:
 #if HAS_EXTENDED_TELEMETRY
             Model.ground_level = 0;

--- a/src/protocol/frskyx_cc2500.c
+++ b/src/protocol/frskyx_cc2500.c
@@ -702,22 +702,23 @@ static void initialize(int bind)
 #endif
 }
 
-const void *FRSKYX_Cmds(enum ProtoCmds cmd)
+uintptr_t FRSKYX_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT: initialize(0); return 0;
         case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)16L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
+        case PROTOCMD_NUMCHAN: return 16;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS:
-            if (!Model.proto_opts[PROTO_OPTS_AD2GAIN]) Model.proto_opts[PROTO_OPTS_AD2GAIN] = 100;  // if not set, default to no gain
-            return frskyx_opts;
+            if (!Model.proto_opts[PROTO_OPTS_AD2GAIN])
+                Model.proto_opts[PROTO_OPTS_AD2GAIN] = 100;  // if not set, default to no gain
+            return (uintptr_t)frskyx_opts;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)PROTO_TELEM_ON;
+            return PROTO_TELEM_ON;
         case PROTOCMD_TELEMETRYTYPE:
-            return (void *)(long) TELEM_FRSKY;
+            return TELEM_FRSKY;
         case PROTOCMD_TELEMETRYRESET:
 #if HAS_EXTENDED_TELEMETRY
             Model.ground_level = 0;
@@ -733,7 +734,7 @@ const void *FRSKYX_Cmds(enum ProtoCmds cmd)
             }
 #endif
             CLOCK_StopTimer();
-            return (void *)(CC2500_Reset() ? 1L : -1L);
+            return (CC2500_Reset() ? 1 : -1);
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/fy326_nrf24l01.c
+++ b/src/protocol/fy326_nrf24l01.c
@@ -384,9 +384,9 @@ uintptr_t FY326_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
-        case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return  11;
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
+        case PROTOCMD_BIND: initialize(); return 0;
+        case PROTOCMD_NUMCHAN: return 11;
         case PROTOCMD_DEFAULT_NUMCHAN: return 11;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return (uintptr_t)fy326_opts;

--- a/src/protocol/fy326_nrf24l01.c
+++ b/src/protocol/fy326_nrf24l01.c
@@ -376,21 +376,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, fy326_callback);
 }
 
-const void *FY326_Cmds(enum ProtoCmds cmd)
+uintptr_t FY326_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 11L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *) 11L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return fy326_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  11;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 11;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)fy326_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/gd00x_nrf24l01.c
+++ b/src/protocol/gd00x_nrf24l01.c
@@ -227,21 +227,21 @@ static void initialize()
     CLOCK_StartTimer(GD00X_INITIAL_WAIT, GD00X_callback);
 }
 
-const void *GD00X_Cmds(enum ProtoCmds cmd)
+uintptr_t GD00X_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L;
-        case PROTOCMD_BIND:  initialize(); return (void*)0L;
-        case PROTOCMD_NUMCHAN: return (void *) 5L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)5L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return (void*)0L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1;
+        case PROTOCMD_BIND:  initialize(); return 0;
+        case PROTOCMD_NUMCHAN: return 5;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 5;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return 0;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/gw008_nrf24l01.c
+++ b/src/protocol/gw008_nrf24l01.c
@@ -243,21 +243,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, gw008_callback);
 }
 
-const void *GW008_Cmds(enum ProtoCmds cmd)
+uintptr_t GW008_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 6L; // A, E, T, R, N/A, flip
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return (void*)0L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 6; // A, E, T, R, N/A, flip
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return 0;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/gw008_nrf24l01.c
+++ b/src/protocol/gw008_nrf24l01.c
@@ -251,9 +251,9 @@ uintptr_t GW008_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return 6; // A, E, T, R, N/A, flip
+        case PROTOCMD_NUMCHAN: return 6;  // A, E, T, R, N/A, flip
         case PROTOCMD_DEFAULT_NUMCHAN: return 6;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return 0;

--- a/src/protocol/h377_nrf24l01.c
+++ b/src/protocol/h377_nrf24l01.c
@@ -358,7 +358,7 @@ uintptr_t H377_Cmds(enum ProtoCmds cmd)
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND:
-            return 0; //Never Autobind
+            return 0;  // Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
         case PROTOCMD_NUMCHAN: return 6;
         case PROTOCMD_DEFAULT_NUMCHAN: return 6;

--- a/src/protocol/h377_nrf24l01.c
+++ b/src/protocol/h377_nrf24l01.c
@@ -348,21 +348,22 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(1000, h377_cb);
 }
 
-const void *H377_Cmds(enum ProtoCmds cmd)
+uintptr_t H377_Cmds(enum ProtoCmds cmd)
 {
      
     switch(cmd) {
-        case PROTOCMD_INIT:  initialize(0); printf("=>H377 : cmd %d PROTOCMD_INIT\n", cmd); return 0;
+        case PROTOCMD_INIT: initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: printf("=>H377 : cmd %d PROTOCMD_CHECK_AUTOBIND\n", cmd); return (void *)0L; //Never Autobind
-        case PROTOCMD_BIND:  initialize(1); printf("=>H377 : cmd %d PROTOCMD_BIND\n", cmd); return 0;
-        case PROTOCMD_NUMCHAN: printf("=>H377 : cmd %d PROTOCMD_NUMCHAN\n", cmd); return (void *)6L;
-        case PROTOCMD_DEFAULT_NUMCHAN: printf("=>H377 : cmd %d PROTOCMD_DEFAULT_NUMCHAN\n", cmd); return (void *)6L;
-        case PROTOCMD_CURRENT_ID: printf("=>H377 : cmd %d PROTOCMD_CURRENT_ID\n", cmd); return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_TELEMETRYSTATE: return (void *) PROTO_TELEM_UNSUPPORTED;
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND:
+            return 0; //Never Autobind
+        case PROTOCMD_BIND:  initialize(1); return 0;
+        case PROTOCMD_NUMCHAN: return 6;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/h8_3d_nrf24l01.c
+++ b/src/protocol/h8_3d_nrf24l01.c
@@ -482,21 +482,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, h8_3d_callback);
 }
 
-const void *H8_3D_Cmds(enum ProtoCmds cmd)
+uintptr_t H8_3D_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 11L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)11L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return h8_3d_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 11;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 11;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)h8_3d_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/h8_3d_nrf24l01.c
+++ b/src/protocol/h8_3d_nrf24l01.c
@@ -490,7 +490,7 @@ uintptr_t H8_3D_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN: return 11;
         case PROTOCMD_DEFAULT_NUMCHAN: return 11;

--- a/src/protocol/hisky_nrf24l01.c
+++ b/src/protocol/hisky_nrf24l01.c
@@ -433,8 +433,8 @@ uintptr_t HiSky_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
-        case PROTOCMD_BIND:  initialize(1); return 0;
+        case PROTOCMD_CHECK_AUTOBIND: return 0;  // Never Autobind
+        case PROTOCMD_BIND: initialize(1); return 0;
         case PROTOCMD_NUMCHAN: return 7;
         case PROTOCMD_DEFAULT_NUMCHAN: return 6;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;

--- a/src/protocol/hisky_nrf24l01.c
+++ b/src/protocol/hisky_nrf24l01.c
@@ -425,21 +425,21 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(1000, hisky_cb);
 }
 
-const void *HiSky_Cmds(enum ProtoCmds cmd)
+uintptr_t HiSky_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
-        case PROTOCMD_INIT:  initialize(0); return 0;
+        case PROTOCMD_INIT: initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)0L; //Never Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)7L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return hisky_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 7;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)hisky_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/hitec_cc2500.c
+++ b/src/protocol/hitec_cc2500.c
@@ -611,23 +611,23 @@ static void initialize(u8 bind)
   CLOCK_StartTimer(initHITEC(), hitec_cb);
 }
 
-const void *Hitec_Cmds(enum ProtoCmds cmd)
+uintptr_t Hitec_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(CC2500_Reset() ? 1L : -1L);
+            return (CC2500_Reset() ? 1 : -1);
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)8L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return (void *)((long)Model.fixed_id);
-        case PROTOCMD_GETOPTIONS: return hitec_opts;
+        case PROTOCMD_NUMCHAN: return 8;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)hitec_opts;
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)(PROTO_TELEM_ON);
+            return PROTO_TELEM_ON;
         case PROTOCMD_TELEMETRYTYPE: 
-            return (void *)(long) TELEM_FRSKY;
+            return TELEM_FRSKY;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/hm830_nrf24l01.c
+++ b/src/protocol/hm830_nrf24l01.c
@@ -372,21 +372,20 @@ static void initialize()
     CLOCK_StartTimer(50000, HM830_callback);
 }
 
-const void *HM830_Cmds(enum ProtoCmds cmd)
+uintptr_t HM830_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // Always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // Always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 5L; // T, A, E, R, G
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)5L;
-        // TODO: return id correctly
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  5; // T, A, E, R, G
+        case PROTOCMD_DEFAULT_NUMCHAN: return 5;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return TAERG;
         default: break;
     }

--- a/src/protocol/hm830_nrf24l01.c
+++ b/src/protocol/hm830_nrf24l01.c
@@ -380,9 +380,9 @@ uintptr_t HM830_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // Always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // Always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return  5; // T, A, E, R, G
+        case PROTOCMD_NUMCHAN: return 5;  // T, A, E, R, G
         case PROTOCMD_DEFAULT_NUMCHAN: return 5;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;

--- a/src/protocol/hontai_nrf24l01.c
+++ b/src/protocol/hontai_nrf24l01.c
@@ -409,21 +409,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, ht_callback);
 }
 
-const void *HonTai_Cmds(enum ProtoCmds cmd)
+uintptr_t HonTai_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 11L; // A, E, T, R, light, flip, photo, video, headless, RTH, calibrate
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)11L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return hontai_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  11; // A, E, T, R, light, flip, photo, video, headless, RTH, calibrate
+        case PROTOCMD_DEFAULT_NUMCHAN: return 11;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)hontai_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/hontai_nrf24l01.c
+++ b/src/protocol/hontai_nrf24l01.c
@@ -417,9 +417,9 @@ uintptr_t HonTai_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return  11; // A, E, T, R, light, flip, photo, video, headless, RTH, calibrate
+        case PROTOCMD_NUMCHAN: return 11;  // A, E, T, R, light, flip, photo, video, headless, RTH, calibrate
         case PROTOCMD_DEFAULT_NUMCHAN: return 11;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return (uintptr_t)hontai_opts;

--- a/src/protocol/hubsan_a7105.c
+++ b/src/protocol/hubsan_a7105.c
@@ -652,27 +652,27 @@ static void initialize(u8 bind) {
     CLOCK_StartTimer(10000, hubsan_cb);
 }
 
-const void *HUBSAN_Cmds(enum ProtoCmds cmd)
+uintptr_t HUBSAN_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT: initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(A7105_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H107 ? (void*)1L : 0;
+            return (A7105_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H107;
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)13L; // A, E, T, R, Leds, Flips(or alt-hold), Snapshot, Video Recording, Headless, RTH, GPS Hold, Mode, flip
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)13L;
+        case PROTOCMD_NUMCHAN: return 13; // A, E, T, R, Leds, Flips(or alt-hold), Snapshot, Video Recording, Headless, RTH, GPS Hold, Mode, flip
+        case PROTOCMD_DEFAULT_NUMCHAN: return 13;
         case PROTOCMD_CURRENT_ID: return 0;
         case PROTOCMD_GETOPTIONS:
             if( Model.proto_opts[PROTOOPTS_VTX_FREQ] == 0)
                 Model.proto_opts[PROTOOPTS_VTX_FREQ] = 5885;
-            return hubsan4_opts;
+            return (uintptr_t)hubsan4_opts;
         case PROTOCMD_TELEMETRYSTATE: 
-            return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
+            return (Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_TELEMETRYTYPE: 
-            return (void *)(long) TELEM_DEVO;
+            return TELEM_DEVO;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/hubsan_a7105.c
+++ b/src/protocol/hubsan_a7105.c
@@ -662,7 +662,7 @@ uintptr_t HUBSAN_Cmds(enum ProtoCmds cmd)
             return (A7105_Reset() ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND: return Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H107;
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return 13; // A, E, T, R, Leds, Flips(or alt-hold), Snapshot, Video Recording, Headless, RTH, GPS Hold, Mode, flip
+        case PROTOCMD_NUMCHAN: return 13;  // A, E, T, R, Leds, Flips(or alt-hold), Snapshot, Video Recording, Headless, RTH, GPS Hold, Mode, flip
         case PROTOCMD_DEFAULT_NUMCHAN: return 13;
         case PROTOCMD_CURRENT_ID: return 0;
         case PROTOCMD_GETOPTIONS:

--- a/src/protocol/inav_nrf24l01.c
+++ b/src/protocol/inav_nrf24l01.c
@@ -811,7 +811,7 @@ uintptr_t INAV_Cmds(enum ProtoCmds cmd)
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
         //case PROTOCMD_CHECK_AUTOBIND: return 0; 
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
         case PROTOCMD_BIND:  initialize(INIT_BIND); return 0;
         case PROTOCMD_NUMCHAN: return rc_channel_count;
         case PROTOCMD_DEFAULT_NUMCHAN: return RC_CHANNEL_COUNT_DEFAULT;

--- a/src/protocol/inav_nrf24l01.c
+++ b/src/protocol/inav_nrf24l01.c
@@ -802,26 +802,26 @@ static void initialize(init_bind_t bind)
     CLOCK_StartTimer(INITIAL_WAIT, inav_callback);
 }
 
-const void *INAV_Cmds(enum ProtoCmds cmd)
+uintptr_t INAV_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(INIT_BIND); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
+            return (NRF24L01_Reset() ? 1 : -1);
         //case PROTOCMD_CHECK_AUTOBIND: return 0; 
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(INIT_BIND); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)((long)rc_channel_count);
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)((long)RC_CHANNEL_COUNT_DEFAULT);
+        case PROTOCMD_NUMCHAN: return rc_channel_count;
+        case PROTOCMD_DEFAULT_NUMCHAN: return RC_CHANNEL_COUNT_DEFAULT;
         case PROTOCMD_CURRENT_ID: return 0;
-        case PROTOCMD_GETOPTIONS: return inav_opts;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)inav_opts;
 #ifdef INAV_TELEMETRY
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
-        case PROTOCMD_TELEMETRYTYPE:  return (void *)(long) TELEM_LTM;
+        case PROTOCMD_TELEMETRYSTATE: return (Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
+        case PROTOCMD_TELEMETRYTYPE:  return TELEM_LTM;
 #else
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
 #endif
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;

--- a/src/protocol/interface.h
+++ b/src/protocol/interface.h
@@ -31,13 +31,13 @@ enum PinConfigState {
     RESET_PIN,
 };
 
-#define AETRG ((void*)0)
-#define UNCHG ((void*)1)
-#define EATRG ((void*)2)
-#define TAERG ((void*)3)
+#define AETRG (0)
+#define UNCHG (1)
+#define EATRG (2)
+#define TAERG (3)
 
 #ifndef MODULAR
-#define PROTODEF(proto, module, map, cmd, name) extern const void * cmd(enum ProtoCmds);
+#define PROTODEF(proto, module, map, cmd, name) extern uintptr_t cmd(enum ProtoCmds);
 #include "protocol.h"
 #undef PROTODEF
 #endif

--- a/src/protocol/j6pro_cyrf6936.c
+++ b/src/protocol/j6pro_cyrf6936.c
@@ -288,20 +288,20 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(2400, j6pro_cb);
 }
 
-const void *J6PRO_Cmds(enum ProtoCmds cmd)
+uintptr_t J6PRO_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(CYRF_Reset() ? 1L : -1L);
+            return (CYRF_Reset() ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)12L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
+        case PROTOCMD_NUMCHAN: return 12;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
         case PROTOCMD_CURRENT_ID: return 0;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/joysway_a7105.c
+++ b/src/protocol/joysway_a7105.c
@@ -238,21 +238,21 @@ static void initialize() {
     CLOCK_StartTimer(2400, joysway_cb);
 }
 
-const void *JOYSWAY_Cmds(enum ProtoCmds cmd)
+uintptr_t JOYSWAY_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(A7105_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L;
+            return (A7105_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1;
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)4L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)4L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return joysway_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 4;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 4;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)joysway_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/kn_nrf24l01.c
+++ b/src/protocol/kn_nrf24l01.c
@@ -194,19 +194,19 @@ uintptr_t KN_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:
-        	kn_start_tx((Model.proto_opts[PROTOOPTS_STARTBIND] == STARTBIND_YES));
+            kn_start_tx((Model.proto_opts[PROTOOPTS_STARTBIND] == STARTBIND_YES));
             return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return ((NRF24L01_Reset()) ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND:
-            return 0; // Never Autobind
+            return 0;  // Never Autobind
         case PROTOCMD_BIND:
-        	kn_start_tx(STARTBIND_YES);
-			return 0;
+            kn_start_tx(STARTBIND_YES);
+            return 0;
         case PROTOCMD_NUMCHAN:
-            return 11; // T, R, E, A, DR, TH, Flight mode, 6G, trim T, R, E and V977 side DR
+            return 11;  // T, R, E, A, DR, TH, Flight mode, 6G, trim T, R, E and V977 side DR
         case PROTOCMD_DEFAULT_NUMCHAN:
             return 11;
         case PROTOCMD_CURRENT_ID: 

--- a/src/protocol/kn_nrf24l01.c
+++ b/src/protocol/kn_nrf24l01.c
@@ -190,7 +190,7 @@ static u32 tx_power_;
 //================================================================================================
 // Public Functions
 //================================================================================================
-const void *KN_Cmds(enum ProtoCmds cmd)
+uintptr_t KN_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:
@@ -199,22 +199,22 @@ const void *KN_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)((NRF24L01_Reset()) ? 1L : -1L);
+            return ((NRF24L01_Reset()) ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND:
-            return (void *)0L; // Never Autobind
+            return 0; // Never Autobind
         case PROTOCMD_BIND:
         	kn_start_tx(STARTBIND_YES);
 			return 0;
         case PROTOCMD_NUMCHAN:
-            return (void *)11L; // T, R, E, A, DR, TH, Flight mode, 6G, trim T, R, E and V977 side DR
+            return 11; // T, R, E, A, DR, TH, Flight mode, 6G, trim T, R, E and V977 side DR
         case PROTOCMD_DEFAULT_NUMCHAN:
-            return (void *)11L;
+            return 11;
         case PROTOCMD_CURRENT_ID: 
-            return (Model.fixed_id) ? (void *)Model.fixed_id : 0;
+            return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: 
-            return KN_PROTOCOL_OPTIONS;
+            return (uintptr_t)KN_PROTOCOL_OPTIONS;
         case PROTOCMD_TELEMETRYSTATE: 
-            return (void *)PROTO_TELEM_UNSUPPORTED;
+            return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP:
             return TAERG;
         default: break;

--- a/src/protocol/loli_nrf24l01.c
+++ b/src/protocol/loli_nrf24l01.c
@@ -442,23 +442,23 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(500, LOLI_callback);
 }
 
-const void *LOLI_Cmds(enum ProtoCmds cmd)
+uintptr_t LOLI_Cmds(enum ProtoCmds cmd)
 {
     switch (cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)0L;
-        case PROTOCMD_BIND:  initialize(1); return (void*)0L;
-        case PROTOCMD_NUMCHAN: return (void *) 8L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((u32)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return loli_opts;
-        case PROTOCMD_SETOPTIONS: rxConfigChanged = 1; return (void*)0L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)PROTO_TELEM_ON;
-        case PROTOCMD_TELEMETRYTYPE: return (void *)(u32)TELEM_FRSKY;
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 0;
+        case PROTOCMD_BIND:  initialize(1); return 0;
+        case PROTOCMD_NUMCHAN: return  8;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)loli_opts;
+        case PROTOCMD_SETOPTIONS: rxConfigChanged = 1; return 0;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_ON;
+        case PROTOCMD_TELEMETRYTYPE: return TELEM_FRSKY;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -450,21 +450,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, mjxq_callback);
 }
 
-const void *MJXq_Cmds(enum ProtoCmds cmd)
+uintptr_t MJXq_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
-        case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 12L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)12L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return mjxq_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_BIND: initialize(); return 0;
+        case PROTOCMD_NUMCHAN: return 12;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 12;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)mjxq_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -458,7 +458,7 @@ uintptr_t MJXq_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
         case PROTOCMD_BIND: initialize(); return 0;
         case PROTOCMD_NUMCHAN: return 12;
         case PROTOCMD_DEFAULT_NUMCHAN: return 12;

--- a/src/protocol/mt99xx_nrf24l01.c
+++ b/src/protocol/mt99xx_nrf24l01.c
@@ -457,9 +457,9 @@ uintptr_t MT99XX_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return  9; // A, E, T, R, light, flip, snapshot, video, headless
+        case PROTOCMD_NUMCHAN: return 9;  // A, E, T, R, light, flip, snapshot, video, headless
         case PROTOCMD_DEFAULT_NUMCHAN: return 9;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return (uintptr_t)mt99xx_opts;

--- a/src/protocol/mt99xx_nrf24l01.c
+++ b/src/protocol/mt99xx_nrf24l01.c
@@ -449,21 +449,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, mt99xx_callback);
 }
 
-const void *MT99XX_Cmds(enum ProtoCmds cmd)
+uintptr_t MT99XX_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 9L; // A, E, T, R, light, flip, snapshot, video, headless
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)9L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return mt99xx_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  9; // A, E, T, R, light, flip, snapshot, video, headless
+        case PROTOCMD_DEFAULT_NUMCHAN: return 9;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)mt99xx_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/ncc1701_nrf24l01.c
+++ b/src/protocol/ncc1701_nrf24l01.c
@@ -376,22 +376,22 @@ static void initNCC(void)
     CLOCK_StartTimer(INITIAL_WAIT, ncc1701_callback);
 }
 
-const void *NCC1701_Cmds(enum ProtoCmds cmd)
+uintptr_t NCC1701_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initNCC(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initNCC(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 5L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)5L; // A,E,T,R,Warp
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return (void *)0L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_ON;
-        case PROTOCMD_TELEMETRYTYPE: return (void *)(long) TELEM_FRSKY;
+        case PROTOCMD_NUMCHAN: return  5;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 5; // A,E,T,R,Warp
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return 0;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_ON;
+        case PROTOCMD_TELEMETRYTYPE: return TELEM_FRSKY;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/ncc1701_nrf24l01.c
+++ b/src/protocol/ncc1701_nrf24l01.c
@@ -384,10 +384,10 @@ uintptr_t NCC1701_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
         case PROTOCMD_BIND:  initNCC(); return 0;
-        case PROTOCMD_NUMCHAN: return  5;
-        case PROTOCMD_DEFAULT_NUMCHAN: return 5; // A,E,T,R,Warp
+        case PROTOCMD_NUMCHAN: return 5;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 5;  // A,E,T,R,Warp
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return 0;
         case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_ON;

--- a/src/protocol/ne260_nrf24l01.c
+++ b/src/protocol/ne260_nrf24l01.c
@@ -316,7 +316,7 @@ uintptr_t NE260_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; //Never Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // Never Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN: return 4;
         case PROTOCMD_DEFAULT_NUMCHAN: return 4;

--- a/src/protocol/ne260_nrf24l01.c
+++ b/src/protocol/ne260_nrf24l01.c
@@ -308,20 +308,20 @@ static void initialize()
     CLOCK_StartTimer(10000, ne260_cb);
 }
 
-const void *NE260_Cmds(enum ProtoCmds cmd)
+uintptr_t NE260_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; //Never Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; //Never Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)4L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)4L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_TELEMETRYSTATE: return (void *) PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 4;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 4;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_TELEMETRYSTATE: return  PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/ppmout.c
+++ b/src/protocol/ppmout.c
@@ -94,23 +94,23 @@ static void initialize()
 }
 
 
-const void * PPMOUT_Cmds(enum ProtoCmds cmd)
+uintptr_t PPMOUT_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT: PWM_Stop(); return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L;
+        case PROTOCMD_CHECK_AUTOBIND: return 1L;
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN:
             if (Model.proto_opts[CENTER_PW] != 0) {
                 uint32_t chan = (Model.proto_opts[PERIOD_PW] - Model.proto_opts[NOTCH_PW])
                               / (Model.proto_opts[CENTER_PW] + Model.proto_opts[DELTA_PW] + Model.proto_opts[NOTCH_PW]);
                 if (chan > NUM_OUT_CHANNELS)
-                    return (void *)(long)NUM_OUT_CHANNELS;
-                return (void *)(long)chan;
+                    return NUM_OUT_CHANNELS;
+                return chan;
             }
-            return (void *)10L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
+            return 10;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
         case PROTOCMD_GETOPTIONS:
             if (Model.proto_opts[CENTER_PW] == 0) {
                 Model.proto_opts[CENTER_PW] = 1100;
@@ -118,9 +118,9 @@ const void * PPMOUT_Cmds(enum ProtoCmds cmd)
                 Model.proto_opts[NOTCH_PW] = 400;
                 Model.proto_opts[PERIOD_PW] = 22500;
             }
-            return ppm_opts;
-	case PROTOCMD_CHANNELMAP: return UNCHG;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+            return (uintptr_t)ppm_opts;
+        case PROTOCMD_CHANNELMAP: return UNCHG;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         default: break;
     }
     return 0;

--- a/src/protocol/protocol.c
+++ b/src/protocol/protocol.c
@@ -51,7 +51,7 @@ static u32 bind_time;
 
 #ifdef ENABLE_MODULAR
 unsigned long * const loaded_protocol = (unsigned long *)ENABLE_MODULAR;
-uintptr_t (* const PROTO_Cmds)(enum ProtoCmds) = (void *)(ENABLE_MODULAR +sizeof(long)+1);
+uintptr_t (* const PROTO_Cmds)(enum ProtoCmds) = (void *)(ENABLE_MODULAR + sizeof(unsigned) + 1);
 #define PROTOCOL_LOADED (*loaded_protocol == Model.protocol)
 #else
 uintptr_t (*PROTO_Cmds)(enum ProtoCmds) = NULL;

--- a/src/protocol/protocol.c
+++ b/src/protocol/protocol.c
@@ -51,10 +51,10 @@ static u32 bind_time;
 
 #ifdef ENABLE_MODULAR
 unsigned long * const loaded_protocol = (unsigned long *)ENABLE_MODULAR;
-void * (* const PROTO_Cmds)(enum ProtoCmds) = (void *)(ENABLE_MODULAR +sizeof(long)+1);
+uintptr_t (* const PROTO_Cmds)(enum ProtoCmds) = (void *)(ENABLE_MODULAR +sizeof(long)+1);
 #define PROTOCOL_LOADED (*loaded_protocol == Model.protocol)
 #else
-const void * (*PROTO_Cmds)(enum ProtoCmds) = NULL;
+uintptr_t (*PROTO_Cmds)(enum ProtoCmds) = NULL;
 #define PROTOCOL_LOADED PROTO_Cmds
 #endif
 
@@ -72,7 +72,7 @@ const struct{
 #define PROTODEF(proto, module, map, cmd, name) {module, cmd, name},
 const struct{
     enum Radio module;
-    const void * (*cmd)(enum ProtoCmds);
+    uintptr_t (*cmd)(enum ProtoCmds);
     const char* name;
 }Protocols[PROTOCOL_COUNT] = {
     { 0, NULL, "None"},

--- a/src/protocol/pxxout.c
+++ b/src/protocol/pxxout.c
@@ -320,7 +320,7 @@ static void initialize(u8 bind)
 }
 
 
-const void * PXXOUT_Cmds(enum ProtoCmds cmd)
+uintptr_t PXXOUT_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
@@ -332,14 +332,14 @@ const void * PXXOUT_Cmds(enum ProtoCmds cmd)
           return 0;
         case PROTOCMD_CHECK_AUTOBIND: return 0;
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)16L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_GETOPTIONS: return pxx_opts;
+        case PROTOCMD_NUMCHAN: return 16;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)pxx_opts;
 #if HAS_EXTENDED_TELEMETRY
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)PROTO_TELEM_ON;
+            return PROTO_TELEM_ON;
         case PROTOCMD_TELEMETRYTYPE:
-            return (void *)(long) TELEM_FRSKY;
+            return TELEM_FRSKY;
 #endif
         case PROTOCMD_CHANNELMAP: return UNCHG;
         default: break;

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -554,9 +554,9 @@ uintptr_t Q303_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return 11; // A, E, T, R, altitude hold, flip, photo, video, headless, RTH, gimbal
+        case PROTOCMD_NUMCHAN: return 11;  // A, E, T, R, altitude hold, flip, photo, video, headless, RTH, gimbal
         case PROTOCMD_DEFAULT_NUMCHAN: return 11;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return (uintptr_t)q303_opts;

--- a/src/protocol/q303_nrf24l01.c
+++ b/src/protocol/q303_nrf24l01.c
@@ -546,21 +546,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, q303_callback);
 }
 
-const void *Q303_Cmds(enum ProtoCmds cmd)
+uintptr_t Q303_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 11L; // A, E, T, R, altitude hold, flip, photo, video, headless, RTH, gimbal
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)11L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return q303_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 11; // A, E, T, R, altitude hold, flip, photo, video, headless, RTH, gimbal
+        case PROTOCMD_DEFAULT_NUMCHAN: return 11;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)q303_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/sbus_uart.c
+++ b/src/protocol/sbus_uart.c
@@ -145,21 +145,21 @@ static void initialize()
     CLOCK_StartTimer(1000, serial_cb);
 }
 
-const void * SBUS_Cmds(enum ProtoCmds cmd)
+uintptr_t SBUS_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT: UART_Initialize(); return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L;
+        case PROTOCMD_CHECK_AUTOBIND: return 1;
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)16L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
+        case PROTOCMD_NUMCHAN: return 16;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
 	case PROTOCMD_CHANNELMAP: return UNCHG;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_GETOPTIONS:
             if (!Model.proto_opts[PROTO_OPTS_PERIOD])
                 Model.proto_opts[PROTO_OPTS_PERIOD] = SBUS_FRAME_PERIOD_MAX;
-            return sbus_opts;
+            return (uintptr_t)sbus_opts;
         default: break;
     }
     return 0;

--- a/src/protocol/sfhss_cc2500.c
+++ b/src/protocol/sfhss_cc2500.c
@@ -392,22 +392,22 @@ static void initialize()
     CLOCK_StartTimer(init_timeout, SFHSS_cb);
 }
 
-const void *SFHSS_Cmds(enum ProtoCmds cmd)
+uintptr_t SFHSS_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(CC2500_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // Always autobind
+            return (CC2500_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // Always autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)8L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
+        case PROTOCMD_NUMCHAN: return 8;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS:
-            return SFHSS_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+            return (uintptr_t)SFHSS_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/sfhss_cc2500.c
+++ b/src/protocol/sfhss_cc2500.c
@@ -400,7 +400,7 @@ uintptr_t SFHSS_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (CC2500_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // Always autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // Always autobind
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN: return 8;
         case PROTOCMD_DEFAULT_NUMCHAN: return 8;

--- a/src/protocol/skyartec_cc2500.c
+++ b/src/protocol/skyartec_cc2500.c
@@ -228,20 +228,20 @@ static void initialize()
     CLOCK_StartTimer(10000, skyartec_cb);
 }
 
-const void *SKYARTEC_Cmds(enum ProtoCmds cmd)
+uintptr_t SKYARTEC_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(CC2500_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)0L; //Never Autobind
+            return (CC2500_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)7L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)7L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 7;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 7;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/skyartec_cc2500.c
+++ b/src/protocol/skyartec_cc2500.c
@@ -236,7 +236,7 @@ uintptr_t SKYARTEC_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (CC2500_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 0;  // Never Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN: return 7;
         case PROTOCMD_DEFAULT_NUMCHAN: return 7;

--- a/src/protocol/slt_nrf24l01.c
+++ b/src/protocol/slt_nrf24l01.c
@@ -489,22 +489,21 @@ static void initialize()
     CLOCK_StartTimer(50000, SLT_callback);
 }
 
-const void *SLT_Cmds(enum ProtoCmds cmd)
+uintptr_t SLT_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // Always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // Always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 13L; // A, E, T, R, G, P, 7, 8, (Q200) Mode, Flip, VidOn, VidOff/Picture, Calibrate
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)13L;
-        // TODO: return id correctly
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return slt_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  13; // A, E, T, R, G, P, 7, 8, (Q200) Mode, Flip, VidOn, VidOff/Picture, Calibrate
+        case PROTOCMD_DEFAULT_NUMCHAN: return 13;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)slt_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/slt_nrf24l01.c
+++ b/src/protocol/slt_nrf24l01.c
@@ -497,9 +497,9 @@ uintptr_t SLT_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // Always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // Always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return  13; // A, E, T, R, G, P, 7, 8, (Q200) Mode, Flip, VidOn, VidOff/Picture, Calibrate
+        case PROTOCMD_NUMCHAN: return 13;  // A, E, T, R, G, P, 7, 8, (Q200) Mode, Flip, VidOn, VidOff/Picture, Calibrate
         case PROTOCMD_DEFAULT_NUMCHAN: return 13;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return (uintptr_t)slt_opts;

--- a/src/protocol/symax_nrf24l01.c
+++ b/src/protocol/symax_nrf24l01.c
@@ -499,7 +499,7 @@ uintptr_t SYMAX_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 1;  // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
         case PROTOCMD_NUMCHAN: return  9;
         case PROTOCMD_DEFAULT_NUMCHAN: return 6;

--- a/src/protocol/symax_nrf24l01.c
+++ b/src/protocol/symax_nrf24l01.c
@@ -491,21 +491,21 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, symax_callback);
 }
 
-const void *SYMAX_Cmds(enum ProtoCmds cmd)
+uintptr_t SYMAX_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L; // always Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1; // always Autobind
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 9L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return symax_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  9;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)symax_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/testrf.c
+++ b/src/protocol/testrf.c
@@ -349,19 +349,19 @@ static void initialize()
     CLOCK_StartTimer(20000, testrf_cb);
 }
 
-const void * TESTRF_Cmds(enum ProtoCmds cmd)
+uintptr_t TESTRF_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT: deinit(); return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L;
+        case PROTOCMD_CHECK_AUTOBIND: return 1;
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)12L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 12;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_GETOPTIONS:
-            return testrf_opts;
-	case PROTOCMD_CHANNELMAP:
+            return (uintptr_t)testrf_opts;
+        case PROTOCMD_CHANNELMAP:
 	    return UNCHG;
         case PROTOCMD_SETOPTIONS:
             initialize();

--- a/src/protocol/testser.c
+++ b/src/protocol/testser.c
@@ -150,18 +150,18 @@ static void initialize()
     CLOCK_StartTimer(10000, serial_cb);
 }
 
-const void * TESTSER_Cmds(enum ProtoCmds cmd)
+uintptr_t TESTSER_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT: UART_Initialize(); return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L;
+        case PROTOCMD_CHECK_AUTOBIND: return 1;
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)16L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)8L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
-	case PROTOCMD_CHANNELMAP: return UNCHG;
-        case PROTOCMD_GETOPTIONS: return testser_opts;
+        case PROTOCMD_NUMCHAN: return 16;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 8;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_CHANNELMAP: return UNCHG;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)testser_opts;
         default: break;
     }
     return 0;

--- a/src/protocol/usbhid.c
+++ b/src/protocol/usbhid.c
@@ -88,17 +88,17 @@ static void initialize()
     CLOCK_StartTimer(1000, usbhid_cb);
 }
 
-const void * USBHID_Cmds(enum ProtoCmds cmd)
+uintptr_t USBHID_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT: HID_Disable(); return 0;
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L;
+        case PROTOCMD_CHECK_AUTOBIND: return 1;
         case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)((unsigned long)USBHID_MAX_CHANNELS);
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
-	case PROTOCMD_CHANNELMAP: return UNCHG;
-	case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return USBHID_MAX_CHANNELS;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
+        case PROTOCMD_CHANNELMAP: return UNCHG;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         default: break;
     }
     return 0;

--- a/src/protocol/v202_nrf24l01.c
+++ b/src/protocol/v202_nrf24l01.c
@@ -571,7 +571,7 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(50000, v202_callback);
 }
 
-const void *V202_Cmds(enum ProtoCmds cmd)
+uintptr_t V202_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:
@@ -580,15 +580,14 @@ const void *V202_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)0L; //Never Autobind
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 12L; // T, R, E, A, LED (on/off/blink), Auto flip, camera, video, headless, X-Y calibration
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)6L;
-        // TODO: return id correctly
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return v202_opts;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return  12; // T, R, E, A, LED (on/off/blink), Auto flip, camera, video, headless, X-Y calibration
+        case PROTOCMD_DEFAULT_NUMCHAN: return 6;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)v202_opts;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/v202_nrf24l01.c
+++ b/src/protocol/v202_nrf24l01.c
@@ -581,9 +581,9 @@ uintptr_t V202_Cmds(enum ProtoCmds cmd)
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
             return (NRF24L01_Reset() ? 1 : -1);
-        case PROTOCMD_CHECK_AUTOBIND: return 0; //Never Autobind
+        case PROTOCMD_CHECK_AUTOBIND: return 0;  // Never Autobind
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return  12; // T, R, E, A, LED (on/off/blink), Auto flip, camera, video, headless, X-Y calibration
+        case PROTOCMD_NUMCHAN: return  12;  // T, R, E, A, LED (on/off/blink), Auto flip, camera, video, headless, X-Y calibration
         case PROTOCMD_DEFAULT_NUMCHAN: return 6;
         case PROTOCMD_CURRENT_ID: return Model.fixed_id;
         case PROTOCMD_GETOPTIONS: return (uintptr_t)v202_opts;

--- a/src/protocol/v911s_nrf24l01.c
+++ b/src/protocol/v911s_nrf24l01.c
@@ -287,21 +287,20 @@ static void initialize(u8 bind)
     CLOCK_StartTimer(V911S_INITIAL_WAIT, V911S_callback);
 }
 
-const void *V911S_Cmds(enum ProtoCmds cmd)
+uintptr_t V911S_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)0L;
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 0;
         case PROTOCMD_BIND:  initialize(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 5L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)5L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return (void*)0L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 5;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 5;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/wfly_cyrf6936.c
+++ b/src/protocol/wfly_cyrf6936.c
@@ -339,21 +339,21 @@ static void initWFLY(u8 bind)
     CLOCK_StartTimer(50000, WFLY_callback);
 }
 
-const void *WFLY_Cmds(enum ProtoCmds cmd)
+uintptr_t WFLY_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initWFLY(0); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(CYRF_Reset() ? 1L : -1L);
+            return (CYRF_Reset() ? 1 : -1);
         case PROTOCMD_CHECK_AUTOBIND: return 0;
         case PROTOCMD_BIND:  initWFLY(1); return 0;
-        case PROTOCMD_NUMCHAN: return (void *)9L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)9L;
-        case PROTOCMD_CURRENT_ID:  return (void *)((unsigned long)Model.fixed_id);
-        case PROTOCMD_GETOPTIONS: return (void*)0L;
-        case PROTOCMD_TELEMETRYSTATE: return (void *) PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_NUMCHAN: return 9;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 9;
+        case PROTOCMD_CURRENT_ID:  return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return 0;
+        case PROTOCMD_TELEMETRYSTATE: return  PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;
     }

--- a/src/protocol/wk2x01.c
+++ b/src/protocol/wk2x01.c
@@ -556,29 +556,23 @@ static void initialize()
     CLOCK_StartTimer(2800, wk_cb);
 }
 
-const void *WK2x01_Cmds(enum ProtoCmds cmd)
+uintptr_t WK2x01_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT: return 0;
         case PROTOCMD_CHECK_AUTOBIND:
-            return (Model.protocol == PROTOCOL_WK2801 && Model.fixed_id) ? 0 : (void *)1L;
+            return (Model.protocol == PROTOCOL_WK2801 && Model.fixed_id) ? 0 : 1;
         case PROTOCMD_BIND:  wk_bind(); return 0;
         case PROTOCMD_DEFAULT_NUMCHAN: return (Model.protocol == PROTOCOL_WK2801)
-              ? (void *)8L
-              : (Model.protocol == PROTOCOL_WK2601)
-                ? (void *)6L
-                : (void *)4L;
+              ? 8 : (Model.protocol == PROTOCOL_WK2601) ? 6 : 4;
         case PROTOCMD_NUMCHAN: return (Model.protocol == PROTOCOL_WK2801)
-              ? (void *)8L
-              : (Model.protocol == PROTOCOL_WK2601)
-                ? (void *)7L
-                : (void *)4L;
+              ? 8 : (Model.protocol == PROTOCOL_WK2601) ? 7 : 4;
         case PROTOCMD_GETOPTIONS:
             if(Model.protocol == PROTOCOL_WK2601)
-                return wk2601_opts;
+                return (uintptr_t)wk2601_opts;
             break;
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
         case PROTOCMD_CHANNELMAP:
             return EATRG;
         default: break;

--- a/src/protocol/yd717_nrf24l01.c
+++ b/src/protocol/yd717_nrf24l01.c
@@ -490,27 +490,27 @@ static void initialize()
     CLOCK_StartTimer(INITIAL_WAIT, yd717_callback);
 }
 
-const void *YD717_Cmds(enum ProtoCmds cmd)
+uintptr_t YD717_Cmds(enum ProtoCmds cmd)
 {
     switch(cmd) {
         case PROTOCMD_INIT:  initialize(); return 0;
         case PROTOCMD_DEINIT:
         case PROTOCMD_RESET:
             CLOCK_StopTimer();
-            return (void *)(NRF24L01_Reset() ? 1L : -1L);
-        case PROTOCMD_CHECK_AUTOBIND: return (void *)1L;
-        case PROTOCMD_BIND:  initialize(); return 0;
-        case PROTOCMD_NUMCHAN: return (void *) 9L;
-        case PROTOCMD_DEFAULT_NUMCHAN: return (void *)5L;
-        case PROTOCMD_CURRENT_ID: return Model.fixed_id ? (void *)((unsigned long)Model.fixed_id) : 0;
-        case PROTOCMD_GETOPTIONS: return yd717_opts;
+            return (NRF24L01_Reset() ? 1 : -1);
+        case PROTOCMD_CHECK_AUTOBIND: return 1;
+        case PROTOCMD_BIND: initialize(); return 0;
+        case PROTOCMD_NUMCHAN: return 9;
+        case PROTOCMD_DEFAULT_NUMCHAN: return 5;
+        case PROTOCMD_CURRENT_ID: return Model.fixed_id;
+        case PROTOCMD_GETOPTIONS: return (uintptr_t)yd717_opts;
 #ifdef YD717_TELEMETRY
         case PROTOCMD_TELEMETRYSTATE:
-            return (void *)(long)(Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
+            return (Model.proto_opts[PROTOOPTS_TELEMETRY] == TELEM_ON ? PROTO_TELEM_ON : PROTO_TELEM_OFF);
         case PROTOCMD_TELEMETRYTYPE: 
-            return (void *)(long) TELEM_DSM;
+            return TELEM_DSM;
 #else
-        case PROTOCMD_TELEMETRYSTATE: return (void *)(long)PROTO_TELEM_UNSUPPORTED;
+        case PROTOCMD_TELEMETRYSTATE: return PROTO_TELEM_UNSUPPORTED;
 #endif
         case PROTOCMD_CHANNELMAP: return AETRG;
         default: break;


### PR DESCRIPTION
1. change void* to uintptr_t, which avoids lots of cast
2. change Model.fixid?fixid:0 to Model.fixid
3. cast protocol options to uintptr_t explict