### PR TITLE
Fix FrskyX s.port telemetry

### DIFF
--- a/src/protocol/frsky_s_telem._c
+++ b/src/protocol/frsky_s_telem._c
@@ -71,13 +71,16 @@ static u8 sport_crc(u8 *data) {
     return 0x00ff - crc;
 }
 
+static u8 check_sport_crc(u8 *data) {
+    return sport_crc(data) == data[8];
+}
 
 static void processSportPacket(u8 *packet) {
 //    u8  instance = (packet[0] & 0x1F) + 1;    // all instances of same sensor write to same telemetry value
     u8  prim = packet[1];
     u16 id = *((u16 *)(packet+2));
 
-        serial_echo(packet);   // echo to trainer port
+    serial_echo(packet);   // echo to trainer port
 
     if (prim != DATA_FRAME)
         return;
@@ -257,9 +260,14 @@ typedef enum {
 } SportStates;
 static SportStates dataState = STATE_DATA_IDLE;   // file scope so can be reset on loss of rx packet sync
 
-static void frsky_parse_sport_stream(u8 data) {
+typedef enum {
+    SPORT_CRC = 0,
+    SPORT_NOCRC = 1
+} sport_crc_t;
+
+static void frsky_parse_sport_stream(u8 data, sport_crc_t crc_configure) {
     static u8 sportRxBufferCount;
-    static u8 sportRxBuffer[FRSKY_SPORT_PACKET_SIZE];   // Receive buffer. 8 bytes (full packet)
+    static u8 sportRxBuffer[FRSKY_SPORT_PACKET_SIZE];   // Receive buffer. 8 bytes no crc, 9 bytes with crc
 
     switch (dataState) {
     case STATE_DATA_START:
@@ -267,7 +275,7 @@ static void frsky_parse_sport_stream(u8 data) {
             dataState = STATE_DATA_IN_FRAME ;
             sportRxBufferCount = 0;
         } else {
-            if (sportRxBufferCount < FRSKY_SPORT_PACKET_SIZE)
+            if (sportRxBufferCount < FRSKY_SPORT_PACKET_SIZE - crc_configure)
                 sportRxBuffer[sportRxBufferCount++] = data;
             dataState = STATE_DATA_IN_FRAME;
         }
@@ -281,13 +289,13 @@ static void frsky_parse_sport_stream(u8 data) {
             dataState = STATE_DATA_IN_FRAME ;
             sportRxBufferCount = 0;
         }
-        else if (sportRxBufferCount < FRSKY_SPORT_PACKET_SIZE) {
+        else if (sportRxBufferCount < FRSKY_SPORT_PACKET_SIZE - crc_configure) {
             sportRxBuffer[sportRxBufferCount++] = data;
         }
         break;
 
     case STATE_DATA_XOR:
-        if (sportRxBufferCount < FRSKY_SPORT_PACKET_SIZE) {
+        if (sportRxBufferCount < FRSKY_SPORT_PACKET_SIZE - crc_configure) {
           sportRxBuffer[sportRxBufferCount++] = data ^ STUFF_MASK;
         }
         dataState = STATE_DATA_IN_FRAME;
@@ -301,9 +309,9 @@ static void frsky_parse_sport_stream(u8 data) {
         break;
     } // switch
 
-    if (sportRxBufferCount >= FRSKY_SPORT_PACKET_SIZE) {
+    if (sportRxBufferCount >= FRSKY_SPORT_PACKET_SIZE - crc_configure) {
         dataState = STATE_DATA_IDLE;
-        if (data == sport_crc(sportRxBuffer))
+        if (crc_configure == SPORT_NOCRC || check_sport_crc(sportRxBuffer))
             processSportPacket(sportRxBuffer);
     }
 }

--- a/src/protocol/frskyx_cc2500.c
+++ b/src/protocol/frskyx_cc2500.c
@@ -373,14 +373,14 @@ static void frsky_check_telemetry(u8 *pkt, u8 len) {
 #if HAS_EXTENDED_TELEMETRY
                 if (pkt[6] <= 6) {
                     for (u8 i=0; i < pkt[6]; i++)
-                        frsky_parse_sport_stream(pkt[7+i]);
+                        frsky_parse_sport_stream(pkt[7+i], SPORT_NOCRC);
                 }
                 // process any saved data from out-of-sequence packet if
                 // it's the next expected packet
                 if (telem_save_seq == seq_rx_expected) {
                     seq_rx_expected = (seq_rx_expected + 1) % 4;
                     for (u8 i=0; i < telem_save_data[0]; i++)
-                        frsky_parse_sport_stream(telem_save_data[1+i]);
+                        frsky_parse_sport_stream(telem_save_data[1+i], SPORT_NOCRC);
                 }
                 telem_save_seq = -1;
 #endif

--- a/src/protocol/pxxout.c
+++ b/src/protocol/pxxout.c
@@ -246,6 +246,10 @@ static void serial_echo(u8 *packet) {(void)packet;}
 #define PROTO_OPTS_AD2GAIN 0
 #include "frsky_d_telem._c"
 #include "frsky_s_telem._c"
+
+static void frsky_parse_sport_stream_crc(u8 data) {
+    frsky_parse_sport_stream(data, SPORT_CRC);
+}
 #endif  // HAS_EXTENDED_TELEMETRY
 
 #ifndef EMULATOR
@@ -294,7 +298,7 @@ static void initialize(u8 bind)
 #endif
 #if HAS_EXTENDED_TELEMETRY
     SSER_Initialize(); // soft serial receiver
-    SSER_StartReceive(frsky_parse_sport_stream);
+    SSER_StartReceive(frsky_parse_sport_stream_crc);
 #endif
 
     PWM_Initialize();


### PR DESCRIPTION
When I added the s.port CRC check for serial s.port the test was also applied to FrskyX s.port telemetry, which does not have the CRC.  This PR fixes the problem by only checking CRC for s.port telemetry received on the serial port (i.e. for the PXX protocol).

Relevant [forum thread](https://www.deviationtx.com/forum/6-general-discussions/8431-jumper-t8s-v2-plus-frsky-smartport-telemetry).