### PR TITLE
Fix devo F series builds

### DIFF
--- a/src/protocol/e016h_nrf24l01.c
+++ b/src/protocol/e016h_nrf24l01.c
@@ -13,11 +13,6 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef MODULAR
-    // Allows the linker to properly relocate
-    #define E016H_Cmds PROTO_Cmds
-    #pragma long_calls
-#endif
 
 #include "common.h"
 #include "interface.h"

--- a/src/protocol/h8_3d_nrf24l01.c
+++ b/src/protocol/h8_3d_nrf24l01.c
@@ -14,11 +14,6 @@
  */
 
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define H8_3D_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
@@ -26,11 +21,6 @@
 #include "config/tx.h" // for Transmitter
 #include "music.h"
 
-#ifdef MODULAR
-  //Some versions of gcc apply this to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/hisky_nrf24l01.c
+++ b/src/protocol/hisky_nrf24l01.c
@@ -13,11 +13,6 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define HiSky_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
@@ -25,11 +20,6 @@
 #include "config/tx.h" // for Transmitter
 #include "telemetry.h"
 
-#ifdef MODULAR
-  //Some versions of gcc apply this to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/hitec_cc2500.c
+++ b/src/protocol/hitec_cc2500.c
@@ -14,11 +14,6 @@
  */
 
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define Hitec_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
@@ -26,11 +21,6 @@
 #include "config/tx.h"
 #include "telemetry.h"
 
-#ifdef MODULAR
-  //Some versions of gcc applythis to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_CC2500
 

--- a/src/protocol/hm830_nrf24l01.c
+++ b/src/protocol/hm830_nrf24l01.c
@@ -28,11 +28,6 @@
    FF : Trim (bit 0-5: Magnitude, bit 6 polarity (set = right)
    GG : Checksum (CRC8 on bytes AA-FF), init = 0xa5, poly = 0x01
 */
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define HM830_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
@@ -40,11 +35,6 @@
 #include "config/tx.h" // for Transmitter
 #include "telemetry.h"
 
-#ifdef MODULAR
-  //Some versions of gcc applythis to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/hontai_nrf24l01.c
+++ b/src/protocol/hontai_nrf24l01.c
@@ -14,22 +14,12 @@
  */
 
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define HonTai_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
 #include "config/model.h"
 #include "config/tx.h" // for Transmitter
 
-#ifdef MODULAR
-  //Some versions of gcc apply this to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/hubsan_a7105.c
+++ b/src/protocol/hubsan_a7105.c
@@ -13,11 +13,6 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define HUBSAN_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
@@ -30,11 +25,6 @@
 #define USE_FIXED_MFGID
 #endif
 
-#ifdef MODULAR
-  //Some versions of gcc applythis to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 #ifdef PROTO_HAS_A7105
 
 // For code readability

--- a/src/protocol/inav_nrf24l01.c
+++ b/src/protocol/inav_nrf24l01.c
@@ -61,11 +61,6 @@
 #define UNUSED(x) (void)(x)
 
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define INAV_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
@@ -73,11 +68,6 @@
 #include "config/tx.h" // for Transmitter
 #include "telemetry.h"
 
-#ifdef MODULAR
-  //Some versions of gcc apply this to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/j6pro_cyrf6936.c
+++ b/src/protocol/j6pro_cyrf6936.c
@@ -13,20 +13,12 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef MODULAR
-    //Allows the linker to properly relocate
-    #define J6PRO_Cmds PROTO_Cmds
-    #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
 #include "config/model.h"
 #include "telemetry.h"
 
-#ifdef MODULAR
-    #pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_CYRF6936
 #define NUM_WAIT_LOOPS (100 / 5) //each loop is ~5us.  Do not wait more than 100us

--- a/src/protocol/joysway_a7105.c
+++ b/src/protocol/joysway_a7105.c
@@ -13,11 +13,6 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define JOYSWAY_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 
 #include "common.h"
 #include "interface.h"
@@ -26,9 +21,6 @@
 #include "config/tx.h"
 #include "telemetry.h"
 
-#ifdef MODULAR
-  #pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_A7105
 

--- a/src/protocol/kn_nrf24l01.c
+++ b/src/protocol/kn_nrf24l01.c
@@ -23,16 +23,6 @@
 #ifdef PROTO_HAS_NRF24L01
 #include "iface_nrf24l01.h"
 
-#ifdef MODULAR
-  //Some versions of gcc apply this to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-
-  //Allows the linker to properly relocate
-  #define KN_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
-
 //================================================================================================
 // Definitions
 //================================================================================================

--- a/src/protocol/loli_nrf24l01.c
+++ b/src/protocol/loli_nrf24l01.c
@@ -13,11 +13,6 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef MODULAR
-    // Allows the linker to properly relocate
-    #define LOLI_Cmds PROTO_Cmds
-    #pragma long_calls
-#endif
 
 #include "common.h"
 #include "interface.h"
@@ -25,11 +20,6 @@
 #include "config/model.h"
 #include "config/tx.h"  // for Transmitter
 
-#ifdef MODULAR
-    // Some versions of gcc apply this to definitions, others to calls
-    // So just use long_calls everywhere
-    // #pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/mjxq_nrf24l01.c
+++ b/src/protocol/mjxq_nrf24l01.c
@@ -14,22 +14,12 @@
  */
 
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define MJXq_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
 #include "config/model.h"
 #include "config/tx.h" // for Transmitter
 
-#ifdef MODULAR
-  //Some versions of gcc apply this to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/mt99xx_nrf24l01.c
+++ b/src/protocol/mt99xx_nrf24l01.c
@@ -14,11 +14,6 @@
  */
 
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define MT99XX_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
@@ -26,11 +21,6 @@
 #include "config/tx.h" // for Transmitter
 #include "telemetry.h"
 
-#ifdef MODULAR
-  //Some versions of gcc apply this to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/ncc1701_nrf24l01.c
+++ b/src/protocol/ncc1701_nrf24l01.c
@@ -13,11 +13,6 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef MODULAR
-    //Allows the linker to properly relocate
-    #define NCC1701_Cmds PROTO_Cmds
-    #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
@@ -25,11 +20,6 @@
 #include "config/tx.h" // for Transmitter
 #include "telemetry.h"
 
-#ifdef MODULAR
-    //Some versions of gcc applythis to definitions, others to calls
-    //So just use long_calls everywhere
-    //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/ne260_nrf24l01.c
+++ b/src/protocol/ne260_nrf24l01.c
@@ -18,22 +18,12 @@
 */
 
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define NE260_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
 #include "config/model.h"
 #include "telemetry.h"
 
-#ifdef MODULAR
-  //Some versions of gcc applythis to definitions, others to calls
-  //So just use long_calls everywhere
-  //#pragma long_calls_off
-#endif
 
 #ifdef PROTO_HAS_NRF24L01
 

--- a/src/protocol/ppmout.c
+++ b/src/protocol/ppmout.c
@@ -13,20 +13,12 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define PPMOUT_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 
 #include "common.h"
 #include "interface.h"
 #include "mixer.h"
 #include "config/model.h"
 
-#ifdef MODULAR
-  #pragma long_calls_off
-#endif
 
 #define PPMOUT_MAX_CHANNELS NUM_OUT_CHANNELS
 static volatile u16 pulses[PPMOUT_MAX_CHANNELS+1];  // +1 for "inter-packet" pulse at end

--- a/src/protocol/scanner_cyrf6936.c
+++ b/src/protocol/scanner_cyrf6936.c
@@ -13,11 +13,6 @@
  along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef MODULAR
-    // Allows the linker to properly relocate
-    #define SCANNER_CYRF_Cmds PROTO_Cmds
-    #pragma long_calls
-#endif
 
 #include "common.h"
 #include "interface.h"

--- a/src/protocol/spi/a7105.c
+++ b/src/protocol/spi/a7105.c
@@ -13,11 +13,6 @@
     along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define DEVO_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 #include "common.h"
 #include "config/tx.h"
 #include "protocol/interface.h"

--- a/src/protocol/spi/cc2500.c
+++ b/src/protocol/spi/cc2500.c
@@ -12,11 +12,6 @@
     You should have received a copy of the GNU General Public License
     along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define DEVO_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 
 #include "common.h"
 #include "config/tx.h"

--- a/src/protocol/spi/nrf24l01.c
+++ b/src/protocol/spi/nrf24l01.c
@@ -12,11 +12,6 @@
     You should have received a copy of the GNU General Public License
     along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define DEVO_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 
 #include "common.h"
 #include "config/tx.h"

--- a/src/target/tx/devo/common/protocol/pwm.c
+++ b/src/target/tx/devo/common/protocol/pwm.c
@@ -12,11 +12,6 @@
     You should have received a copy of the GNU General Public License
     along with Deviation.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifdef MODULAR
-  //Allows the linker to properly relocate
-  #define DEVO_Cmds PROTO_Cmds
-  #pragma long_calls
-#endif
 
 #include <stdio.h>
 #include <string.h>

--- a/src/target/tx/devo/devof7/protocol.ld
+++ b/src/target/tx/devo/devof7/protocol.ld
@@ -1,3 +1,5 @@
+EXTERN(protocol_type)
+
 MEMORY
 {
 	ram (rwx) : ORIGIN = 0x20004000, LENGTH = 4K
@@ -6,7 +8,7 @@ SECTIONS
 {
         .text : {
             KEEP(*(.rodata.protocol_type))
-            KEEP(*(.text.PROTO_Cmds))
+            KEEP(*(.text.*_Cmds))
             *(.text*)
             . = ALIGN(4);
             *(.rodata*)     /* Read-only data */


### PR DESCRIPTION
In master several of the .mod files for the devo F series are four byte files.  The loader file change in PR #770 were not made in the devof7 file.  With this change the conditional define of PROTO_Cmds can be removed from protocol files, but the protocol command function name must now match /*_Cmds/.

Only some protocol files were changed by #770.  This PR removes the rest of the unnecessary defines.  

A remaining issue is the scancyrf.mod and xn297dump.mod files.  These are both 4 byte files in the devo7e build, but only the scancyrf.mod file is 4 bytes long in the devof* builds.