### PR TITLE
Read multiplexed PID values from telemetry data.

### DIFF
--- a/src/protocol/bayang_nrf24l01.c
+++ b/src/protocol/bayang_nrf24l01.c
@@ -19,6 +19,9 @@
 // TELEM_DSM_FLOG_HOLDS - rx reception strenght ( packets per second )
 // TELEM_DSM_FLOG_FRAMELOSS - tx telemetry reception strenght ( packets per second )
 // TELEM_DSM_FLOG_FADESL - battery low flag ( LVC )
+// TELEM_DSM_FLOG_FADESA - Kp ( multiplied by 1000 )
+// TELEM_DSM_FLOG_FADESB - Ki ( multiplied by 1000 )
+// TELEM_DSM_FLOG_FADESR - Kd ( multiplied by 1000 )
 
 #include "common.h"
 #include "interface.h"
@@ -356,6 +359,27 @@ static int check_rx(void)
             // battery low flag
             Telemetry.value[TELEM_DSM_FLOG_FADESL] = (flags & 1) ? 100 : 0;
             TELEMETRY_SetUpdated(TELEM_DSM_FLOG_FADESL);
+
+            // Multiplexed P, I, D values in packet[8] and packet[9].
+            // The two most significant bits specify which term is sent.
+            // Remaining 14 bits represent the value: 0 .. 16383
+            const u8 pid_term = packet[8] >> 6;
+            chanval.bytes.msb = packet[8] & 0x3F;
+            chanval.bytes.lsb = packet[9];
+            int telem_idx;
+            switch (pid_term) {
+                case 0: // P
+                    telem_idx = TELEM_DSM_FLOG_FADESA;
+                    break;
+                case 1: // I
+                    telem_idx = TELEM_DSM_FLOG_FADESB;
+                    break;
+                case 2: // D
+                    telem_idx = TELEM_DSM_FLOG_FADESR;
+                    break;
+            }
+            Telemetry.value[telem_idx] = chanval.value;
+            TELEMETRY_SetUpdated(telem_idx);
 
             telemetry_count++;
             return 1;

--- a/src/protocol/bayang_nrf24l01.c
+++ b/src/protocol/bayang_nrf24l01.c
@@ -368,13 +368,13 @@ static int check_rx(void)
             chanval.bytes.lsb = packet[9];
             int telem_idx;
             switch (pid_term) {
-                case 0: // P
+                case 0:  // P
                     telem_idx = TELEM_DSM_FLOG_FADESA;
                     break;
-                case 1: // I
+                case 1:  // I
                     telem_idx = TELEM_DSM_FLOG_FADESB;
                     break;
-                case 2: // D
+                case 2:  // D
                     telem_idx = TELEM_DSM_FLOG_FADESR;
                     break;
             }

--- a/src/protocol/bayang_nrf24l01.c
+++ b/src/protocol/bayang_nrf24l01.c
@@ -366,7 +366,7 @@ static int check_rx(void)
             const u8 pid_term = packet[8] >> 6;
             chanval.bytes.msb = packet[8] & 0x3F;
             chanval.bytes.lsb = packet[9];
-            int telem_idx;
+            int telem_idx = 0;
             switch (pid_term) {
                 case 0:  // P
                     telem_idx = TELEM_DSM_FLOG_FADESA;


### PR DESCRIPTION
For SilverWare, optional telemetry support was added to the Bayang protocol quite some time ago.

Recently, current PID settings were added to the telemetry data. This pull request makes them available via FadesA, FadesB, and FadesR. The change is backwards compatible and has no implications for older firmware which does not send these values.

The PID values are sent sequentially using just two bytes.

Details: https://www.rcgroups.com/forums/showpost.php?p=42032515&postcount=398