### PR TITLE
Fix crash on at10

### DIFF
--- a/src/pages/320x240x16/standard/standard.h
+++ b/src/pages/320x240x16/standard/standard.h
@@ -3,7 +3,7 @@
 #include "../../common/standard/common_standard.h"
 
 int STDMIX_ScrollCB(guiObject_t *parent, u8 pos, s8 direction, void *data);
-#define ENTRIES_BY_SCREENSIZE (LCD_HEIGHT / 30)  // 240: 8, 272: 9, 320: 10
+#define ENTRIES_BY_SCREENSIZE ((LCD_HEIGHT / 30) + 1)  // 240: 8, 272: 9, 320: 10
 #define ENTRIES_PER_PAGE      (ENTRIES_BY_SCREENSIZE > NUM_CHANNELS ? NUM_CHANNELS : ENTRIES_BY_SCREENSIZE)
 
 #endif


### PR DESCRIPTION
because this variable is defined here:
struct advmixer_obj {
    guiButton_t testico;
    guiButton_t reorderico;
    union {
        guiButton_t but;
        guiLabel_t lbl;
    } name[ENTRIES_PER_PAGE];
    guiButton_t tmpl[ENTRIES_PER_PAGE];
    guiLabel_t src[ENTRIES_PER_PAGE];
    guiLabel_t sw1[ENTRIES_PER_PAGE];
    guiLabel_t sw2[ENTRIES_PER_PAGE];
    guiKeyboard_t keyboard;
    guiScrollable_t scrollable;
};
