### PR TITLE
Add CRC check for s.port telemetry

### DIFF
--- a/src/protocol/frsky_s_telem._c
+++ b/src/protocol/frsky_s_telem._c
@@ -48,7 +48,7 @@
 #define START_STOP              0x7e
 #define BYTESTUFF               0x7d
 #define STUFF_MASK              0x20
-#define FRSKY_SPORT_PACKET_SIZE    8
+#define FRSKY_SPORT_PACKET_SIZE    9
 
 static void serial_echo(u8 *packet);
 
@@ -60,6 +60,16 @@ static void serial_echo(u8 *packet);
 #define SPORT_DATA_U32(packet)  (*((uint32_t *)(packet+4)))
 #define HUB_DATA_U16(packet)    (*((uint16_t *)(packet+4)))
 
+
+static u8 sport_crc(u8 *data) {
+    u16 crc = 0;
+    for (int i=1; i < FRSKY_SPORT_PACKET_SIZE-1; ++i) {
+        crc += data[i];
+        crc += crc >> 8;
+        crc &= 0x00ff;
+    }
+    return 0x00ff - crc;
+}
 
 static void processSportPacket(u8 *packet) {
 //    u8  instance = (packet[0] & 0x1F) + 1;    // all instances of same sensor write to same telemetry value
@@ -248,7 +258,8 @@ static void frsky_parse_sport_stream(u8 data) {
         break;
     } // switch
 
-    if (sportRxBufferCount >= FRSKY_SPORT_PACKET_SIZE) {
+    if (sportRxBufferCount >= FRSKY_SPORT_PACKET_SIZE
+     && data == sport_crc(sportRxBuffer)) {
         processSportPacket(sportRxBuffer);
         dataState = STATE_DATA_IDLE;
     }

--- a/src/protocol/frsky_s_telem._c
+++ b/src/protocol/frsky_s_telem._c
@@ -258,10 +258,10 @@ static void frsky_parse_sport_stream(u8 data) {
         break;
     } // switch
 
-    if (sportRxBufferCount >= FRSKY_SPORT_PACKET_SIZE
-     && data == sport_crc(sportRxBuffer)) {
-        processSportPacket(sportRxBuffer);
+    if (sportRxBufferCount >= FRSKY_SPORT_PACKET_SIZE) {
         dataState = STATE_DATA_IDLE;
+        if (data == sport_crc(sportRxBuffer))
+            processSportPacket(sportRxBuffer);
     }
 }
 

--- a/src/protocol/frskyx_cc2500.c
+++ b/src/protocol/frskyx_cc2500.c
@@ -313,7 +313,7 @@ static void frskyX_data_frame() {
 #include "frsky_s_telem._c"
 
 static s8 telem_save_seq;
-static u8 telem_save_data[FRSKY_SPORT_PACKET_SIZE+1];
+static u8 telem_save_data[FRSKY_SPORT_PACKET_SIZE];
 
 static void setup_serial_port() {
     if ( Model.proto_opts[PROTO_OPTS_SPORTOUT] ) {
@@ -327,24 +327,14 @@ static void setup_serial_port() {
     }
 }
 
-static u8 sport_crc(u8 *data) {
-    u16 crc = 0;
-    for (int i=1; i < FRSKY_SPORT_PACKET_SIZE-1; ++i) {
-        crc += data[i];
-        crc += crc >> 8;
-        crc &= 0x00ff;
-    }
-    return 0x00ff - crc;
-}
-
 static void serial_echo(u8 *packet) {
-  static u8 outbuf[FRSKY_SPORT_PACKET_SIZE+2] = {0x7e};
+  static u8 outbuf[FRSKY_SPORT_PACKET_SIZE+1] = {0x7e};
 
   if (PPMin_Mode() || !Model.proto_opts[PROTO_OPTS_SPORTOUT]) return;
 
-  memcpy(outbuf+1, packet, FRSKY_SPORT_PACKET_SIZE);
-  outbuf[FRSKY_SPORT_PACKET_SIZE+1] = sport_crc(outbuf+2);
-  UART_Send(outbuf, FRSKY_SPORT_PACKET_SIZE+2);
+  memcpy(outbuf+1, packet, FRSKY_SPORT_PACKET_SIZE-1);
+  outbuf[FRSKY_SPORT_PACKET_SIZE] = sport_crc(outbuf+2);
+  UART_Send(outbuf, FRSKY_SPORT_PACKET_SIZE+1);
 }
 
 #endif // HAS_EXTENDED_TELEMETRY


### PR DESCRIPTION
Fixes issue with interpreting corrupted telemetry packets as valid data.