### PR TITLE
New method for handling custom alarms

### DIFF
--- a/src/extended_audio.c
+++ b/src/extended_audio.c
@@ -248,8 +248,29 @@ int AUDIO_AddQueue(u16 music) {
         printf("Voice: mp3 length is zero\n");
         return 0;
     }
-
-    audio_queue[num_audio++] = music;
+    
+    int new_num_audio = -1;
+    
+#if USE_NEW_CUSTOM_ALARM_MODE
+    u32 t = CLOCK_getms();
+    
+    // Replace the last custom alarm id, if there is already one
+    if(voice_map[music].id>=CUSTOM_ALARM_ID)
+    {
+        u32 id = voice_map[audio_queue[next_audio-1]].id;
+        if(id==0 || id>=CUSTOM_ALARM_ID) // Only skip welcome message or custom alarms
+            audio_queue_time = t + CUSTOM_ALARM_IGNORE_MS; // Do not consume the audio right away (prevent triggering transitional sounds)
+        
+        for(u8 i=next_audio; i<num_audio; i++)
+            if(voice_map[audio_queue[i]].id>=CUSTOM_ALARM_ID)
+                new_num_audio = i;
+    }
+#endif
+        
+    if(new_num_audio < 0)
+        audio_queue[num_audio++] = music; // Add to queue
+    else
+        audio_queue[new_num_audio] = music; // Replace queue item, do not enqueue custom sounds
     return 1;
 }
 

--- a/src/music.h
+++ b/src/music.h
@@ -37,6 +37,8 @@ enum Music {
 #endif
 #define VOICE_UNIT_OFFSET 130
 #define CUSTOM_ALARM_ID 200 // start of custom MP3 IDs
+#define USE_NEW_CUSTOM_ALARM_MODE 1 // if this is 0, all the custom alarms are enqueued and never skipped
+#define CUSTOM_ALARM_IGNORE_MS 200 // ignore custom alarms if the switch was faster than this value (requires USE_NEW_CUSTOM_ALARM_MODE)
 #define VOICE_DEC_SEP 110  // MP3 ID of DECSEP = 110 + MUSIC_TOTAL
 #define NUM_STICKS 4
 #define NUM_AUX_KNOBS	(INP_HAS_CALIBRATION - NUM_STICKS)	// Exclude sticks


### PR DESCRIPTION
This fixes https://github.com/DeviationTX/deviation/issues/960

Available settings in `src/music.c`:
`USE_NEW_CUSTOM_ALARM_MODE`, if is `0` then the behaviour is exactly the same as the original

`CUSTOM_ALARM_IGNORE_MS`, is the time in ms that the sound will not be triggered. So if is 200 ms and the user switch from A to C, sound B wont be played if the user took less than 200 ms on moving the switch from B to C.

