### PR TITLE
STM32 reorg: remove hardcoded gpio pin definitions

### DIFF
--- a/src/protocol/spi/avr_program.c
+++ b/src/protocol/spi/avr_program.c
@@ -25,8 +25,6 @@
 #include <stdlib.h>
 #include "protospi.h"
 
-static const struct mcu_pin AVR_RESET_PIN   = _SPI_AVR_RESET_PIN;
-
 u32 AVR_StartProgram()
 {
     u32 sync = 0;

--- a/src/protocol/spi/cyrf6936.c
+++ b/src/protocol/spi/cyrf6936.c
@@ -109,7 +109,6 @@ int CYRF_Reset()
         Delay(200);
         /* Reset the CYRF chip */
 #else
-        static const struct mcu_pin CYRF_RESET_PIN  = _SPI_CYRF_RESET_PIN;
         PROTOSPI_pin_set(CYRF_RESET_PIN);
         Delay(100);
         PROTOSPI_pin_clear(CYRF_RESET_PIN);

--- a/src/target/drivers/display/8080/320x240x16.c
+++ b/src/target/drivers/display/8080/320x240x16.c
@@ -69,12 +69,10 @@ int lcd_detect()
 {
 #ifdef LCD_RESET_PIN
     /* Reset pin for ILI9341 */
-    gpio_set_mode(LCD_RESET_PIN.port, GPIO_MODE_OUTPUT_50_MHZ,
-                  GPIO_CNF_OUTPUT_PUSHPULL, LCD_RESET_PIN.pin);
-
-    gpio_clear(LCD_RESET_PIN.port, LCD_RESET_PIN.pin);
+    GPIO_setup_output(LCD_RESET_PIN, OTYPE_PUSHPULL);
+    GPIO_pin_clear(LCD_RESET_PIN);
     _usleep(10);   // must be held low for at least 10us
-    gpio_set(LCD_RESET_PIN.port, LCD_RESET_PIN.pin);
+    GPIO_pin_set(LCD_RESET_PIN);
     _msleep(120);  // must wait 120ms after reset
 #endif  // LCD_RESET_PIN
 

--- a/src/target/drivers/display/i2c/video_tw8816.c
+++ b/src/target/drivers/display/i2c/video_tw8816.c
@@ -272,27 +272,43 @@ static void TW8816_Init_Ports()
     _i2c_init(LCD_I2C_CFG);
 
     // LCD Reset
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPEEN);
-    gpio_set_mode(GPIOE, GPIO_MODE_OUTPUT_50_MHZ,
-              GPIO_CNF_OUTPUT_PUSHPULL, GPIO7);
-    gpio_set(GPIOE, GPIO7);
+    rcc_periph_clock_enable(get_rcc_from_pin(LCD_RESET_PIN));
+    GPIO_setup_output(LCD_RESET_PIN, OTYPE_PUSHPULL);
+    GPIO_pin_set(LCD_RESET_PIN);
 
-    //Video channel bits 2:0 and av on/off
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPDEN);
-    gpio_set_mode(GPIOE, GPIO_MODE_OUTPUT_50_MHZ,
-              GPIO_CNF_OUTPUT_PUSHPULL, GPIO8 | GPIO9 | GPIO10 | GPIO11);
-    gpio_clear(GPIOE, GPIO8 | GPIO9 | GPIO10 | GPIO11);
-    //Video channel bit 3, 4
-    gpio_set_mode(GPIOD, GPIO_MODE_OUTPUT_50_MHZ,
-              GPIO_CNF_OUTPUT_PUSHPULL, GPIO8 | GPIO10);
-    gpio_clear(GPIOD, GPIO8 | GPIO10);
+    // Video channel bits 2:0 and av on/off
+    // NOTE: do no wrap this in a loop.  Doing so will break macro expansion
+    // CS0
+    rcc_periph_clock_enable(get_rcc_from_pin(LCD_VIDEO_CS0));
+    GPIO_setup_output(LCD_VIDEO_CS0, OTYPE_PUSHPULL);
+    GPIO_pin_clear(LCD_VIDEO_CS0);
+    // CS1
+    rcc_periph_clock_enable(get_rcc_from_pin(LCD_VIDEO_CS1));
+    GPIO_setup_output(LCD_VIDEO_CS1, OTYPE_PUSHPULL);
+    GPIO_pin_clear(LCD_VIDEO_CS1);
+    // CS2
+    rcc_periph_clock_enable(get_rcc_from_pin(LCD_VIDEO_CS2));
+    GPIO_setup_output(LCD_VIDEO_CS2, OTYPE_PUSHPULL);
+    GPIO_pin_clear(LCD_VIDEO_CS2);
+    // CS3
+    rcc_periph_clock_enable(get_rcc_from_pin(LCD_VIDEO_CS3));
+    GPIO_setup_output(LCD_VIDEO_CS3, OTYPE_PUSHPULL);
+    GPIO_pin_clear(LCD_VIDEO_CS3);
+    // CS4
+    rcc_periph_clock_enable(get_rcc_from_pin(LCD_VIDEO_CS4));
+    GPIO_setup_output(LCD_VIDEO_CS4, OTYPE_PUSHPULL);
+    GPIO_pin_clear(LCD_VIDEO_CS4);
+    // PWR
+    rcc_periph_clock_enable(get_rcc_from_pin(LCD_VIDEO_PWR));
+    GPIO_setup_output(LCD_VIDEO_PWR, OTYPE_PUSHPULL);
+    GPIO_pin_clear(LCD_VIDEO_PWR);
 }
 
 static void TW8816_Reset()
 {
-    gpio_clear(GPIOE, GPIO7);
+    GPIO_pin_clear(LCD_RESET_PIN);
     _msleep(250);
-    gpio_set(GPIOE, GPIO7);
+    GPIO_pin_set(LCD_RESET_PIN);
     _msleep(100);
 }
 
@@ -625,37 +641,38 @@ void TW8816_SetVideoStandard(u8 standard)
 void TW8816_SetVideoChannel(int ch)
 {
     if(ch & 0x01)
-        gpio_clear(GPIOE, GPIO8);
+        GPIO_pin_clear(LCD_VIDEO_CS0);
     else
-        gpio_set(GPIOE, GPIO8);
+        GPIO_pin_set(LCD_VIDEO_CS0);
 
     if(ch & 0x02)
-        gpio_clear(GPIOE, GPIO9);
+        GPIO_pin_clear(LCD_VIDEO_CS1);
     else
-        gpio_set(GPIOE, GPIO9);
+        GPIO_pin_set(LCD_VIDEO_CS1);
 
     if(ch & 0x04)
-        gpio_clear(GPIOE, GPIO10);
+        GPIO_pin_clear(LCD_VIDEO_CS2);
     else
-        gpio_set(GPIOE, GPIO10);
+        GPIO_pin_set(LCD_VIDEO_CS2);
 
     if(ch & 0x08)
-        gpio_clear(GPIOD, GPIO10);
+        GPIO_pin_clear(LCD_VIDEO_CS3);
     else
-        gpio_set(GPIOD, GPIO10);
+        GPIO_pin_set(LCD_VIDEO_CS3);
+
     if(ch & 0x10)
-        gpio_set(GPIOD, GPIO8);
+        GPIO_pin_set(LCD_VIDEO_CS4);
     else
-        gpio_clear(GPIOD, GPIO8);
+        GPIO_pin_clear(LCD_VIDEO_CS4);
 }
 
 void TW8816_EnableVideo(int on)
 {
     if(on) {
-        gpio_set(GPIOE, GPIO11);
+        GPIO_pin_set(LCD_VIDEO_PWR);
         LCD_ShowVideo(1);
     } else {
-        gpio_clear(GPIOE, GPIO11);
+        GPIO_pin_clear(LCD_VIDEO_PWR);
         LCD_ShowVideo(0);
     }
 }

--- a/src/target/drivers/display/spi/128x64x1_oled_ssd1306.c
+++ b/src/target/drivers/display/spi/128x64x1_oled_ssd1306.c
@@ -120,10 +120,9 @@ void LCD_Init()
 
 void BACKLIGHT_Init()
 {
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPBEN);
+    rcc_periph_clock_enable(get_rcc_from_pin(BACKLIGHT_TIM.pin));
     //Turn off backlight
-    gpio_set_mode(GPIOB, GPIO_MODE_INPUT,
-                  GPIO_CNF_INPUT_FLOAT, GPIO1);
+    GPIO_setup_input(BACKLIGHT_TIM.pin, ITYPE_FLOAT);
 }
 
 void BACKLIGHT_Brightness(unsigned brightness)

--- a/src/target/drivers/display/spi/video_ia9211.c
+++ b/src/target/drivers/display/spi/video_ia9211.c
@@ -270,8 +270,7 @@ void LCD_Init()
         _spi_init(LCD_SPI_CFG);
     }
     // Setup CS as B.0 Data/Control = C.5
-    gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_50_MHZ,
-                  GPIO_CNF_OUTPUT_PUSHPULL, GPIO0);
+    GPIO_setup_output(LCD_SPI.csn, OTYPE_PUSHPULL);
     GPIO_pin_set(LCD_SPI.csn);  // CS_HI();
 
     LCD_Cmd(LCD_IA911_CLEAR_VRAM); //Clear the VRAM

--- a/src/target/drivers/mcu/emu/protospi.h
+++ b/src/target/drivers/mcu/emu/protospi.h
@@ -7,8 +7,8 @@ u8 PROTOSPI_xfer(u8 byte);
 #define PROTOSPI_pin_clear(io) if(0) {}
 #define _NOP() if(0) {}
 
-#define _SPI_CYRF_RESET_PIN {0, 0}
-#define _SPI_AVR_RESET_PIN {0, 0}
+#define CYRF_RESET_PIN {0, 0}
+#define AVR_RESET_PIN {0, 0}
 #pragma weak A7105_Reset
 #pragma weak CC2500_Reset
 #pragma weak CYRF_Reset

--- a/src/target/drivers/mcu/stm32/exti.h
+++ b/src/target/drivers/mcu/stm32/exti.h
@@ -25,26 +25,4 @@ INLINE static inline uint32_t EXTIx(struct mcu_pin pin)
     }
 }
 
-INLINE static inline uint32_t NVIC_EXTIx_IRQ(struct mcu_pin pin)
-{
-    switch (pin.pin) {
-        case GPIO1: return NVIC_EXTI1_IRQ;
-        case GPIO2: return NVIC_EXTI2_IRQ;
-        case GPIO3: return NVIC_EXTI3_IRQ;
-        case GPIO4: return NVIC_EXTI4_IRQ;
-        case GPIO5: return NVIC_EXTI9_5_IRQ;
-        case GPIO6: return NVIC_EXTI9_5_IRQ;
-        case GPIO7: return NVIC_EXTI9_5_IRQ;
-        case GPIO8: return NVIC_EXTI9_5_IRQ;
-        case GPIO9: return NVIC_EXTI9_5_IRQ;
-        case GPIO10: return NVIC_EXTI15_10_IRQ;
-        case GPIO11: return NVIC_EXTI15_10_IRQ;
-        case GPIO12: return NVIC_EXTI15_10_IRQ;
-        case GPIO13: return NVIC_EXTI15_10_IRQ;
-        case GPIO14: return NVIC_EXTI15_10_IRQ;
-        case GPIO15: return NVIC_EXTI15_10_IRQ;
-        default: ltassert(); return 0;
-    }
-}
-
 #endif  // _DTX_STM32_EXTI_H_

--- a/src/target/drivers/mcu/stm32/f1/nvic.h
+++ b/src/target/drivers/mcu/stm32/f1/nvic.h
@@ -3,6 +3,7 @@
 
 #include <libopencm3/cm3/nvic.h>
 #include <libopencm3/stm32/dma.h>
+#include <libopencm3/stm32/timer.h>
 #include <libopencm3/stm32/usart.h>
 
 static inline uint32_t get_nvic_dma_irq(struct dma_config dma)
@@ -45,6 +46,28 @@ static inline uint32_t get_nvic_irq(uint32_t port)
         case TIM6: return NVIC_TIM6_IRQ;
         case TIM7: return NVIC_TIM7_IRQ;
         // case TIM8: return NVIC_TIM8_IRQ;
+        default: ltassert(); return 0;
+    }
+}
+
+INLINE static inline uint32_t NVIC_EXTIx_IRQ(struct mcu_pin pin)
+{
+    switch (pin.pin) {
+        case GPIO1: return NVIC_EXTI1_IRQ;
+        case GPIO2: return NVIC_EXTI2_IRQ;
+        case GPIO3: return NVIC_EXTI3_IRQ;
+        case GPIO4: return NVIC_EXTI4_IRQ;
+        case GPIO5: return NVIC_EXTI9_5_IRQ;
+        case GPIO6: return NVIC_EXTI9_5_IRQ;
+        case GPIO7: return NVIC_EXTI9_5_IRQ;
+        case GPIO8: return NVIC_EXTI9_5_IRQ;
+        case GPIO9: return NVIC_EXTI9_5_IRQ;
+        case GPIO10: return NVIC_EXTI15_10_IRQ;
+        case GPIO11: return NVIC_EXTI15_10_IRQ;
+        case GPIO12: return NVIC_EXTI15_10_IRQ;
+        case GPIO13: return NVIC_EXTI15_10_IRQ;
+        case GPIO14: return NVIC_EXTI15_10_IRQ;
+        case GPIO15: return NVIC_EXTI15_10_IRQ;
         default: ltassert(); return 0;
     }
 }

--- a/src/target/drivers/mcu/stm32/f1/pwr.h
+++ b/src/target/drivers/mcu/stm32/f1/pwr.h
@@ -1,0 +1,17 @@
+#ifndef _DTX_STM32F1_PWR_H_
+#define _DTX_STM32F1_PWR_H_
+
+static inline void _pwr_init()
+{
+    SCB_VTOR = VECTOR_TABLE_LOCATION;
+    SCB_SCR  &= ~SCB_SCR_SLEEPONEXIT;  // sleep immediate on WFI
+    rcc_clock_setup_in_hse_8mhz_out_72mhz();
+}
+
+static inline void _pwr_shutdown()
+{
+    rcc_set_sysclk_source(RCC_CFGR_SW_SYSCLKSEL_HSICLK);
+    rcc_wait_for_osc_ready(RCC_HSI);
+}
+
+#endif  // _DTX_STM32F1_PWR_H_

--- a/src/target/drivers/mcu/stm32/f1/rcc.h
+++ b/src/target/drivers/mcu/stm32/f1/rcc.h
@@ -17,6 +17,7 @@ __attribute__((always_inline)) static inline enum rcc_periph_clken get_rcc_from_
         case GPIOB:  return RCC_GPIOB;
         case GPIOC:  return RCC_GPIOC;
         case GPIOD:  return RCC_GPIOD;
+        case GPIOE:  return RCC_GPIOE;
         case SPI1:   return RCC_SPI1;
         case SPI2:   return RCC_SPI2;
         case SPI3:   return RCC_SPI3;

--- a/src/target/drivers/mcu/stm32/pwr.h
+++ b/src/target/drivers/mcu/stm32/pwr.h
@@ -1,0 +1,10 @@
+#ifndef _DTX_STM32_PWR_H_
+#define _DTX_STM32_PWR_H_
+
+#if defined(STM32F1)
+    #include "f1/pwr.h"
+#elif defined(STM32F2)
+    #include "f2/pwr.h"
+#endif
+
+#endif  // _DTX_STM32_PWR_H_

--- a/src/target/drivers/mcu/stm32/spi_flash.c
+++ b/src/target/drivers/mcu/stm32/spi_flash.c
@@ -209,12 +209,12 @@ void SPIFlash_Init()
 #if 0 //4IN1DEBUG
     // This code is equivalent to using SPISwitch_Init
     static const struct mcu_pin FLASH_RESET_PIN ={GPIOB, GPIO11};
-    PORT_mode_setup(FLASH_RESET_PIN,  GPIO_MODE_OUTPUT_50_MHZ, GPIO_CNF_OUTPUT_PUSHPULL);
+    GPIO_setup_output(FLASH_RESET_PIN, OTYPE_PUSHPULL);
     // And this is equivalent of using SPISwitch_UseFlashModule in CS_LO
     u8 cmd = 4;
-    PORT_pin_clear(FLASH_RESET_PIN);
+    GPIO_pin_clear(FLASH_RESET_PIN);
     spi_xfer(FLASH_SPI.spi, cmd);
-    PORT_pin_set(FLASH_RESET_PIN);
+    GPIO_pin_set(FLASH_RESET_PIN);
 #endif
 #if HAS_FLASH_DETECT
     detect_memory_type();

--- a/src/target/tx/devo/common/haptic.c
+++ b/src/target/tx/devo/common/haptic.c
@@ -17,29 +17,27 @@
 #include "common.h"
 #include "devo.h"
 #include "config/tx.h"
+#include "target/drivers/mcu/stm32/rcc.h"
 
 void VIBRATINGMOTOR_Init()
 {
     if (!HAS_VIBRATINGMOTOR)
         return;
-    rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPDEN);
-
-    gpio_set_mode(GPIOD, GPIO_MODE_OUTPUT_2_MHZ,
-            GPIO_CNF_OUTPUT_PUSHPULL, GPIO2);
-    gpio_clear(GPIOD, GPIO2);
+    rcc_periph_clock_enable(get_rcc_from_pin(USB_ENABLE_PIN));
+    GPIO_setup_output(USB_ENABLE_PIN, OTYPE_PUSHPULL);
+    GPIO_pin_clear(USB_ENABLE_PIN);
 }
 
 void VIBRATINGMOTOR_Start()
 {
     if (!HAS_VIBRATINGMOTOR || !Transmitter.vibration_state)
         return;
-    gpio_set(GPIOD, GPIO2);
+    GPIO_pin_set(USB_ENABLE_PIN);
 }
 
 void VIBRATINGMOTOR_Stop()
 {
     if (!HAS_VIBRATINGMOTOR)
         return;
-    gpio_clear(GPIOD, GPIO2);
+    GPIO_pin_clear(USB_ENABLE_PIN);
 }
-

--- a/src/target/tx/devo/common/hardware.h
+++ b/src/target/tx/devo/common/hardware.h
@@ -165,4 +165,29 @@
     #define SSER_RX_ISR exti15_10_isr
 #endif  // SSER-TIM
 
+#ifndef USB_ENABLE_PIN
+    #define USB_ENABLE_PIN ((struct mcu_pin) {GPIOB, GPIO10})
+#endif
+
+#ifndef HAPTIC_PIN
+    #define HAPTIC_PIN ((struct mcu_pin) {GPIOD, GPIO2})
+#endif
+
+// Power switch configuration
+#ifndef PWR_SWITCH_PIN
+    #define PWR_SWITCH_PIN ((struct mcu_pin) {GPIOA, GPIO3})
+#endif
+
+#ifndef PWR_ENABLE_PIN
+    #define PWR_ENABLE_PIN ((struct mcu_pin) {GPIOA, GPIO2})
+#endif
+
+// Protocol pins
+#ifndef CYRF_RESET_PIN
+    #define CYRF_RESET_PIN ((struct mcu_pin) {GPIOB, GPIO11})
+#endif
+#ifndef AVR_RESET_PIN
+    #define AVR_RESET_PIN ((struct mcu_pin) {GPIO_BANK_JTCK_SWCLK, GPIO_JTCK_SWCLK})
+#endif
+
 #endif  // _DEVO_DEFAULT_HARDWARE_H_

--- a/src/target/tx/devo/common/msc2/usb_devo8.c
+++ b/src/target/tx/devo/common/msc2/usb_devo8.c
@@ -52,20 +52,19 @@ void MSC_Init() {
 
 void USB_Enable(unsigned use_interrupt)
 {
-    gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_50_MHZ,
-        GPIO_CNF_OUTPUT_PUSHPULL, GPIO10);
-        gpio_set(GPIOB, GPIO10);
+    GPIO_setup_output(USB_ENABLE_PIN, OTYPE_PUSHPULL);
+    GPIO_pin_set(USB_ENABLE_PIN);
     //rcc_set_usbpre(RCC_CFGR_USBPRE_PLL_CLK_DIV1_5);
-    rcc_peripheral_enable_clock(&RCC_APB1ENR, RCC_APB1ENR_USBEN);
+    rcc_periph_clock_enable(RCC_USB);
     USB_Init();
     if(use_interrupt) {
-        nvic_enable_irq(NVIC_USB_LP_CAN_RX0_IRQ);
+        nvic_enable_irq(NVIC_USB_LP_CAN_RX0_IRQ);  // NTE: This is STM32F1 only
     }
 }
 
 void USB_Disable()
 {
-    gpio_set(GPIOB, GPIO10);
+    GPIO_pin_set(USB_ENABLE_PIN);
     nvic_disable_irq(NVIC_USB_LP_CAN_RX0_IRQ);
 }
 
@@ -104,25 +103,24 @@ void USB_Connect()
 #ifdef USB_TEST
 int main(void)
 {
-	PWR_Init();
-	gpio_set_mode(GPIOB, GPIO_MODE_OUTPUT_50_MHZ,
-		GPIO_CNF_OUTPUT_OPENDRAIN, GPIO10);
-	gpio_set(GPIOB, GPIO10);
-	Delay(0x2710);
-	LCD_Init();
+    PWR_Init();
+    GPIO_setup_output(USB_ENABLE_PIN, OTYPE_OPENDRAIN);
+    GPIO_pin_set(USB_ENABLE_PIN);
+    Delay(0x2710);
+    LCD_Init();
         SPIFlash_Init();
         UART_Initialize();
 
-	LCD_Clear(0x0000);
+    LCD_Clear(0x0000);
         LCD_PrintStringXY(40, 10, "Hello\n");
         printf("Hello\n");
 
         USB_Enable();
-	//gpio_set(GPIOB, GPIO10);
-	SPI_FlashBlockWriteEnable(1);
-	while (1) {
-		if(PWR_CheckPowerSwitch())
-			PWR_Shutdown();
+    // GPIO_pin_set(USB_ENABLE_PIN);
+    SPI_FlashBlockWriteEnable(1);
+    while (1) {
+        if (PWR_CheckPowerSwitch())
+            PWR_Shutdown();
         }
 }
 #endif

--- a/src/target/tx/devo/common/ports.h
+++ b/src/target/tx/devo/common/ports.h
@@ -10,18 +10,6 @@
     #define SPIFLASH_TYPE SST25VFxxxB
 #endif
 
-//Power switch configuration
-#ifndef _PWRSW_PORT
-    #define _PWRSW_PORT               GPIOA
-    #define _PWRSW_PIN                GPIO3
-    #define _PWRSW_RCC_APB2ENR_IOPEN  RCC_APB2ENR_IOPAEN
-#endif //_PWRSW_PORT
-#ifndef _PWREN_PORT
-    #define _PWREN_PORT                GPIOA
-    #define _PWREN_PIN                 GPIO2
-    #define _PWREN_RCC_APB2ENR_IOPEN   RCC_APB2ENR_IOPAEN
-#endif //_PWREN_PORT
-
 #include "hardware.h"
 
 #endif //_PORTS_H_

--- a/src/target/tx/devo/common/ports.h
+++ b/src/target/tx/devo/common/ports.h
@@ -5,12 +5,6 @@
 #include "target/drivers/mcu/stm32/gpio.h"
 #endif
 
-#define PORT_mode_setup(io, mode, pullup) gpio_set_mode(io.port, mode, pullup, io.pin)
-#define PORT_pin_set(io)                  gpio_set(io.port,io.pin)
-#define PORT_pin_clear(io)                gpio_clear(io.port,io.pin)
-#define PORT_pin_get(io)                  gpio_get(io.port,io.pin)
-
-
 //SPI Flash
 #ifndef SPIFLASH_TYPE
     #define SPIFLASH_TYPE SST25VFxxxB

--- a/src/target/tx/devo/common/ppmin.c
+++ b/src/target/tx/devo/common/ppmin.c
@@ -27,6 +27,7 @@
 #include "target/drivers/mcu/stm32/rcc.h"
 #include "target/drivers/mcu/stm32/tim.h"
 #include "target/drivers/mcu/stm32/exti.h"
+#include "target/drivers/mcu/stm32/nvic.h"
 //#include "interface.h"
 #include "mixer.h"
 #include "config/model.h"

--- a/src/target/tx/devo/common/protospi.h
+++ b/src/target/tx/devo/common/protospi.h
@@ -6,13 +6,9 @@
 
 u8 PROTOSPI_read3wire();
 
-#define PROTOSPI_pin_set(io) gpio_set(io.port,io.pin)
-#define PROTOSPI_pin_clear(io) gpio_clear(io.port,io.pin)
-#define PROTOSPI_xfer(byte) spi_xfer(SPI2, byte)
+#define PROTOSPI_pin_set(io) GPIO_pin_set(io)
+#define PROTOSPI_pin_clear(io) GPIO_pin_clear(io)
+#define PROTOSPI_xfer(byte) spi_xfer(PROTO_SPI.spi, byte)
 #define _NOP()  asm volatile ("nop")
-
-
-#define _SPI_CYRF_RESET_PIN {GPIOB, GPIO11}
-#define _SPI_AVR_RESET_PIN {GPIO_BANK_JTCK_SWCLK, GPIO_JTCK_SWCLK}
 
 #endif // _SPIPROTO_H_

--- a/src/target/tx/devo/devo12/devo12_ports.h
+++ b/src/target/tx/devo/devo12/devo12_ports.h
@@ -2,16 +2,5 @@
 #define _DEVO12_PORTS_H_
 
 #include "hardware.h"
-//End ADC
-
-//Power Switch configuration
-#define _PWRSW_PORT               GPIOA
-#define _PWRSW_PIN                GPIO4
-#define _PWRSW_RCC_APB2ENR_IOPEN  RCC_APB2ENR_IOPAEN
-
-#define _PWREN_PORT                GPIOE
-#define _PWREN_PIN                 GPIO0
-#define _PWREN_RCC_APB2ENR_IOPEN   RCC_APB2ENR_IOPEEN
-//End Power switch configuration
 
 #endif //_DEVO12_PORTS_H_

--- a/src/target/tx/devo/devo12/hardware.h
+++ b/src/target/tx/devo/devo12/hardware.h
@@ -57,4 +57,8 @@
     .ch = 3,               \
     })
 
+// Power switch override
+#define PWR_SWITCH_PIN ((struct mcu_pin) {GPIOA, GPIO4})
+#define PWR_ENABLE_PIN ((struct mcu_pin) {GPIOE, GPIO0})
+
 #endif  // _DEVO12_HARDWARE_H_

--- a/src/target/tx/devo/devof12e/hardware.h
+++ b/src/target/tx/devo/devof12e/hardware.h
@@ -9,4 +9,13 @@
     .fastmode  = 1,                     \
     })
 #define LCD_I2C_CFG I2C1_CFG
+
+#define LCD_RESET_PIN ((struct mcu_pin){GPIOE, GPIO7})
+
+#define LCD_VIDEO_CS0 ((struct mcu_pin) {GPIOE, GPIO8})
+#define LCD_VIDEO_CS1 ((struct mcu_pin) {GPIOE, GPIO9})
+#define LCD_VIDEO_CS2 ((struct mcu_pin) {GPIOE, GPIO10})
+#define LCD_VIDEO_CS3 ((struct mcu_pin) {GPIOD, GPIO10})
+#define LCD_VIDEO_CS4 ((struct mcu_pin) {GPIOD, GPIO8})
+#define LCD_VIDEO_PWR ((struct mcu_pin){GPIOE, GPIO11})
 #endif

--- a/src/target/tx/radiolink/common/common_at.h
+++ b/src/target/tx/radiolink/common/common_at.h
@@ -10,3 +10,5 @@
 
 #define USE_4BUTTON_MODE 1
 #define HAS_HARD_POWER_OFF  1
+
+#include "hardware.h"

--- a/src/target/tx/radiolink/common/hardware.h
+++ b/src/target/tx/radiolink/common/hardware.h
@@ -1,0 +1,11 @@
+#ifndef _RADIOLINK_HARDWARE_H_
+#define _RADIOLINK_HARDWARE_H_
+
+#include "target/drivers/mcu/stm32/gpio.h"
+
+#define ROTARY_PIN0      ((struct mcu_pin){GPIOC, GPIO13})
+#define ROTARY_PIN1      ((struct mcu_pin){GPIOC, GPIO14})
+#define ROTARY_PRESS_PIN ((struct mcu_pin){GPIOC, GPIO15})
+#define ROTARY_ISR       exti15_10_isr
+
+#endif  // _RADIOLINK_HARDWARE_H_


### PR DESCRIPTION
Replace all hardcoded GPIO pins with those defined in hardware.h