### PR TITLE
Add Silverware's analog aux channel feature to Bayang protocol

### DIFF
--- a/src/protocol/bayang_nrf24l01.c
+++ b/src/protocol/bayang_nrf24l01.c
@@ -206,8 +206,7 @@ static void send_packet(u8 bind)
         }
         if (analogaux) {
             packet[1] = scale_channel(CHANNEL_ANAAUX1, 0, 0xff);
-        }
-        else {
+        } else {
             packet[1] = 0xfa;       // normal mode is 0xf7, expert 0xfa
         }
         packet[2] = GET_FLAG(CHANNEL_FLIP, 0x08)
@@ -237,8 +236,7 @@ static void send_packet(u8 bind)
                 packet[12] = txid[2];
                 if (analogaux) {
                     packet[13] = scale_channel(CHANNEL_ANAAUX2, 0, 0xff);
-                }
-                else {
+                } else {
                     packet[13] = 0x0a;
                 }
                 break;
@@ -534,7 +532,7 @@ uintptr_t Bayang_Cmds(enum ProtoCmds cmd)
         initialize();
         return 0;
     case PROTOCMD_NUMCHAN:
-        return (analogaux ? 14 : 12);
+        return 14;
     case PROTOCMD_DEFAULT_NUMCHAN:
         return (analogaux ? 14 : 12);
     case PROTOCMD_CURRENT_ID:

--- a/src/protocol/bayang_nrf24l01.c
+++ b/src/protocol/bayang_nrf24l01.c
@@ -534,7 +534,7 @@ uintptr_t Bayang_Cmds(enum ProtoCmds cmd)
     case PROTOCMD_NUMCHAN:
         return 14;
     case PROTOCMD_DEFAULT_NUMCHAN:
-        return (analogaux ? 14 : 12);
+        return 14;
     case PROTOCMD_CURRENT_ID:
         return Model.fixed_id;
     case PROTOCMD_GETOPTIONS:


### PR DESCRIPTION
This change to the Bayang protocol adds an option to steal two presently unused (by the Silverware firmware, which targets several Bayang quads) in the protocol to send two more "analog" (non-binary) channels of data to the Rx. With corresponding changes on the Rx firmware, those new aux channels can be used to do more interesting things than the other binary aux channels. Some users have really liked PID tuning with the extra channels.

More information on the Silverware additions here:
https://www.rcgroups.com/forums/showthread.php?3121896-Analog-Aux-Channels-for-Silverware

The main NFE Silverware fork now has this feature available:
https://github.com/NotFastEnuf/NFE_Silverware

I am making a corresponding pull request to DIY Multiprotocol TX with the same additions to the Bayang protocol.