### PR TITLE
Fix rare nrf24l01 problem

### DIFF
--- a/src/protocol/spi/nrf24l01.c
+++ b/src/protocol/spi/nrf24l01.c
@@ -64,7 +64,7 @@ u8 NRF24L01_WriteReg(u8 reg, u8 data)
     CS_LO();
     u8 res = PROTOSPI_xfer(W_REGISTER | (REGISTER_MASK & reg));
     PROTOSPI_xfer(data);
-    while(GPIO_pin_get(PROTO_SPI_CFG.sck));
+    while (GPIO_pin_get(PROTO_SPI_CFG.sck)) {}
     CS_HI();
     return res;
 }
@@ -77,7 +77,7 @@ u8 NRF24L01_WriteRegisterMulti(u8 reg, const u8 data[], u8 length)
     {
         PROTOSPI_xfer(data[i]);
     }
-    while(GPIO_pin_get(PROTO_SPI_CFG.sck));
+    while (GPIO_pin_get(PROTO_SPI_CFG.sck)) {}
     CS_HI();
     return res;
 }
@@ -90,7 +90,7 @@ u8 NRF24L01_WritePayload(u8 *data, u8 length)
     {
         PROTOSPI_xfer(data[i]);
     }
-    while(GPIO_pin_get(PROTO_SPI_CFG.sck));
+    while (GPIO_pin_get(PROTO_SPI_CFG.sck)) {}
     CS_HI();
     return res;
 }

--- a/src/protocol/spi/nrf24l01.c
+++ b/src/protocol/spi/nrf24l01.c
@@ -64,7 +64,7 @@ u8 NRF24L01_WriteReg(u8 reg, u8 data)
     CS_LO();
     u8 res = PROTOSPI_xfer(W_REGISTER | (REGISTER_MASK & reg));
     PROTOSPI_xfer(data);
-    while (GPIO_pin_get(PROTO_SPI_CFG.sck)) {}
+    while (PROTOSPI_pin_get(PROTO_SPI_CFG.sck)) {}
     CS_HI();
     return res;
 }
@@ -77,7 +77,7 @@ u8 NRF24L01_WriteRegisterMulti(u8 reg, const u8 data[], u8 length)
     {
         PROTOSPI_xfer(data[i]);
     }
-    while (GPIO_pin_get(PROTO_SPI_CFG.sck)) {}
+    while (PROTOSPI_pin_get(PROTO_SPI_CFG.sck)) {}
     CS_HI();
     return res;
 }
@@ -90,7 +90,7 @@ u8 NRF24L01_WritePayload(u8 *data, u8 length)
     {
         PROTOSPI_xfer(data[i]);
     }
-    while (GPIO_pin_get(PROTO_SPI_CFG.sck)) {}
+    while (PROTOSPI_pin_get(PROTO_SPI_CFG.sck)) {}
     CS_HI();
     return res;
 }

--- a/src/protocol/spi/nrf24l01.c
+++ b/src/protocol/spi/nrf24l01.c
@@ -64,6 +64,7 @@ u8 NRF24L01_WriteReg(u8 reg, u8 data)
     CS_LO();
     u8 res = PROTOSPI_xfer(W_REGISTER | (REGISTER_MASK & reg));
     PROTOSPI_xfer(data);
+    // wait spi transfer completes
     while (PROTOSPI_pin_get(PROTO_SPI_CFG.sck)) {}
     CS_HI();
     return res;
@@ -77,6 +78,7 @@ u8 NRF24L01_WriteRegisterMulti(u8 reg, const u8 data[], u8 length)
     {
         PROTOSPI_xfer(data[i]);
     }
+    // wait spi transfer completes
     while (PROTOSPI_pin_get(PROTO_SPI_CFG.sck)) {}
     CS_HI();
     return res;
@@ -90,6 +92,7 @@ u8 NRF24L01_WritePayload(u8 *data, u8 length)
     {
         PROTOSPI_xfer(data[i]);
     }
+    // wait spi transfer completes
     while (PROTOSPI_pin_get(PROTO_SPI_CFG.sck)) {}
     CS_HI();
     return res;

--- a/src/protocol/spi/nrf24l01.c
+++ b/src/protocol/spi/nrf24l01.c
@@ -64,6 +64,7 @@ u8 NRF24L01_WriteReg(u8 reg, u8 data)
     CS_LO();
     u8 res = PROTOSPI_xfer(W_REGISTER | (REGISTER_MASK & reg));
     PROTOSPI_xfer(data);
+    while(GPIO_pin_get(PROTO_SPI_CFG.sck));
     CS_HI();
     return res;
 }
@@ -76,6 +77,7 @@ u8 NRF24L01_WriteRegisterMulti(u8 reg, const u8 data[], u8 length)
     {
         PROTOSPI_xfer(data[i]);
     }
+    while(GPIO_pin_get(PROTO_SPI_CFG.sck));
     CS_HI();
     return res;
 }
@@ -88,6 +90,7 @@ u8 NRF24L01_WritePayload(u8 *data, u8 length)
     {
         PROTOSPI_xfer(data[i]);
     }
+    while(GPIO_pin_get(PROTO_SPI_CFG.sck));
     CS_HI();
     return res;
 }

--- a/src/target/drivers/mcu/emu/protospi.h
+++ b/src/target/drivers/mcu/emu/protospi.h
@@ -3,8 +3,8 @@
 
 u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
-#define PROTOSPI_pin_set(io) if (0) {}
-#define PROTOSPI_pin_clear(io) if (0) {}
+#define PROTOSPI_pin_set(io) do {} while (0)
+#define PROTOSPI_pin_clear(io) do {} while (0)
 #define PROTOSPI_pin_get(io) (0)
 #define _NOP() if(0) {}
 

--- a/src/target/drivers/mcu/emu/protospi.h
+++ b/src/target/drivers/mcu/emu/protospi.h
@@ -5,6 +5,7 @@ u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
 #define PROTOSPI_pin_set(io) if(0) {}
 #define PROTOSPI_pin_clear(io) if(0) {}
+#define PROTOSPI_pin_get(io) if(0) {}
 #define _NOP() if(0) {}
 
 #pragma weak A7105_Reset

--- a/src/target/drivers/mcu/emu/protospi.h
+++ b/src/target/drivers/mcu/emu/protospi.h
@@ -5,7 +5,7 @@ u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
 #define PROTOSPI_pin_set(io) if (0) {}
 #define PROTOSPI_pin_clear(io) if (0) {}
-#define PROTOSPI_pin_get(io) if (0) {}
+#define PROTOSPI_pin_get(io) (0)
 #define _NOP() if(0) {}
 
 #pragma weak A7105_Reset

--- a/src/target/drivers/mcu/emu/protospi.h
+++ b/src/target/drivers/mcu/emu/protospi.h
@@ -3,9 +3,9 @@
 
 u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
-#define PROTOSPI_pin_set(io) if(0) {}
-#define PROTOSPI_pin_clear(io) if(0) {}
-#define PROTOSPI_pin_get(io) if(0) {}
+#define PROTOSPI_pin_set(io) if (0) {}
+#define PROTOSPI_pin_clear(io) if (0) {}
+#define PROTOSPI_pin_get(io) if (0) {}
 #define _NOP() if(0) {}
 
 #pragma weak A7105_Reset

--- a/src/target/tx/devo/common/protospi.h
+++ b/src/target/tx/devo/common/protospi.h
@@ -8,6 +8,7 @@ u8 PROTOSPI_read3wire();
 
 #define PROTOSPI_pin_set(io) GPIO_pin_set(io)
 #define PROTOSPI_pin_clear(io) GPIO_pin_clear(io)
+#define PROTOSPI_pin_get(io) GPIO_pin_get(io)
 #define PROTOSPI_xfer(byte) spi_xfer(PROTO_SPI.spi, byte)
 #define _NOP()  asm volatile ("nop")
 

--- a/src/target/tx/opentx/x9d/protospi.h
+++ b/src/target/tx/opentx/x9d/protospi.h
@@ -6,9 +6,9 @@
 
 u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
-#define PROTOSPI_pin_set(io) gpio_set((io).port,(io).pin)
-#define PROTOSPI_pin_clear(io) gpio_clear((io).port,(io).pin)
-#define PROTOSPI_pin_get(io) gpio_get(io).port,(io).pin)
+#define PROTOSPI_pin_set(io) gpio_set((io).port, (io).pin)
+#define PROTOSPI_pin_clear(io) gpio_clear((io).port, (io).pin)
+#define PROTOSPI_pin_get(io) gpio_get(io).port, (io).pin)
 #define _NOP(n) asm volatile ("nop")
 
 #define _SPI_CYRF_RESET_PIN {0, 0}

--- a/src/target/tx/opentx/x9d/protospi.h
+++ b/src/target/tx/opentx/x9d/protospi.h
@@ -8,6 +8,7 @@ u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
 #define PROTOSPI_pin_set(io) gpio_set((io).port,(io).pin)
 #define PROTOSPI_pin_clear(io) gpio_clear((io).port,(io).pin)
+#define PROTOSPI_pin_get(io) gpio_get(io).port,(io).pin)
 #define _NOP(n) asm volatile ("nop")
 
 #define _SPI_CYRF_RESET_PIN {0, 0}

--- a/src/target/tx/other/test/protospi.h
+++ b/src/target/tx/other/test/protospi.h
@@ -5,7 +5,7 @@ u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
 #define PROTOSPI_pin_set(io) if (0) {}
 #define PROTOSPI_pin_clear(io) if (0) {}
-#define PROTOSPI_pin_get(io) if (0) {}
+#define PROTOSPI_pin_get(io) (0)
 #define _NOP() if(0) {}
 
 #define _SPI_CYRF_RESET_PIN {0, 0}

--- a/src/target/tx/other/test/protospi.h
+++ b/src/target/tx/other/test/protospi.h
@@ -3,8 +3,8 @@
 
 u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
-#define PROTOSPI_pin_set(io) if (0) {}
-#define PROTOSPI_pin_clear(io) if (0) {}
+#define PROTOSPI_pin_set(io) do {} while (0)
+#define PROTOSPI_pin_clear(io) do {} while (0)
 #define PROTOSPI_pin_get(io) (0)
 #define _NOP() if(0) {}
 

--- a/src/target/tx/other/test/protospi.h
+++ b/src/target/tx/other/test/protospi.h
@@ -5,6 +5,7 @@ u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
 #define PROTOSPI_pin_set(io) if(0) {}
 #define PROTOSPI_pin_clear(io) if(0) {}
+#define PROTOSPI_pin_get(io) if(0) {}
 #define _NOP() if(0) {}
 
 #define _SPI_CYRF_RESET_PIN {0, 0}

--- a/src/target/tx/other/test/protospi.h
+++ b/src/target/tx/other/test/protospi.h
@@ -3,9 +3,9 @@
 
 u8 PROTOSPI_read3wire();
 u8 PROTOSPI_xfer(u8 byte);
-#define PROTOSPI_pin_set(io) if(0) {}
-#define PROTOSPI_pin_clear(io) if(0) {}
-#define PROTOSPI_pin_get(io) if(0) {}
+#define PROTOSPI_pin_set(io) if (0) {}
+#define PROTOSPI_pin_clear(io) if (0) {}
+#define PROTOSPI_pin_get(io) if (0) {}
 #define _NOP() if(0) {}
 
 #define _SPI_CYRF_RESET_PIN {0, 0}

--- a/src/target/tx/radiolink/common/protospi.h
+++ b/src/target/tx/radiolink/common/protospi.h
@@ -6,9 +6,9 @@
 
 u8 PROTOSPI_read3wire();
 
-#define PROTOSPI_pin_set(io) gpio_set(io.port,io.pin)
-#define PROTOSPI_pin_clear(io) gpio_clear(io.port,io.pin)
-#define PROTOSPI_pin_get(io) gpio_get(io.port,io.pin)
+#define PROTOSPI_pin_set(io) gpio_set(io.port, io.pin)
+#define PROTOSPI_pin_clear(io) gpio_clear(io.port, io.pin)
+#define PROTOSPI_pin_get(io) gpio_get(io.port, io.pin)
 #define PROTOSPI_xfer(byte) spi_xfer(SPI2, byte)
 #define _NOP()  asm volatile ("nop")
 

--- a/src/target/tx/radiolink/common/protospi.h
+++ b/src/target/tx/radiolink/common/protospi.h
@@ -8,6 +8,7 @@ u8 PROTOSPI_read3wire();
 
 #define PROTOSPI_pin_set(io) gpio_set(io.port,io.pin)
 #define PROTOSPI_pin_clear(io) gpio_clear(io.port,io.pin)
+#define PROTOSPI_pin_get(io) gpio_get(io.port,io.pin)
 #define PROTOSPI_xfer(byte) spi_xfer(SPI2, byte)
 #define _NOP()  asm volatile ("nop")
 

--- a/src/universaltx/include/protospi.h
+++ b/src/universaltx/include/protospi.h
@@ -11,6 +11,7 @@ uint8_t spi_xfer8(uint32_t spi, uint8_t data);
 #define spi_xfer             DO_NOT_USE
 #define PROTOSPI_pin_set     PORT_pin_set
 #define PROTOSPI_pin_clear   PORT_pin_clear
+#define PROTOSPI_pin_get     PORT_pin_get
 #define PROTOSPI_xfer(byte)  spi_xfer8(SPI2, byte)
 
 #define _NOP()  asm volatile ("nop")


### PR DESCRIPTION
Fix rare nrf24l01 problem where CS goes HIGH before the last clock pulse has completed:
![fail](https://user-images.githubusercontent.com/1297665/53637814-77ecaf00-3c24-11e9-9c59-cbef2360c70e.png)
When this happens, the last byte is not registered by the nrf24l01 and is replaced by the previous one.
