### PR TITLE
fix crsf datatype for config page

### DIFF
--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -440,11 +440,11 @@ static void parse_bytes(enum data_type type, char **buffer, void *dest) {
         *buffer += 1;
         break;
     case UINT16:
-        *(u16 *)dest = (u16) (((*buffer)[0] << 16) | (*buffer)[1]);
+        *(u16 *)dest = (u16) (((*buffer)[0] << 8) | (*buffer)[1]);
         *buffer += 2;
         break;
     case INT16:
-        *(s16 *)dest = (s16) (((*buffer)[0] << 16) | (*buffer)[1]);
+        *(s16 *)dest = (s16) (((*buffer)[0] << 8) | (*buffer)[1]);
         *buffer += 2;
         break;
     case FLOAT:


### PR DESCRIPTION
Just a very small fix of the CRSF config page when showing int16 and uint16 data types.