### PR TITLE
Advcurve ui bugfix

### DIFF
--- a/src/pages/128x64x1/advanced/mixer_curves.c
+++ b/src/pages/128x64x1/advanced/mixer_curves.c
@@ -58,7 +58,8 @@ void PAGE_EditCurvesInit(int page)
     }
     edit->curve = *curve;
 
-    GUI_CreateTextSelectPlate(&gui->name, NAME_X, 0, NAME_W, HEADER_HEIGHT, &TEXTSEL_FONT, NULL, set_curvename_cb, NULL);
+    //GUI_CreateTextSelectPlate(&gui->name, NAME_X, 0, NAME_W, HEADER_HEIGHT, &TEXTSEL_FONT, NULL, set_curvename_cb, NULL);
+    GUI_CreateLabelBox(&gui->title, NAME_X, 0 , NAME_W, HEADER_HEIGHT, &LABEL_FONT, GUI_Localize, NULL, _tr(CURVE_GetName(tempstring, curve)));
     GUI_CreateButtonPlateText(&gui->save, SAVE_X, 0, SAVE_W, HEADER_WIDGET_HEIGHT, &BUTTON_FONT , GUI_Localize, okcancel_cb, _tr_noop("Save"));
     // Draw a line
     if (UNDERLINE)

--- a/src/pages/128x64x1/advanced/mixer_curves.c
+++ b/src/pages/128x64x1/advanced/mixer_curves.c
@@ -90,7 +90,7 @@ void PAGE_EditCurvesInit(int page)
                               CHAN_MAX_VALUE, CHAN_MAX_VALUE,
                               0, 0, //CHAN_MAX_VALUE / 4, CHAN_MAX_VALUE / 4,
                               show_curve_cb, NULL, touch_cb, &edit->curve);
-    GUI_SetSelected((guiObject_t *)&gui->point);
+    GUI_SetSelected((guiObject_t *)&gui->value);
 }
 
 static unsigned action_cb(u32 button, unsigned flags, void *data)

--- a/src/pages/128x64x1/guiobj.h
+++ b/src/pages/128x64x1/guiobj.h
@@ -270,7 +270,8 @@ struct crsfdevice_obj {
 
 /****Advanced ****/
 struct advcurve_obj {
-    guiTextSelect_t name;
+    //guiTextSelect_t name;
+    guiLabel_t title;
     guiButton_t save;
     guiRect_t rect;
     guiLabel_t pointlbl;

--- a/src/pages/common/advanced/_mixer_curves.c
+++ b/src/pages/common/advanced/_mixer_curves.c
@@ -17,7 +17,7 @@ static struct advcurve_obj * const gui  = &gui_objs.u.advcurve;
 static struct curve_edit   * const edit = &pagemem.u.mixer_page.edit;
 
 static void okcancel_cb(guiObject_t *obj, const void *data);
-static const char *set_curvename_cb(guiObject_t *obj, int dir, void *data);
+//static const char *set_curvename_cb(guiObject_t *obj, int dir, void *data);
 static const char *set_pointnum_cb(guiObject_t *obj, int dir, void *data);
 static const char *set_expopoint_cb(guiObject_t *obj, int dir, void *data);
 static const char *set_value_cb(guiObject_t *obj, int dir, void *data);
@@ -42,7 +42,7 @@ s32 show_curve_cb(s32 xval, void *data)
     return yval;
 }
     
-static const char *set_curvename_cb(guiObject_t *obj, int dir, void *data)
+/*static const char *set_curvename_cb(guiObject_t *obj, int dir, void *data)
 {
     (void)data;
     (void)obj;
@@ -58,7 +58,7 @@ static const char *set_curvename_cb(guiObject_t *obj, int dir, void *data)
         }
     }
     return _tr(CURVE_GetName(tempstring, curve));
-}
+}*/
 static void okcancel_cb(guiObject_t *obj, const void *data)
 {
     (void)obj;


### PR DESCRIPTION
There are some small details in the interface of mixer -> curves editor

1. The titlebar is selectable but it is not in reality.
2. The curve value should be selected by default

![image](https://user-images.githubusercontent.com/1091420/89722575-80394400-d9eb-11ea-8605-b761e6a517a7.png)
