### PR TITLE
Don't inherit LANGUAGE from environmant

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,6 @@
 ## the following disable builtin rules which we don't need
 ## and make debugging harder
+unexport LANGUAGE
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 


### PR DESCRIPTION
If $LANGUAGE is set in the env, then devofs filesystems get language files even when they sholdn't.  LANGUAGE should not be inherited