### PR TITLE
Added crsf-shot

### DIFF
--- a/src/crsf.h
+++ b/src/crsf.h
@@ -34,6 +34,10 @@
 #define TYPE_SETTINGS_ENTRY   0x2B
 #define TYPE_SETTINGS_READ    0x2C
 #define TYPE_SETTINGS_WRITE   0x2D
+#define TYPE_RADIO_ID         0x3A
+
+// Frame Subtype
+#define SUBTYPE_TIMING_UPDATE 0x10
 
 #define TELEMETRY_RX_PACKET_SIZE   64
 


### PR DESCRIPTION
Implementation is based on opentx, tested with ExpressLRS hardware.
Before - packet rate is stuck at 250 packets per second.
After - packet rate depends on the settings and varies from 25 to 500 per second.

Tested with T8SG V2 plus, builds for T8SG V2 and T8SG V2 plus attached below.
[deviation-t8sg_v2_plus-v5.0.0-f04bc27.zip](https://github.com/DeviationTX/deviation/files/7532297/deviation-t8sg_v2_plus-v5.0.0-f04bc27.zip)
[deviation-t8sg_v2-v5.0.0-f04bc27.zip](https://github.com/DeviationTX/deviation/files/7532298/deviation-t8sg_v2-v5.0.0-f04bc27.zip)
