### PR TITLE
Fix crash introduced by #750

### DIFF
--- a/src/target/drivers/input/analog/analog.c
+++ b/src/target/drivers/input/analog/analog.c
@@ -55,7 +55,6 @@ static volatile u16 adc_array_oversample[SAMPLE_COUNT];
 #endif
 
 
-
 void ADC_Init(void)
 {
     #define ADC_CHAN(x, y) (x ? get_rcc_from_port(x) : 0)
@@ -73,7 +72,6 @@ void ADC_Init(void)
         rcc_periph_clock_enable(adc_rcc[i]);
         GPIO_setup_input(adc_pins[i], ITYPE_ANALOG);
     }
-
     rcc_periph_clock_enable(get_rcc_from_port(ADC_CFG.adc));
     adc_power_off(ADC_CFG.adc);
     ADC_reset(ADC_CFG.adc);
@@ -215,3 +213,13 @@ void ADC_ScanChannels()
         }
     }
 }
+
+/* Return milivolts */
+unsigned PWR_ReadVoltage(void)
+{
+    u32 v = adc_array_raw[NUM_ADC_CHANNELS-1];
+    /* Multily the above by 1000 to get milivolts */
+    v = v * VOLTAGE_NUMERATOR / 100 + VOLTAGE_OFFSET;
+    return v;
+}
+

--- a/src/target/drivers/input/analog/analog.c
+++ b/src/target/drivers/input/analog/analog.c
@@ -54,9 +54,6 @@ static volatile u16 adc_array_oversample[SAMPLE_COUNT];
     // End
 #endif
 
-#define ADC_CHAN(...) ADC_PIN_TO_CHAN(__VA_ARGS__)
-static const u8 adc_chan_sel[NUM_ADC_CHANNELS] = ADC_CHANNELS;
-#undef ADC_CHAN
 
 
 void ADC_Init(void)
@@ -66,6 +63,9 @@ void ADC_Init(void)
     #undef ADC_CHAN
     #define ADC_CHAN(...) {__VA_ARGS__}
     const struct mcu_pin adc_pins[NUM_ADC_CHANNELS] = ADC_CHANNELS;
+    #undef ADC_CHAN
+    #define ADC_CHAN(...) ADC_PIN_TO_CHAN(__VA_ARGS__)
+    static const u8 adc_chan_sel[NUM_ADC_CHANNELS] = ADC_CHANNELS;
     #undef ADC_CHAN
     for (unsigned i = 0; i < NUM_ADC_CHANNELS; i++) {
         if (!HAS_PIN(adc_pins[i]))

--- a/src/target/drivers/mcu/stm32/gpio.h
+++ b/src/target/drivers/mcu/stm32/gpio.h
@@ -63,8 +63,7 @@ struct dma_config {
 };
 
 #define NULL_PIN ((struct mcu_pin){0, 0})
-#define HAS_PIN(x) (x.pin)
-#define TEMPERATURE_ADC 0, 0
+#define HAS_PIN(x) (x.port)
 
 
 #if defined(STM32F1)

--- a/src/target/tx/devo/common/devo.h
+++ b/src/target/tx/devo/common/devo.h
@@ -21,7 +21,6 @@ u32 SOUND_Callback();
 extern void PROTO_Stubs(int);
 // ADC defines
 #define NUM_ADC_CHANNELS (INP_HAS_CALIBRATION + 2) //Inputs + Temprature + Voltage
-extern const u8 adc_chan_sel[NUM_ADC_CHANNELS];
 extern volatile u16 adc_array_raw[NUM_ADC_CHANNELS];
 void ADC_Filter();
 

--- a/src/target/tx/devo/common/power.c
+++ b/src/target/tx/devo/common/power.c
@@ -78,15 +78,6 @@ void PWR_Sleep()
     //asm("wfi");
 }
 
-/* Return milivolts */
-unsigned PWR_ReadVoltage(void)
-{
-    u32 v = adc_array_raw[NUM_ADC_CHANNELS-1];
-    /* Multily the above by 1000 to get milivolts */
-    v = v * VOLTAGE_NUMERATOR / 100 + VOLTAGE_OFFSET;
-    return v;
-}
-
 void PWR_JumpToProgrammer()
 {
     scb_reset_system();

--- a/src/target/tx/devo/devo10/channels.c
+++ b/src/target/tx/devo/devo10/channels.c
@@ -19,8 +19,6 @@
 #include "config/tx.h"
 #include "../common/devo.h"
 
-const u8 adc_chan_sel[NUM_ADC_CHANNELS] = {13, 12, 11, 15, 10, 4, 16, 14};
-
 void CHAN_Init()
 {
     ADC_Init();

--- a/src/target/tx/devo/devo12/channels.c
+++ b/src/target/tx/devo/devo12/channels.c
@@ -19,8 +19,6 @@
 #include "config/tx.h"
 #include "../common/devo.h"
 
-const u8 adc_chan_sel[NUM_ADC_CHANNELS] = {2, 11, 10, 8, 5, 12, 6, 13, 4, 7, 16, 3};
-
 void CHAN_Init()
 {
     rcc_peripheral_enable_clock(&RCC_APB2ENR, RCC_APB2ENR_IOPCEN);

--- a/src/target/tx/radiolink/at10/at10_power.c
+++ b/src/target/tx/radiolink/at10/at10_power.c
@@ -44,12 +44,3 @@ void PWR_Sleep()
 {
     // asm("wfi");
 }
-
-/* Return milivolts */
-unsigned PWR_ReadVoltage(void)
-{
-    u32 v = adc_array_raw[NUM_ADC_CHANNELS-1];
-    /* Multily the above by 1000 to get milivolts */
-    v = v * VOLTAGE_NUMERATOR / 100 + VOLTAGE_OFFSET;
-    return v;
-}

--- a/src/target/tx/radiolink/at9/at9_power.c
+++ b/src/target/tx/radiolink/at9/at9_power.c
@@ -51,12 +51,3 @@ void PWR_Sleep()
 {
     //asm("wfi");
 }
-
-/* Return milivolts */
-unsigned PWR_ReadVoltage(void)
-{
-    u32 v = adc_array_raw[NUM_ADC_CHANNELS-1];
-    /* Multily the above by 1000 to get milivolts */
-    v = v * VOLTAGE_NUMERATOR / 100 + VOLTAGE_OFFSET;
-    return v;
-}


### PR DESCRIPTION
This should fix the crashes in transmitters other than the devo12 due to the recent ADC updates.