### PR TITLE
Enable correct DMA for ADC  Fix for #711 on Devo12

### DIFF
--- a/src/target/drivers/mcu/stm32/adc.c
+++ b/src/target/drivers/mcu/stm32/adc.c
@@ -61,7 +61,7 @@ void ADC_Init(void)
 
     /* The following is based on code from here: http://code.google.com/p/rayaairbot */
     /* Enable DMA clock */
-    rcc_periph_clock_enable(ADC_DMA.dma);
+    rcc_periph_clock_enable(get_rcc_from_port(ADC_DMA.dma));
     /* 1) Disable DMA and wait for it to complete */
     DMA_stream_reset(ADC_DMA);
     /* 2) get the data from the ADC data register */


### PR DESCRIPTION
On Devo12, the ADC DMA is not properly enabled due to a typo.  This works on other radios because the same DMA is used for UART which enables the RCC for us.  the Devo12 has a different DMA for analog inputs, and so wasn't powered on properly.