### PR TITLE
Run lint (in non-failure mode) after every make

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -264,7 +264,6 @@ coverity:
 lint:
 	../utils/run_linter.py --diff --debug
 
-
 ##########################################
 #Ensure necessary directories are created#
 ##########################################

--- a/src/Makefile
+++ b/src/Makefile
@@ -264,6 +264,7 @@ coverity:
 lint:
 	../utils/run_linter.py --diff --debug
 
+
 ##########################################
 #Ensure necessary directories are created#
 ##########################################
@@ -322,6 +323,7 @@ ifeq "$(TYPE)" "dev"
 else
 	../utils/check_string_size.pl -target $(FILESYSTEM) -objdir $(ODIR) -quiet
 endif
+	../utils/run_linter.py --diff --skip-github --no-fail
 
 ######################
 #Necessary Font files#


### PR DESCRIPTION
This is not great for running 'zips' as it runs for each target as opposed to only once.  Not sure of a good way to fix that.