### PR TITLE
Cleanup _tr usage

### DIFF
--- a/src/config/model.c
+++ b/src/config/model.c
@@ -505,7 +505,7 @@ static int layout_ini_handler(void* user, const char* section, const char* name,
                 return 1;
 #if HAS_RTC
             for(i = 0; i < NUM_RTC; i++) {
-                if(mapstrcasecmp(ptr, RTC_Name(str, i)) == 0) {
+                if (mapstrcasecmp(ptr, RTC_Name(i)) == 0) {
                     src = i + 1;
                     break;
                 }

--- a/src/curves.c
+++ b/src/curves.c
@@ -218,23 +218,23 @@ s32 CURVE_Evaluate(s32 xval, struct Curve *curve)
 const char *CURVE_GetName(char *str, struct Curve *curve)
 {
     switch (CURVE_TYPE(curve)) {
-        case CURVE_NONE: return _tr("1-to-1");
-        case CURVE_FIXED: return _tr("Fixed");
-        case CURVE_MIN_MAX:  return _tr("Min/Max");
-        case CURVE_ZERO_MAX: return _tr("Zero/Max");
+        case CURVE_NONE: return _tr_noop("1-to-1");
+        case CURVE_FIXED: return _tr_noop("Fixed");
+        case CURVE_MIN_MAX:  return _tr_noop("Min/Max");
+        case CURVE_ZERO_MAX: return _tr_noop("Zero/Max");
         case CURVE_GT_ZERO:  return "> 0"; //Don't translate these
         case CURVE_LT_ZERO:  return "< 0"; //Don't translate these
-        case CURVE_ABSVAL:   return _tr("ABSVAL");
-        case CURVE_EXPO:     sprintf(str, _tr("EXPO %d"), curve->points[0]); return str;
-        case CURVE_DEADBAND: return _tr("Deadband");
-        case CURVE_3POINT:   return _tr("3 Point");
-        case CURVE_5POINT:   return _tr("5 Point");
-        case CURVE_7POINT:   return _tr("7 Point");
-        case CURVE_9POINT:   return _tr("9 Point");
-        case CURVE_11POINT:  return _tr("11 Point");
-        case CURVE_13POINT:  return _tr("13 Point");
+        case CURVE_ABSVAL:   return _tr_noop("ABSVAL");
+        case CURVE_EXPO:     sprintf(str, _tr_noop("EXPO %d"), curve->points[0]); return str;
+        case CURVE_DEADBAND: return _tr_noop("Deadband");
+        case CURVE_3POINT:   return _tr_noop("3 Point");
+        case CURVE_5POINT:   return _tr_noop("5 Point");
+        case CURVE_7POINT:   return _tr_noop("7 Point");
+        case CURVE_9POINT:   return _tr_noop("9 Point");
+        case CURVE_11POINT:  return _tr_noop("11 Point");
+        case CURVE_13POINT:  return _tr_noop("13 Point");
     }
-    return _tr("Unknown");
+    return _tr_noop("Unknown");
 }
 
 unsigned CURVE_NumPoints(struct Curve *curve)

--- a/src/datalog.c
+++ b/src/datalog.c
@@ -54,11 +54,11 @@ u16 data_size;
 const char *DATALOG_RateString(int idx)
 {
     switch(idx) {
-        case 0: return _tr("1 sec");
-        case 1: return _tr("5 sec");
-        case 2: return _tr("10 sec");
-        case 3: return _tr("30 sec");
-        case 4: return _tr("60 sec");
+        case 0: return _tr_noop("1 sec");
+        case 1: return _tr_noop("5 sec");
+        case 2: return _tr_noop("10 sec");
+        case 3: return _tr_noop("30 sec");
+        case 4: return _tr_noop("60 sec");
     }
     return "";
 }
@@ -67,17 +67,17 @@ const char *DATALOG_Source(char *str, int idx)
 {
 #if HAS_RTC
     if (idx == DLOG_TIME) {
-        strcpy(str, _tr("RTC Time"));
+        strcpy(str, _tr_noop("RTC Time"));
     } else
 #endif
     if (idx == DLOG_GPSTIME) {
-        strcpy(str, _tr("GPS Time"));
+        strcpy(str, _tr_noop("GPS Time"));
     } else if (idx == DLOG_GPSLOC) {
-        strcpy(str, _tr("GPS Coords"));
+        strcpy(str, _tr_noop("GPS Coords"));
     } else if (idx == DLOG_GPSALT) {
-        strcpy(str, _tr("GPS Alt."));
+        strcpy(str, _tr_noop("GPS Alt."));
     } else if (idx == DLOG_GPSSPEED) {
-        strcpy(str, _tr("GPS Speed"));
+        strcpy(str, _tr_noop("GPS Speed"));
     } else if (idx >= DLOG_INPUTS) {
         return INPUT_SourceName(str, idx - DLOG_INPUTS + 1);
     } else if (idx >= DLOG_TELEMETRY) {

--- a/src/inputs.c
+++ b/src/inputs.c
@@ -89,28 +89,24 @@
 #define INPNAME_SWH0(x,y)      x = _tr_noop("SW H"); y = 0
 #define INPNAME_SWH1(x,y)      x = _tr_noop("SW H"); y = 1
 
-#define SWITCH_NAME_GEAR0 _tr("GEAR")
-#define SWITCH_NAME_GEAR1 _tr("GEAR")
-#define SWITCH_NAME_GEAR0 _tr("GEAR")
-
-#define BUTNAME_TRIM_LV_NEG _tr("TRIMLV-")
-#define BUTNAME_TRIM_LV_POS _tr("TRIMLV+")
-#define BUTNAME_TRIM_RV_NEG _tr("TRIMRV-")
-#define BUTNAME_TRIM_RV_POS _tr("TRIMRV+")
-#define BUTNAME_TRIM_LH_NEG _tr("TRIMLH-")
-#define BUTNAME_TRIM_LH_POS _tr("TRIMLH+")
-#define BUTNAME_TRIM_RH_NEG _tr("TRIMRH-")
-#define BUTNAME_TRIM_RH_POS _tr("TRIMRH+")
-#define BUTNAME_TRIM_L_NEG  _tr("TRIM_L-")
-#define BUTNAME_TRIM_L_POS  _tr("TRIM_L+")
-#define BUTNAME_TRIM_R_NEG  _tr("TRIM_R-")
-#define BUTNAME_TRIM_R_POS  _tr("TRIM_R+")
-#define BUTNAME_LEFT        _tr("Left")
-#define BUTNAME_RIGHT       _tr("Right")
-#define BUTNAME_DOWN        _tr("Down")
-#define BUTNAME_UP          _tr("Up")
-#define BUTNAME_ENTER       _tr("Enter")
-#define BUTNAME_EXIT        _tr("Exit")
+#define BUTNAME_TRIM_LV_NEG _tr_noop("TRIMLV-")
+#define BUTNAME_TRIM_LV_POS _tr_noop("TRIMLV+")
+#define BUTNAME_TRIM_RV_NEG _tr_noop("TRIMRV-")
+#define BUTNAME_TRIM_RV_POS _tr_noop("TRIMRV+")
+#define BUTNAME_TRIM_LH_NEG _tr_noop("TRIMLH-")
+#define BUTNAME_TRIM_LH_POS _tr_noop("TRIMLH+")
+#define BUTNAME_TRIM_RH_NEG _tr_noop("TRIMRH-")
+#define BUTNAME_TRIM_RH_POS _tr_noop("TRIMRH+")
+#define BUTNAME_TRIM_L_NEG  _tr_noop("TRIM_L-")
+#define BUTNAME_TRIM_L_POS  _tr_noop("TRIM_L+")
+#define BUTNAME_TRIM_R_NEG  _tr_noop("TRIM_R-")
+#define BUTNAME_TRIM_R_POS  _tr_noop("TRIM_R+")
+#define BUTNAME_LEFT        _tr_noop("Left")
+#define BUTNAME_RIGHT       _tr_noop("Right")
+#define BUTNAME_DOWN        _tr_noop("Down")
+#define BUTNAME_UP          _tr_noop("Up")
+#define BUTNAME_ENTER       _tr_noop("Enter")
+#define BUTNAME_EXIT        _tr_noop("Exit")
 
 const char * const tx_stick_names[4] = {
     _tr_noop("RIGHT_H"),
@@ -251,11 +247,10 @@ const char *INPUT_MapSourceName(unsigned idx, unsigned *val)
     return NULL;
 }
 
-
 const char *INPUT_ButtonName(unsigned button)
 {
     if (! button) {
-        return _tr("None");
+        return "None";
     }
     #define BUTTONDEF(x) case BUT_##x : return BUTNAME_##x;
     switch(button) {

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -884,7 +884,7 @@ const char *MIXER_TemplateName(enum TemplateType template)
 const char *MIXER_SwashType(enum SwashType swash_type)
 {
     switch(swash_type) {
-        case SWASH_TYPE_NONE: return _tr("None");
+        case SWASH_TYPE_NONE: return _tr_noop("None");
         case SWASH_TYPE_120:  return "120";
         case SWASH_TYPE_120X: return "120X";
         case SWASH_TYPE_140:  return "140";

--- a/src/mixer.c
+++ b/src/mixer.c
@@ -870,14 +870,14 @@ unsigned MIXER_SourceHasTrim(unsigned src)
 const char *MIXER_TemplateName(enum TemplateType template)
 {
     switch(template) {
-    case MIXERTEMPLATE_NONE :   return _tr("None");
-    case MIXERTEMPLATE_SIMPLE:  return _tr("Simple");
-    case MIXERTEMPLATE_EXPO_DR: return _tr("Expo&DR");
-    case MIXERTEMPLATE_COMPLEX: return _tr("Complex");
-    case MIXERTEMPLATE_CYC1:    return _tr("Cyclic1");
-    case MIXERTEMPLATE_CYC2:    return _tr("Cyclic2");
-    case MIXERTEMPLATE_CYC3:    return _tr("Cyclic3");
-    default:                    return _tr("Unknown");
+    case MIXERTEMPLATE_NONE :   return _tr_noop("None");
+    case MIXERTEMPLATE_SIMPLE:  return _tr_noop("Simple");
+    case MIXERTEMPLATE_EXPO_DR: return _tr_noop("Expo&DR");
+    case MIXERTEMPLATE_COMPLEX: return _tr_noop("Complex");
+    case MIXERTEMPLATE_CYC1:    return _tr_noop("Cyclic1");
+    case MIXERTEMPLATE_CYC2:    return _tr_noop("Cyclic2");
+    case MIXERTEMPLATE_CYC3:    return _tr_noop("Cyclic3");
+    default:                    return _tr_noop("Unknown");
     }
 }
 

--- a/src/mixer_standard.c
+++ b/src/mixer_standard.c
@@ -164,15 +164,9 @@ unsigned STDMIXER_ValidateTraditionModel()
     return 1;
 }
 
-static const char * ModeNames[] =
-{
-    _tr_noop("Advanced"),
-    _tr_noop("Standard"),
-};
-
 const char *STDMIXER_ModeName(int mode)
 {
-    return ModeNames[mode - 0x01];
+    return mode == MIXER_ADVANCED ? _tr_noop("Advanced") : _tr_noop("Standard");
 }
 
 void STDMIXER_InitSwitches()

--- a/src/mixer_standard.c
+++ b/src/mixer_standard.c
@@ -164,9 +164,15 @@ unsigned STDMIXER_ValidateTraditionModel()
     return 1;
 }
 
+static const char * ModeNames[] =
+{
+    _tr_noop("Advanced"),
+    _tr_noop("Standard"),
+};
+
 const char *STDMIXER_ModeName(int mode)
 {
-    return mode == MIXER_ADVANCED ? _tr("Advanced") : _tr("Standard");
+    return ModeNames[mode - 0x01];
 }
 
 void STDMIXER_InitSwitches()

--- a/src/pages/128x64x1/main_config.c
+++ b/src/pages/128x64x1/main_config.c
@@ -96,7 +96,7 @@ static const char *cfglabel_cb(guiObject_t *obj, const void *data)
         str = _tr("Toggle");
         break;
     default:
-        str = GetElemName(type);
+        str = _tr(GetElemName(type));
         break;
     }
     sprintf(tempstring,"%s%d", str, idx+1);

--- a/src/pages/128x64x1/trim_page.c
+++ b/src/pages/128x64x1/trim_page.c
@@ -60,7 +60,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     GUI_CreateTextSelectPlate(&gui->item[relrow], TEXTSEL_X, y,
             TEXTSEL_WIDTH, LINE_HEIGHT, &TINY_FONT,  NULL, set_trimstep_cb, (void *)(long)(absrow + 0x000)); //0x000: Use Model.trims
     GUI_CreateLabelBox(&gui->name[relrow], LABEL_X, y, LABEL_WIDTH, LINE_HEIGHT,
-            &TINY_FONT, NULL, NULL,  (void *)INPUT_ButtonName(trim[absrow].pos));
+            &TINY_FONT, GUI_Localize, NULL,  (void *)INPUT_ButtonName(trim[absrow].pos));
     return 2;
 }
 

--- a/src/pages/320x240x16/model_page.c
+++ b/src/pages/320x240x16/model_page.c
@@ -72,7 +72,7 @@ void PAGE_ModelInit(int page)
     row += 20;
     GUI_CreateLabelBox(&gui->namelbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Model name"));  // use the same naming convention for devo8 and devo10
     GUI_CreateButton(&gui->name, COL2, row, BUTTON_96x16, show_text_cb, _changename_cb, Model.name);
-    GUI_CreateButton(&gui->icon, COL3, row, BUTTON_64x16, show_text_cb, changeicon_cb, _tr("Icon"));
+    GUI_CreateButton(&gui->icon, COL3, row, BUTTON_64x16, show_text_cb_loc, changeicon_cb, _tr_noop("Icon"));
 
     row += 20;
     GUI_CreateLabelBox(&gui->typelbl, COL1, row, LABEL_WIDTH, 18, &LABEL_FONT, GUI_Localize, NULL, _tr_noop("Model type"));

--- a/src/pages/320x240x16/trim_page.c
+++ b/src/pages/320x240x16/trim_page.c
@@ -45,7 +45,7 @@ static const char *negtrim_str(guiObject_t *obj, const void *data)
     if(Model.trims[i].step == TRIM_MOMENTARY || Model.trims[i].step == TRIM_TOGGLE)
         return _tr("None");
     struct Trim *trim = MIXER_GetAllTrims();
-    return INPUT_ButtonName(trim[i].neg);
+    return _tr(INPUT_ButtonName(trim[i].neg));
 }
 
 static int row_cb(int absrow, int relrow, int y, void *data)
@@ -55,7 +55,7 @@ static int row_cb(int absrow, int relrow, int y, void *data)
     GUI_CreateButton(&gui->src[relrow], PCOL1, y, BUTTON_64x16,
         trimsource_name_cb, edit_trim_cb, (void *)((long)absrow));
     GUI_CreateLabel(&gui->neg[relrow], PCOL2 + 6, y, negtrim_str, DEFAULT_FONT, (void *)(long)absrow);
-    GUI_CreateLabel(&gui->pos[relrow], PCOL3 + 6, y, NULL, DEFAULT_FONT, (void *)INPUT_ButtonName(trim[absrow].pos));
+    GUI_CreateLabel(&gui->pos[relrow], PCOL3 + 6, y, GUI_Localize, DEFAULT_FONT, (void *)INPUT_ButtonName(trim[absrow].pos));
     GUI_CreateTextSelect(&gui->step[relrow], PCOL4 + 6, y, TEXTSELECT_96, NULL,
                          set_trimstep_cb, (void *)(long)(absrow + 0x000)); //0x000: Use Model.trims
     return 2;

--- a/src/pages/common/_chantest_page.c
+++ b/src/pages/common/_chantest_page.c
@@ -42,7 +42,7 @@ const char *button_str_cb(guiObject_t *obj, const void *data)
 {
     (void)obj;
     int button = (long)data;
-    return INPUT_ButtonName(button + 1);
+    return _tr(INPUT_ButtonName(button + 1));
 }
 
 unsigned button_capture_cb(u32 button, unsigned flags, void *data)

--- a/src/pages/common/_datalog_page.c
+++ b/src/pages/common/_datalog_page.c
@@ -22,7 +22,7 @@ u32 remaining;
 const char *source_cb(guiObject_t *obj, const void *data)
 {
     (void)obj;
-    return _tr(DATALOG_Source(tempstring, (long)data));
+    return _tr(DATALOG_Source(tempstring, (uintptr_t)data));
 }
 
 static const char *ratesel_cb(guiObject_t *obj, int dir, void *data)

--- a/src/pages/common/_datalog_page.c
+++ b/src/pages/common/_datalog_page.c
@@ -22,7 +22,7 @@ u32 remaining;
 const char *source_cb(guiObject_t *obj, const void *data)
 {
     (void)obj;
-    return DATALOG_Source(tempstring, (long)data);
+    return _tr(DATALOG_Source(tempstring, (long)data));
 }
 
 static const char *ratesel_cb(guiObject_t *obj, int dir, void *data)
@@ -30,7 +30,7 @@ static const char *ratesel_cb(guiObject_t *obj, int dir, void *data)
     (void)obj;
     (void)data;
     dlog->rate = GUI_TextSelectHelper(dlog->rate, 0, DLOG_RATE_LAST-1, dir, 1, 1, NULL);
-    return DATALOG_RateString(dlog->rate);
+    return _tr(DATALOG_RateString(dlog->rate));
 }
 
 static const char *sourcesel_cb(guiObject_t *obj, int dir, void *data)

--- a/src/pages/common/_main_config.c
+++ b/src/pages/common/_main_config.c
@@ -46,7 +46,7 @@ int elem_get_count(int type)
     return 0;
 }
 
-const char *_GetBoxSource(char *str, int src, int real)
+static const char *_GetBoxSource(char *str, int src)
 {
     if (src) {
 #if HAS_RTC
@@ -58,25 +58,20 @@ const char *_GetBoxSource(char *str, int src, int real)
         else if( src - NUM_RTC - NUM_TIMERS <= NUM_TELEM)
             return TELEMETRY_Name(str, src - NUM_RTC - NUM_TIMERS);
     }
-    if (real) {
-        return INPUT_SourceNameReal(str, src
-               ? src - (NUM_TELEM + NUM_TIMERS + NUM_RTC) + NUM_INPUTS
-               : 0);
-    } else {
-        return INPUT_SourceName(str, src
-               ? src - (NUM_TELEM + NUM_TIMERS + NUM_RTC) + NUM_INPUTS
-               : 0);
-    }
+
+    return INPUT_SourceNameReal(str, src
+           ? src - (NUM_TELEM + NUM_TIMERS + NUM_RTC) + NUM_INPUTS
+           : 0);
 }
 
 const char *GetBoxSource(char *str, int src)
 {
-    return _GetBoxSource(str, src, 0);
+    return _tr(_GetBoxSource(str, src));
 }
 
 const char *GetBoxSourceReal(char *str, int src)
 {
-    return _GetBoxSource(str, src, 1);
+    return _GetBoxSource(str, src);
 }
 
 const char *GetElemName(int type)

--- a/src/pages/common/_main_config.c
+++ b/src/pages/common/_main_config.c
@@ -46,7 +46,7 @@ int elem_get_count(int type)
     return 0;
 }
 
-static const char *_GetBoxSource(char *str, int src)
+const char *_GetBoxSource(char *str, int src, int real)
 {
     if (src) {
 #if HAS_RTC
@@ -58,20 +58,25 @@ static const char *_GetBoxSource(char *str, int src)
         else if( src - NUM_RTC - NUM_TIMERS <= NUM_TELEM)
             return TELEMETRY_Name(str, src - NUM_RTC - NUM_TIMERS);
     }
-
-    return INPUT_SourceNameReal(str, src
-           ? src - (NUM_TELEM + NUM_TIMERS + NUM_RTC) + NUM_INPUTS
-           : 0);
+    if (real) {
+        return INPUT_SourceNameReal(str, src
+               ? src - (NUM_TELEM + NUM_TIMERS + NUM_RTC) + NUM_INPUTS
+               : 0);
+    } else {
+        return INPUT_SourceName(str, src
+               ? src - (NUM_TELEM + NUM_TIMERS + NUM_RTC) + NUM_INPUTS
+               : 0);
+    }
 }
 
 const char *GetBoxSource(char *str, int src)
 {
-    return _tr(_GetBoxSource(str, src));
+    return _GetBoxSource(str, src, 0);
 }
 
 const char *GetBoxSourceReal(char *str, int src)
 {
-    return _GetBoxSource(str, src);
+    return _GetBoxSource(str, src, 1);
 }
 
 const char *GetElemName(int type)

--- a/src/pages/common/_main_config.c
+++ b/src/pages/common/_main_config.c
@@ -51,7 +51,7 @@ const char *_GetBoxSource(char *str, int src, int real)
     if (src) {
 #if HAS_RTC
         if (src <= NUM_RTC)
-            return _tr(RTC_Name(str, src - 1));
+            return _tr(RTC_Name(src - 1));
 #endif
         if (src - NUM_RTC <= NUM_TIMERS)
             return TIMER_Name(str, src - NUM_RTC - 1);

--- a/src/pages/common/_main_config.c
+++ b/src/pages/common/_main_config.c
@@ -51,7 +51,7 @@ const char *_GetBoxSource(char *str, int src, int real)
     if (src) {
 #if HAS_RTC
         if (src <= NUM_RTC)
-            return RTC_Name(str, src - 1);
+            return _tr(RTC_Name(str, src - 1));
 #endif
         if (src - NUM_RTC <= NUM_TIMERS)
             return TIMER_Name(str, src - NUM_RTC - 1);

--- a/src/pages/common/_main_config.c
+++ b/src/pages/common/_main_config.c
@@ -77,15 +77,15 @@ const char *GetBoxSourceReal(char *str, int src)
 const char *GetElemName(int type)
 {
     switch(type) {
-        case ELEM_SMALLBOX: return _tr("Small-box");
-        case ELEM_BIGBOX:   return _tr("Big-box");
-        case ELEM_TOGGLE:   return _tr("Toggle");
-        case ELEM_BAR:      return _tr("Bargraph");
-        case ELEM_VTRIM:    return _tr("V-trim");
-        case ELEM_HTRIM:    return _tr("H-trim");
-        case ELEM_MODELICO: return _tr("Model");
-        case ELEM_BATTERY:  return _tr("Battery");
-        case ELEM_TXPOWER:  return _tr("TxPower");
+        case ELEM_SMALLBOX: return _tr_noop("Small-box");
+        case ELEM_BIGBOX:   return _tr_noop("Big-box");
+        case ELEM_TOGGLE:   return _tr_noop("Toggle");
+        case ELEM_BAR:      return _tr_noop("Bargraph");
+        case ELEM_VTRIM:    return _tr_noop("V-trim");
+        case ELEM_HTRIM:    return _tr_noop("H-trim");
+        case ELEM_MODELICO: return _tr_noop("Model");
+        case ELEM_BATTERY:  return _tr_noop("Battery");
+        case ELEM_TXPOWER:  return _tr_noop("TxPower");
     }
     return "";
 }
@@ -96,7 +96,7 @@ const char *newelem_cb(guiObject_t *obj, int dir, void *data)
     (void)obj;
     const int last_elem = (HAS_TOUCH) ? ELEM_BATTERY : ELEM_LAST; //FIXME
     lp->newelem = GUI_TextSelectHelper(lp->newelem, 0, last_elem-1, dir, 1, 1, NULL);
-    return GetElemName(lp->newelem);
+    return _tr(GetElemName(lp->newelem));
 }
 
 int create_element()

--- a/src/pages/common/_model_config.c
+++ b/src/pages/common/_model_config.c
@@ -22,7 +22,7 @@ static const char *swash_val_cb(guiObject_t *obj, int dir, void *data)
     (void)obj;
     (void)data;
     Model.swash_type = GUI_TextSelectHelper(Model.swash_type, 0 , SWASH_TYPE_90, dir, 1, 1, NULL);
-    return MIXER_SwashType(Model.swash_type);
+    return _tr(MIXER_SwashType(Model.swash_type));
 }
 
 static const char *swashinv_val_cb(guiObject_t *obj, int dir, void *data)

--- a/src/pages/common/_model_page.c
+++ b/src/pages/common/_model_page.c
@@ -352,6 +352,6 @@ static const char *mixermode_cb(guiObject_t *obj, int dir, void *data)
             STDMIXER_SaveSwitches();
         }
     }
-    return STDMIXER_ModeName(Model.mixer_mode);
+    return _tr(STDMIXER_ModeName(Model.mixer_mode));
 }
 #endif //HAS_STANDARD_GUI

--- a/src/pages/common/_model_page.c
+++ b/src/pages/common/_model_page.c
@@ -76,6 +76,11 @@ const char *show_text_cb(guiObject_t *obj, const void *data)
     return tempstring;
 }
 
+const char *show_text_cb_loc(guiObject_t *obj, const void *data)
+{
+    return show_text_cb(obj, _tr(data));
+}
+
 const char *show_bindtext_cb(guiObject_t *obj, const void *data)
 {
     (void)obj;

--- a/src/pages/common/_trim_page.c
+++ b/src/pages/common/_trim_page.c
@@ -77,7 +77,7 @@ const char *set_trim_cb(guiObject_t *obj, int dir, void *data)
     do {
       *button = GUI_TextSelectHelper(*button, 0, NUM_TX_BUTTONS, dir, 1, 1, NULL);
     } while ((1 << *button) & Transmitter.ignore_buttons);
-    return INPUT_ButtonName(*button);
+    return _tr(INPUT_ButtonName(*button));
 }
 
 static const char *set_trimstep_cb(guiObject_t *obj, int dir, void *data)

--- a/src/pages/common/advanced/_mixer_curves.c
+++ b/src/pages/common/advanced/_mixer_curves.c
@@ -57,7 +57,7 @@ static const char *set_curvename_cb(guiObject_t *obj, int dir, void *data)
             GUI_Redraw(&gui->point);
         }
     }
-    return CURVE_GetName(tempstring, curve);
+    return _tr(CURVE_GetName(tempstring, curve));
 }
 static void okcancel_cb(guiObject_t *obj, const void *data)
 {

--- a/src/pages/common/advanced/_mixer_page.c
+++ b/src/pages/common/advanced/_mixer_page.c
@@ -90,10 +90,8 @@ static const char *template_name_cb(guiObject_t *obj, const void *data)
     (void)obj;
     u8 ch = (long)data;
     enum TemplateType template = MIXER_GetTemplate(ch);
-    return MIXER_TemplateName(template);
+    return _tr(MIXER_TemplateName(template));
 }
-
-
 
 void show_chantest_cb(guiObject_t *obj, const void *data)
 {

--- a/src/pages/common/advanced/_mixer_setup.c
+++ b/src/pages/common/advanced/_mixer_setup.c
@@ -124,7 +124,7 @@ static const char *templatetype_cb(guiObject_t *obj, int dir, void *data)
         MIXPAGE_ChangeTemplate(0);
         return "";
     }
-    return MIXER_TemplateName(mp->cur_template);
+    return _tr(MIXER_TemplateName(mp->cur_template));
 }
 
 static const char *set_curvename_cb(guiObject_t *obj, int dir, void *data);

--- a/src/pages/common/advanced/_mixer_setup.c
+++ b/src/pages/common/advanced/_mixer_setup.c
@@ -495,7 +495,7 @@ static const char *set_curvename_cb(guiObject_t *obj, int dir, void *data)
         MIXPAGE_RedrawGraphs();
     }
     GUI_TextSelectEnablePress((guiTextSelect_t *)obj, type > CURVE_FIXED);
-    return CURVE_GetName(tempstring, &mix->curve);
+    return _tr(CURVE_GetName(tempstring, &mix->curve));
 }
 
 void sourceselect_cb(guiObject_t *obj, void *data)

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -308,15 +308,8 @@ void RTC_GetTimeGTM(struct gtm *t)
     t->tm_year = _RTC_GetYear(value) - 1900;
 }
 
-
-const char * const RTCNames[] =
+const char *RTC_Name(int i)
 {
-    _tr_noop("Clock"),
-    _tr_noop("Date"),
-};
-const char *RTC_Name(char *str, int i)
-{
-    (void)str;
-    return RTCNames[i];
+    return i == 0 ? _tr_noop("Clock") : _tr_noop("Date");
 }
 #endif //HAS_RTC

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -308,9 +308,14 @@ void RTC_GetTimeGTM(struct gtm *t)
     t->tm_year = _RTC_GetYear(value) - 1900;
 }
 
+
+const char * const RTCNames[] =
+{
+    _tr_noop("Clock"),
+    _tr_noop("Date"),
+};
 const char *RTC_Name(char *str, int i)
 {
-    sprintf(str, "%s", i == 0 ? _tr("Clock") : _tr("Date"));
-    return str;
+    return RTC_Names[i];
 }
 #endif //HAS_RTC

--- a/src/rtc.c
+++ b/src/rtc.c
@@ -316,6 +316,7 @@ const char * const RTCNames[] =
 };
 const char *RTC_Name(char *str, int i)
 {
-    return RTC_Names[i];
+    (void)str;
+    return RTCNames[i];
 }
 #endif //HAS_RTC

--- a/src/rtc.h
+++ b/src/rtc.h
@@ -63,5 +63,5 @@ void RTC_GetDateFormattedBigbox(char *str, u32 date); // only this fits in big b
 void RTC_GetDateFormattedOrder(unsigned index, u8 *left, u8 *middle, u8 *right); // for ordering the input fields
 
 //return RTC name
-const char *RTC_Name(char *str, int i);
+const char *RTC_Name(int i);
 #endif


### PR DESCRIPTION
Make most _tr calls only happen inside pages with the following exceptions:
1. input.c
2. telemetry
which will be addressed separately.
