### PR TITLE
Add inverted ppmout option

### DIFF
--- a/src/protocol/ppmout.c
+++ b/src/protocol/ppmout.c
@@ -38,6 +38,7 @@ static const char * const ppm_opts[] = {
   _tr_noop("Delta PW"),   "100",   "700",   STEP_SIZE, NULL,
   _tr_noop("Notch PW"),   "100",   "500",   STEP_SIZE, NULL,
   _tr_noop("Frame Size"), "10000", "30000", STEPSIZE2, NULL,
+  _tr_noop("Polarity"), _tr_noop("Uninverted"), _tr_noop("Inverted"), NULL,
   NULL
 };
 enum {
@@ -45,6 +46,7 @@ enum {
     DELTA_PW,
     NOTCH_PW,
     PERIOD_PW,
+    POLARITY,
     LAST_PROTO_OPT,
 };
 ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
@@ -66,7 +68,7 @@ static void build_data_pkt()
 static u16 ppmout_cb()
 {
     build_data_pkt();
-    PPM_Enable(Model.proto_opts[NOTCH_PW], pulses, Model.num_channels+1);
+    PPM_Enable(Model.proto_opts[NOTCH_PW], pulses, Model.num_channels+1, Model.proto_opts[POLARITY]);
 #ifdef EMULATOR
     return 3000;
 #else

--- a/src/protocol/ppmout.c
+++ b/src/protocol/ppmout.c
@@ -38,7 +38,7 @@ static const char * const ppm_opts[] = {
   _tr_noop("Delta PW"),   "100",   "700",   STEP_SIZE, NULL,
   _tr_noop("Notch PW"),   "100",   "500",   STEP_SIZE, NULL,
   _tr_noop("Frame Size"), "10000", "30000", STEPSIZE2, NULL,
-  _tr_noop("Polarity"), _tr_noop("Uninverted"), _tr_noop("Inverted"), NULL,
+  _tr_noop("Polarity"), _tr_noop("Normal"), _tr_noop("Inverted"), NULL,
   NULL
 };
 enum {

--- a/src/target.h
+++ b/src/target.h
@@ -156,10 +156,12 @@ typedef enum {
 extern volatile mixsync_t mixer_sync;
 
 /*PWM/PPM functions */
+#define PPM_UNINVERTED 0
+#define PPM_INVERTED 1
 void PWM_Initialize();
 void PWM_Stop();
 void PWM_Set(int);
-void PPM_Enable(unsigned low_time, volatile u16 *pulses, u8 num_pulses);
+void PPM_Enable(unsigned active_time, volatile u16 *pulses, u8 num_pulses, u8 polarity);
 void PXX_Enable(u8 *packet);
 
 /* PPM-In functions */

--- a/src/target.h
+++ b/src/target.h
@@ -156,8 +156,8 @@ typedef enum {
 extern volatile mixsync_t mixer_sync;
 
 /*PWM/PPM functions */
-#define PPM_UNINVERTED 0
-#define PPM_INVERTED 1
+#define PPM_POLARITY_NORMAL 0
+#define PPM_POLARITY_INVERTED 1
 void PWM_Initialize();
 void PWM_Stop();
 void PWM_Set(int);

--- a/src/target/drivers/mcu/emu/radio.c
+++ b/src/target/drivers/mcu/emu/radio.c
@@ -146,9 +146,10 @@ void PXX_Enable(u8 *packet) {
         printf("%02x ", packet[i]);
     printf("\n");
 }
-void PPM_Enable(unsigned low_time, volatile u16 *pulses, u8 num_pulses) {
+void PPM_Enable(unsigned active_time, volatile u16 *pulses, u8 num_pulses, u8 polarity) {
+    (void)polarity;
     int i;
-    printf("PPM: low=%d ", (int)low_time);
+    printf("PPM: low=%d ", (int)active_time);
     for(i = 0; i < num_pulses; i++)
         printf("%04d ", pulses[i]);
     printf("\n");

--- a/src/target/tx/devo/common/protocol/pwm.c
+++ b/src/target/tx/devo/common/protocol/pwm.c
@@ -83,7 +83,7 @@ void PWM_Stop()
     }
 }
 
-void PPM_Enable(unsigned low_time, volatile u16 *pulses, u8 num_pulses)
+void PPM_Enable(unsigned active_time, volatile u16 *pulses, u8 num_pulses, u8 polarity)
 {
     if (!pulses || num_pulses < 1) return;
 
@@ -101,9 +101,12 @@ void PPM_Enable(unsigned low_time, volatile u16 *pulses, u8 num_pulses)
     DMA_enable_stream(PWM_DMA);    // dma ready to go
 
     // Setup timer for PPM
-    timer_set_oc_value(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch), low_time);
+    timer_set_oc_value(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch), active_time);
     timer_set_period(PWM_TIMER.tim, 22500);
-    timer_set_oc_polarity_low(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch));        // output active low
+    if (polarity == PPM_UNINVERTED)
+        timer_set_oc_polarity_low(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch));        // output active low
+    else
+        timer_set_oc_polarity_high(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch));        // output active high
     timer_set_oc_mode(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch), TIM_OCM_PWM1);  // output active when timer below compare
     timer_enable_oc_output(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch));           // enable OCx to pin
     timer_enable_break_main_output(PWM_TIMER.tim);               // master output enable

--- a/src/target/tx/devo/common/protocol/pwm.c
+++ b/src/target/tx/devo/common/protocol/pwm.c
@@ -103,7 +103,7 @@ void PPM_Enable(unsigned active_time, volatile u16 *pulses, u8 num_pulses, u8 po
     // Setup timer for PPM
     timer_set_oc_value(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch), active_time);
     timer_set_period(PWM_TIMER.tim, 22500);
-    if (polarity == PPM_UNINVERTED)
+    if (polarity == PPM_POLARITY_NORMAL)
         timer_set_oc_polarity_low(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch));        // output active low
     else
         timer_set_oc_polarity_high(PWM_TIMER.tim, TIM_OCx(PWM_TIMER.ch));        // output active high

--- a/src/target/tx/opentx/x9d/x9d_stubs.c
+++ b/src/target/tx/opentx/x9d/x9d_stubs.c
@@ -85,8 +85,9 @@ const char *MCU_GetPinName(char *str, struct mcu_pin *port) { return "None";}
 
 void PWM_Initialize() {}
 void PWM_Stop() {}
-void PPM_Enable(unsigned low_time, volatile u16 *pulses, u8 num_pulses) {
-    (void)low_time;
+void PPM_Enable(unsigned active_time, volatile u16 *pulses, u8 num_pulses, u8 polarity) {
+    (void)polarity;
+    (void)active_time;
     (void)pulses;
     (void)num_pulses;
 }

--- a/src/target/tx/other/test/radio.c
+++ b/src/target/tx/other/test/radio.c
@@ -140,9 +140,10 @@ int CYRF_Reset() {return 1;}
 void SPI_AVRProgramInit() {}
 void PWM_Initialize() {}
 void PWM_Stop() {}
-void PPM_Enable(unsigned low_time, volatile u16 *pulses, u8 num_pulses) {
+void PPM_Enable(unsigned active_time, volatile u16 *pulses, u8 num_pulses, u8 polarity) {
+    (void)polarity;
     int i;
-    printf("PPM: low=%d ", (int)low_time);
+    printf("PPM: low=%d ", (int)active_time);
     for(i = 0; i < num_pulses; i++)
         printf("%04d ", pulses[i]);
     printf("\n");

--- a/src/target/tx/radiolink/common/at_stubs.c
+++ b/src/target/tx/radiolink/common/at_stubs.c
@@ -56,10 +56,10 @@ const char *MCU_GetPinName(char *str, struct mcu_pin *port) {
 void PWM_Initialize() {}
 void PWM_Stop() {}
 void PPM_Enable(unsigned active_time, volatile u16 *pulses, u8 num_pulses, u8 polarity) {
-    (void)polarity;
-    (void)low_time;
+    (void)active_time;
     (void)pulses;
     (void)num_pulses;
+    (void)polarity;
 }
 void PXX_Enable(u8 *packet) { (void)packet; }
 typedef void sser_callback_t(u8 data);

--- a/src/target/tx/radiolink/common/at_stubs.c
+++ b/src/target/tx/radiolink/common/at_stubs.c
@@ -55,7 +55,8 @@ const char *MCU_GetPinName(char *str, struct mcu_pin *port) {
 
 void PWM_Initialize() {}
 void PWM_Stop() {}
-void PPM_Enable(unsigned low_time, volatile u16 *pulses, u8 num_pulses) {
+void PPM_Enable(unsigned active_time, volatile u16 *pulses, u8 num_pulses, u8 polarity) {
+    (void)polarity;
     (void)low_time;
     (void)pulses;
     (void)num_pulses;


### PR DESCRIPTION
Add an option to reverse signal polarity to the PPM protocol.
~~Note that PPM out is broken in current master (at least on T8SG V2+), it outputs only 1 pulse per frame, maybe a DMA issue ?~~ (fixed by #777 )
Tested with an older version.