### PR TITLE
Protocol for TDR Phoenix Mini

### DIFF
--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -224,7 +224,7 @@ static void send_packet(u8 bind)
                        | GET_FLAG_INV(CHANNEL_LED, 0x20); // air/ground mode
             if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_PHOENIX) {
                 packet[10] |= GET_FLAG(CHANNEL_ARM, 0x80);
-                packet[14] &= ~0x24;
+                packet[14] &= ~0x20;
             }
             if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H26WH) {
                 packet[10] |= 0x40;  // high rate

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -338,7 +338,8 @@ static void mjxq_init()
     NRF24L01_WriteReg(NRF24L01_02_EN_RXADDR, 0x01);
     NRF24L01_WriteReg(NRF24L01_04_SETUP_RETR, 0x00); // no retransmits
     NRF24L01_WriteReg(NRF24L01_11_RX_PW_P0, PACKET_SIZE);
-    if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_E010)
+    if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_E010 
+     || Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_PHOENIX)
         NRF24L01_SetBitrate(NRF24L01_BR_250K);             // 250kbps
     else
         NRF24L01_SetBitrate(NRF24L01_BR_1M);             // 1Mbps

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -55,7 +55,7 @@
 #define ADDRESS_LENGTH     5
 
 static const char * const mjxq_opts[] = {
-  _tr_noop("Format"), "WLH08", "X600", "X800", "H26D", "H26WH", "E010", NULL,
+  _tr_noop("Format"), "WLH08", "X600", "X800", "H26D", "H26WH", "E010", "Phoenix", NULL,
   NULL
 };
 enum {
@@ -69,6 +69,7 @@ enum {
     FORMAT_H26D,
     FORMAT_H26WH,
     FORMAT_E010,
+    FORMAT_PHOENIX,
 };
 ctassert(LAST_PROTO_OPT <= NUM_PROTO_OPTS, too_many_protocol_opts);
 
@@ -212,6 +213,7 @@ static void send_packet(u8 bind)
         /* FALLTHROUGH */
     case FORMAT_WLH08:
     case FORMAT_E010:
+    case FORMAT_PHOENIX:
         packet[10] += GET_FLAG(CHANNEL_RTH, 0x02)
                     | GET_FLAG(CHANNEL_HEADLESS, 0x01);
         if (!bind) {
@@ -220,7 +222,8 @@ static void send_packet(u8 bind)
                        | GET_FLAG(CHANNEL_PICTURE, 0x08)
                        | GET_FLAG(CHANNEL_VIDEO, 0x10)
                        | GET_FLAG_INV(CHANNEL_LED, 0x20); // air/ground mode
-            if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H26WH) {
+            if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H26WH ||
+                Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_PHOENIX ) {
                 packet[10] |= 0x40;  // high rate
                 packet[14] &= ~0x24; // unset air/ground & arm flags
                 packet[14] |= GET_FLAG(CHANNEL_ARM, 0x02);
@@ -303,6 +306,7 @@ static void mjxq_init()
         case FORMAT_H26D:
         case FORMAT_H26WH:
         case FORMAT_E010:
+        case FORMAT_PHOENIX:
             memcpy(rf_channels, "\x36\x3e\x46\x2e", sizeof(rf_channels));
             break;
         default:
@@ -352,6 +356,7 @@ static void mjxq_init2()
             memcpy(rf_channels, "\x47\x42\x37\x32", sizeof(rf_channels));
             break;
         case FORMAT_E010:
+        case FORMAT_PHOENIX:
             memcpy(rf_channels, e010_tx_rf_map[Model.fixed_id % (sizeof(e010_tx_rf_map)/sizeof(e010_tx_rf_map[0]))].rfchan, sizeof(rf_channels));
             break;
         case FORMAT_H26D:
@@ -419,6 +424,7 @@ static void initialize_txid()
             memcpy(txid, "\xa4\x03\x00", sizeof(txid));
             break;
         case FORMAT_E010:
+        case FORMAT_PHOENIX:
             memcpy(txid, e010_tx_rf_map[Model.fixed_id % (sizeof(e010_tx_rf_map)/sizeof(e010_tx_rf_map[0]))].txid, 2);
             txid[2] = 0x00;
             break;

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -223,8 +223,9 @@ static void send_packet(u8 bind)
                        | GET_FLAG(CHANNEL_VIDEO, 0x10)
                        | GET_FLAG_INV(CHANNEL_LED, 0x20); // air/ground mode
             if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_PHOENIX) {
-                packet[10] |= GET_FLAG(CHANNEL_ARM, 0x80);
-                packet[14] &= ~0x20;
+                packet[10] |= 0x20  // high rate
+                           |  GET_FLAG(CHANNEL_ARM, 0x80);
+                packet[14] &= ~0x24;
             }
             if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H26WH) {
                 packet[10] |= 0x40;  // high rate

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -90,7 +90,7 @@ enum {
     CHANNEL12,    // Camera tilt
 };
 #define CHANNEL_LED         CHANNEL5
-#define CHANNEL_ARM         CHANNEL5  // H26WH
+#define CHANNEL_ARM         CHANNEL5  // H26WH - TDR Phoenix mini
 #define CHANNEL_FLIP        CHANNEL6
 #define CHANNEL_PICTURE     CHANNEL7
 #define CHANNEL_VIDEO       CHANNEL8
@@ -222,8 +222,11 @@ static void send_packet(u8 bind)
                        | GET_FLAG(CHANNEL_PICTURE, 0x08)
                        | GET_FLAG(CHANNEL_VIDEO, 0x10)
                        | GET_FLAG_INV(CHANNEL_LED, 0x20); // air/ground mode
-            if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H26WH ||
-                Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_PHOENIX ) {
+            if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_PHOENIX) {
+                packet[10] |= GET_FLAG(CHANNEL_ARM, 0x80);
+                packet[14] &= ~0x24;
+            }
+            if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_H26WH) {
                 packet[10] |= 0x40;  // high rate
                 packet[14] &= ~0x24; // unset air/ground & arm flags
                 packet[14] |= GET_FLAG(CHANNEL_ARM, 0x02);
@@ -338,7 +341,7 @@ static void mjxq_init()
     NRF24L01_WriteReg(NRF24L01_02_EN_RXADDR, 0x01);
     NRF24L01_WriteReg(NRF24L01_04_SETUP_RETR, 0x00); // no retransmits
     NRF24L01_WriteReg(NRF24L01_11_RX_PW_P0, PACKET_SIZE);
-    if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_E010 
+    if (Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_E010
      || Model.proto_opts[PROTOOPTS_FORMAT] == FORMAT_PHOENIX)
         NRF24L01_SetBitrate(NRF24L01_BR_250K);             // 250kbps
     else


### PR DESCRIPTION
Add "Phoenix" format option to the MJXq protocol.
Channel 5: arm

This is a clone of the EAchine E010 with altitude hold, same as the E010 protocol it's using XN297L @ 250 kbps and doesn't work well with every nrf24l01 modules.
https://www.deviationtx.com/forum/protocol-development/8314-tdr-phoenix-mini-eachine-e010-clone

I'd like to add a note in the manual/wiki for those XN297L @ 250 kbps (sub)protocols, but I'm not sure how to phrase it without being too technical. To make it short, the xn297(L) has a ~+200 kHz frequency drift compared to the nrf24l01, that's not an issue @ 1 Mbps but with 250 kbps the xn297l has a tighter oscillator accuracy requirement (20ppm vs 60ppm) thus not enough selectivity to cope with this drift sometimes. Success depends only on the (in)accuracy of the oscillators in the tx and rx, you can even have 2 of those quads with one working perfectly while the other does not bind at all.

I should make some tests the other way round, emulating a nrf24l01 with a XN297L, if it works well (there's no reason it doesn't ...) maybe we could tell the 4-in-1 manufacturers to use XN297L instead of nrf24l01 in the future as its base frequency can be fine tuned (same as the 3 other transceivers) and so far we've more xn297 protocols than nrf24l01 anyway. Also, it has an internal PA that can be set to 2 dBm (up to 13 dBm but that would saturate our PA), that would allow 150mW for nrf24l01/xn297 protocols.