### PR TITLE
Fix incorrect handling of long names

### DIFF
--- a/src/crsf.h
+++ b/src/crsf.h
@@ -22,10 +22,14 @@
 
 // Frame Type
 #define TYPE_GPS              0x02
+#define TYPE_VARIO            0x07
 #define TYPE_BATTERY          0x08
-#define TYPE_VIDEO            0x08
+#define TYPE_HEARTBEAT        0x0b
+#define TYPE_VIDEO            0x0F
 #define TYPE_LINK             0x14
 #define TYPE_CHANNELS         0x16
+#define TYPE_RX_ID            0x1C
+#define TYPE_TX_ID            0x1D
 #define TYPE_ATTITUDE         0x1E
 #define TYPE_FLIGHT_MODE      0x21
 #define TYPE_PING_DEVICES     0x28
@@ -34,10 +38,13 @@
 #define TYPE_SETTINGS_ENTRY   0x2B
 #define TYPE_SETTINGS_READ    0x2C
 #define TYPE_SETTINGS_WRITE   0x2D
+#define TYPE_COMMAND_ID       0x32
 #define TYPE_RADIO_ID         0x3A
 
 // Frame Subtype
 #define SUBTYPE_TIMING_UPDATE 0x10
+// MultiModule? #define UART_SYNC                      0xC8
+#define COMMAND_MODEL_SELECT_ID        0x05
 
 #define TELEMETRY_RX_PACKET_SIZE   64
 
@@ -122,6 +129,7 @@ void CRSF_ping_devices(u8 address);
 void CRSF_read_param(u8 device, u8 id, u8 chunk);
 void CRSF_set_param(crsf_param_t *param);
 void CRSF_send_command(crsf_param_t *param, enum cmd_status status);
+u32 CRSF_read_timeout();
 
 #endif  // SUPPORT_CRSF_CONFIG
 

--- a/src/crsf.h
+++ b/src/crsf.h
@@ -118,7 +118,7 @@ extern crsf_device_t crsf_devices[CRSF_MAX_DEVICES];
 void CRSF_serial_rcv(u8 *buffer, u8 num_bytes);
 u8 CRSF_serial_txd(u8 *buffer, u8 max_len);
 u8 crsf_crc8(const u8 *ptr, u8 len);
-void CRSF_ping_devices();
+void CRSF_ping_devices(u8 address);
 void CRSF_read_param(u8 device, u8 id, u8 chunk);
 void CRSF_set_param(crsf_param_t *param);
 void CRSF_send_command(crsf_param_t *param, enum cmd_status status);

--- a/src/pages/128x64x1/crsfconfig_page.c
+++ b/src/pages/128x64x1/crsfconfig_page.c
@@ -46,7 +46,7 @@ void PAGE_CrsfconfigInit(int page)
     PAGE_SetModal(0);
 
     memset(crsf_devices, 0, sizeof crsf_devices);
-    CRSF_ping_devices();    // ask all TBS devices to respond with device info
+    CRSF_ping_devices(ADDR_BROADCAST);    // ask all TBS devices to respond with device info
 
     PAGE_ShowHeader(PAGE_GetName(PAGEID_CRSFCFG));
     GUI_CreateScrollable(&gui->scrollable, 0, HEADER_HEIGHT, LCD_WIDTH, LCD_HEIGHT - HEADER_HEIGHT,

--- a/src/pages/128x64x1/crsfdevice_page.c
+++ b/src/pages/128x64x1/crsfdevice_page.c
@@ -115,7 +115,8 @@ void PAGE_CrsfdeviceInit(int page)
     device_idx = page;
     crsfdevice_init();
     current_folder = 0;
-    CRSF_read_param(device_idx, next_param, next_chunk);
+    if (crsf_devices[device_idx].number_of_params)
+        CRSF_read_param(device_idx, next_param, next_chunk);
 
     show_page(current_folder);
     PAGE_SetActionCB(action_cb);

--- a/src/pages/320x240x16/crsfconfig_page.c
+++ b/src/pages/320x240x16/crsfconfig_page.c
@@ -50,7 +50,7 @@ void PAGE_CrsfconfigInit(int page)
     PAGE_SetModal(0);
 
     memset(crsf_devices, 0, sizeof crsf_devices);
-    CRSF_ping_devices();    // ask all TBS devices to respond with device info
+    CRSF_ping_devices(ADDR_BROADCAST);    // ask all TBS devices to respond with device info
 
     PAGE_ShowHeader(PAGE_GetName(PAGEID_CRSFCFG));
     GUI_CreateScrollable(&gui->scrollable, LCD_WIDTH/2-100, HEADER_HEIGHT, LCD_WIDTH,

--- a/src/pages/common/_crsfconfig_page.c
+++ b/src/pages/common/_crsfconfig_page.c
@@ -54,16 +54,12 @@ static const char *crsfconfig_str_cb(guiObject_t *obj, const void *data)
 
 void PAGE_CRSFConfigEvent()
 {
-    if (CLOCK_getms() - mp->last_update > 500) {
-        mp->last_update = CLOCK_getms();
-        u8 device_count = CRSF_number_of_devices();
-        if (number_of_devices != device_count) {
-            number_of_devices = device_count;
-            for (int i=0; i < device_count; i++)
-                GUI_Redraw(&gui->name[i]);
-        }
+    u8 device_count = CRSF_number_of_devices();
+    if (number_of_devices != device_count) {
+        number_of_devices = device_count;
+        for (int i=0; i < device_count; i++)
+            GUI_Redraw(&gui->name[i]);
     }
-    mp->last_update = CLOCK_getms();
 }
 
 #endif

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -23,7 +23,6 @@ crsf_param_t crsf_params[CRSF_MAX_PARAMS];
 static struct crsfdevice_page * const mp = &pagemem.u.crsfdevice_page;
 static struct crsfdevice_obj * const gui = &gui_objs.u.crsfdevice;
 
-static u32 last_update;
 static u32 read_timeout;
 static u8 current_folder = 0;
 static u8 params_loaded;     // if not zero, number displayed so far for current device
@@ -293,13 +292,10 @@ static unsigned action_cb(u32 button, unsigned flags, void *data)
 void PAGE_CRSFDeviceEvent() {
     // update page as parameter info is received
     // until all parameters loaded
-    if (CLOCK_getms() - last_update > 300) {
-        u8 params_count = count_params_loaded();
-        if (params_loaded != params_count) {
-            params_loaded = params_count;
-            show_page(current_folder);
-        }
-        last_update = CLOCK_getms();
+    u8 params_count = count_params_loaded();
+    if (params_loaded != params_count) {
+        params_loaded = params_count;
+        show_page(current_folder);
     }
 
     // commands may require interaction through dialog

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -486,9 +486,10 @@ static void add_device(u8 *buffer) {
     for (int i=0; i < CRSF_MAX_DEVICES; i++) {
         if (crsf_devices[i].address == buffer[2]        //  device already in table
          || crsf_devices[i].address == 0) {             //  not found, add to table
+            u8 first_time = !crsf_devices[i].address;
             parse_device(buffer, &crsf_devices[i]);
             // some modules only send details if device direct ping?  ELRS
-            if (crsf_devices[i].number_of_params == 0)
+            if (first_time)
                 CRSF_ping_devices(crsf_devices[i].address);
             break;
         }

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -473,7 +473,8 @@ static void add_device(u8 *buffer) {
             //  not found, add to table
             buffer += 2;
             crsf_devices[i].address = (u8) *buffer++;
-            buffer += strlcpy(crsf_devices[i].name, (const char *)buffer, CRSF_MAX_NAME_LEN) + 1;
+            strlcpy(crsf_devices[i].name, (const char *)buffer, CRSF_MAX_NAME_LEN);
+            buffer += strlen((const char*)buffer) + 1;
             crsf_devices[i].serial_number = parse_u32(buffer);
             buffer += 4;
             crsf_devices[i].hardware_id = parse_u32(buffer);
@@ -529,8 +530,9 @@ static void add_param(u8 *buffer, u8 num_bytes) {
             if (!update) {
                 parameter->hidden = *recv_param_ptr++ & 0x80;
                 parameter->name = alloc_string(strlen(recv_param_ptr)+1);
-                recv_param_ptr += strlcpy(parameter->name, (const char *)recv_param_ptr,
-                                      CRSF_STRING_BYTES_AVAIL(parameter->name)) + 1;
+                strlcpy(parameter->name, (const char *)recv_param_ptr,
+                        CRSF_STRING_BYTES_AVAIL(parameter->name));
+                recv_param_ptr += strlen(recv_param_ptr) + 1;
             } else {
                 if (parameter->hidden != (*recv_param_ptr & 0x80))
                     params_loaded = 0;   // if item becomes hidden others may also, so reload all params
@@ -561,9 +563,10 @@ static void add_param(u8 *buffer, u8 num_bytes) {
             case TEXT_SELECTION:
                 if (!update) {
                     parameter->value = alloc_string(strlen(recv_param_ptr)+1);
-                    recv_param_ptr += strlcpy(parameter->value,
-                                         (const char *)recv_param_ptr,
-                                         CRSF_STRING_BYTES_AVAIL(parameter->value)) + 1;
+                    strlcpy(parameter->value,
+                            (const char *)recv_param_ptr,
+                            CRSF_STRING_BYTES_AVAIL(parameter->value));
+                    recv_param_ptr += strlen(recv_param_ptr) + 1;
                     // put null between selection options
                     // find max choice string length to adjust textselectplate size
                     char *start = (char *)parameter->value;
@@ -593,9 +596,10 @@ static void add_param(u8 *buffer, u8 num_bytes) {
             case INFO:
                 if (!update) {
                     parameter->value = alloc_string(strlen(recv_param_ptr)+1);
-                    recv_param_ptr += strlcpy(parameter->value,
-                                         (const char *)recv_param_ptr,
-                                         CRSF_STRING_BYTES_AVAIL(parameter->value)) + 1;
+                    strlcpy(parameter->value,
+                            (const char *)recv_param_ptr,
+                            CRSF_STRING_BYTES_AVAIL(parameter->value));
+                    recv_param_ptr += strlen(recv_param_ptr) + 1;
                 }
                 break;
 

--- a/src/pages/common/crsfconfig_page.h
+++ b/src/pages/common/crsfconfig_page.h
@@ -3,7 +3,6 @@
 
 #if SUPPORT_CRSF_CONFIG
 struct crsfconfig_page {
-    u32 last_update;
 };
 
 #endif

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -186,6 +186,7 @@ static void processCrossfireTelemetryData(u8 data, u8 status) {
 
   if (telemetryRxBufferCount == 1 && (data < 2 || data > TELEMETRY_RX_PACKET_SIZE-2)) {
     telemetryRxBufferCount = 0;
+    memset(telemetryRxBuffer, 0, TELEMETRY_RX_PACKET_SIZE);  // clear buff for device ping data detection
     return;
   }
   
@@ -193,6 +194,7 @@ static void processCrossfireTelemetryData(u8 data, u8 status) {
     telemetryRxBuffer[telemetryRxBufferCount++] = data;
   } else {
     telemetryRxBufferCount = 0;
+    memset(telemetryRxBuffer, 0, TELEMETRY_RX_PACKET_SIZE);  // clear buff for device ping data detection
     return;
   }
   
@@ -207,6 +209,7 @@ static void processCrossfireTelemetryData(u8 data, u8 status) {
       }
     }
     telemetryRxBufferCount = 0;
+    memset(telemetryRxBuffer, 0, TELEMETRY_RX_PACKET_SIZE);  // clear buff for device ping data detection
   }
 }
 #endif  // HAS_EXTENDED_TELEMETRY

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -144,7 +144,6 @@ static void processCrossfireTelemetryFrame()
       break;
 
     case TYPE_BATTERY:
-break;
       if (getCrossfireTelemetryValue(3, &value, 2))
         set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value);
       if (getCrossfireTelemetryValue(5, &value, 2))
@@ -177,26 +176,15 @@ break;
   }
 }
 
-static u8 err_uart;
-static u8 err_start;
 // serial data receive ISR callback
 static void processCrossfireTelemetryData(u8 data, u8 status) {
   (void)status;
-u8 value = Telemetry.value[TELEM_CRSF_BATT_VOLTAGE];
-if (status & 0x20) set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value |= 0x80);
-if (status & 0x02) set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value |= 0x40);
-if (status & 0x04) set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value |= 0x20);
-if (status & 0x08) set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value |= 0x10);
-if (status & 0x0f) { set_telemetry(TELEM_CRSF_BATT_CURRENT, err_uart++); return; }
 
   if (telemetryRxBufferCount == 0 && data != ADDR_RADIO) {
-set_telemetry(TELEM_CRSF_BATT_CAPACITY, err_start++);
     return;
   }
 
   if (telemetryRxBufferCount == 1 && (data < 2 || data > TELEMETRY_RX_PACKET_SIZE-2)) {
-set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value |= 0x04);
-//set_telemetry(TELEM_CRSF_BATT_CAPACITY, *((u8*)(0x40013808U))); /// USART_BRR(UART_CFG.uart));
     telemetryRxBufferCount = 0;
     return;
   }
@@ -204,7 +192,6 @@ set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value |= 0x04);
   if (telemetryRxBufferCount < TELEMETRY_RX_PACKET_SIZE) {
     telemetryRxBuffer[telemetryRxBufferCount++] = data;
   } else {
-set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value |= 0x02);
     telemetryRxBufferCount = 0;
     return;
   }
@@ -216,12 +203,9 @@ set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value |= 0x02);
 #if SUPPORT_CRSF_CONFIG
       } else {
         CRSF_serial_rcv(telemetryRxBuffer+2, telemetryRxBuffer[1]-1);  // Extended frame
-set_telemetry(TELEM_CRSF_BATT_VOLTAGE, 0);
 #endif
       }
     }
-else { set_telemetry(TELEM_CRSF_BATT_VOLTAGE, value |= 0x01); }
-
     telemetryRxBufferCount = 0;
   }
 }
@@ -324,8 +308,6 @@ static u16 serial_cb()
         length = CRSF_serial_txd(packet, sizeof packet);
         if (length) {
             UART_Send(packet, length);
-            state = ST_DATA1;
-            return 6000;
         } else {
             length = build_rcdata_pkt();
             UART_Send(packet, length);

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -178,7 +178,12 @@ static void processCrossfireTelemetryFrame()
 
 // serial data receive ISR callback
 static void processCrossfireTelemetryData(u8 data, u8 status) {
-  (void)status;
+//  (void)status;
+if (status == 0x20) Telemetry.gps.altitude |= 0x80;
+if (status == 0x22) Telemetry.gps.altitude |= 0x40;
+if (status == 0x26) Telemetry.gps.altitude |= 0x20;
+if (status & 0x08)  Telemetry.gps.altitude |= 0x08;
+TELEMETRY_SetUpdated(TELEM_GPS_ALT);
 
   if (telemetryRxBufferCount == 0 && data != ADDR_RADIO) {
     return;

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -186,7 +186,6 @@ static void processCrossfireTelemetryData(u8 data, u8 status) {
 
   if (telemetryRxBufferCount == 1 && (data < 2 || data > TELEMETRY_RX_PACKET_SIZE-2)) {
     telemetryRxBufferCount = 0;
-    memset(telemetryRxBuffer, 0, TELEMETRY_RX_PACKET_SIZE);  // clear buff for device ping data detection
     return;
   }
   
@@ -194,7 +193,6 @@ static void processCrossfireTelemetryData(u8 data, u8 status) {
     telemetryRxBuffer[telemetryRxBufferCount++] = data;
   } else {
     telemetryRxBufferCount = 0;
-    memset(telemetryRxBuffer, 0, TELEMETRY_RX_PACKET_SIZE);  // clear buff for device ping data detection
     return;
   }
   
@@ -209,7 +207,6 @@ static void processCrossfireTelemetryData(u8 data, u8 status) {
       }
     }
     telemetryRxBufferCount = 0;
-    memset(telemetryRxBuffer, 0, TELEMETRY_RX_PACKET_SIZE);  // clear buff for device ping data detection
   }
 }
 #endif  // HAS_EXTENDED_TELEMETRY

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -306,18 +306,15 @@ static u16 serial_cb()
         if (mixer_sync != MIX_DONE && mixer_runtime < 2000) mixer_runtime += 50;
 #if SUPPORT_CRSF_CONFIG
         length = CRSF_serial_txd(packet, sizeof packet);
-        if (length) {
-            UART_Send(packet, length);
-        } else {
+        if (length == 0) {
             length = build_rcdata_pkt();
-            UART_Send(packet, length);
         }
 #else
         length = build_rcdata_pkt();
-        UART_Send(packet, length);
 #endif
-
+        UART_Send(packet, length);
         state = ST_DATA1;
+
         return get_update_interval() - mixer_runtime;
     }
 

--- a/src/target/drivers/serial/uart/uart.c
+++ b/src/target/drivers/serial/uart/uart.c
@@ -178,10 +178,13 @@ void UART_StopReceive()
 void UART_SetDuplex(uart_duplex duplex)
 {
     // no libopencm3 function for duplex
-    if (duplex == UART_DUPLEX_FULL)
+    if (duplex == UART_DUPLEX_FULL) {
         USART_CR3(UART_CFG.uart) &= ~USART_CR3_HDSEL;
-    else
+        usart_set_mode(UART_CFG.uart, USART_MODE_TX_RX);
+    } else {
         USART_CR3(UART_CFG.uart) |= USART_CR3_HDSEL;
+        usart_set_mode(UART_CFG.uart, USART_MODE_RX);
+    }
 }
 
 void UART_SendByte(u8 x)

--- a/src/target/drivers/serial/uart/uart.c
+++ b/src/target/drivers/serial/uart/uart.c
@@ -53,6 +53,8 @@ void UART_Initialize()
 
     /* Finally enable the USART. */
     usart_enable(UART_CFG.uart);
+    /* USART irq always needed for DMA completion, sometimes for serial receive */
+    nvic_enable_irq(get_nvic_irq(UART_CFG.uart));
 
     nvic_set_priority(get_nvic_dma_irq(USART_DMA), 3);
     nvic_enable_irq(get_nvic_dma_irq(USART_DMA));
@@ -81,6 +83,7 @@ void UART_Stop()
 {
     UART_StopReceive();
     nvic_disable_irq(get_nvic_dma_irq(USART_DMA));
+    nvic_disable_irq(get_nvic_irq(UART_CFG.uart));
     usart_set_mode(UART_CFG.uart, 0);
     usart_disable(UART_CFG.uart);
     rcc_periph_clock_disable(get_rcc_from_port(UART_CFG.uart));
@@ -161,13 +164,10 @@ void UART_StartReceive(usart_callback_t *isr_callback)
 {
     rx_callback = isr_callback;
 
-    if (isr_callback) {
-        nvic_enable_irq(get_nvic_irq(UART_CFG.uart));
+    if (isr_callback)
         usart_enable_rx_interrupt(UART_CFG.uart);
-    } else {
+    else
         usart_disable_rx_interrupt(UART_CFG.uart);
-        nvic_disable_irq(get_nvic_irq(UART_CFG.uart));
-    }
 }
 
 void UART_StopReceive()

--- a/src/target/drivers/serial/uart/uart_isr.c
+++ b/src/target/drivers/serial/uart/uart_isr.c
@@ -44,11 +44,11 @@ void __attribute__((__used__)) _UART_ISR(void)
 
     // handle transmit complete at end of DMA transfer
     if (status & USART_SR_TC) {
-        busy = 0;
         USART_CR1(UART_CFG.uart) &= ~USART_CR1_TCIE;
         if (USART_CR3(UART_CFG.uart) & USART_CR3_HDSEL) {   // change to receiver if half-duplex
             usart_set_mode(UART_CFG.uart, USART_MODE_RX);
         }
+        busy = 0;
     }
         
     if (status & (USART_SR_PE | USART_SR_FE | USART_SR_NE | USART_SR_ORE))

--- a/src/target/drivers/serial/uart/uart_isr.c
+++ b/src/target/drivers/serial/uart/uart_isr.c
@@ -23,6 +23,8 @@
 
 extern volatile u8 busy;
 
+static volatile u8 one_more;
+
 void __attribute__((__used__)) _USART_DMA_ISR(void)
 {
     DMA_IFCR(USART_DMA.dma) |= DMA_IFCR_CTCIF(USART_DMA.stream);
@@ -31,21 +33,28 @@ void __attribute__((__used__)) _USART_DMA_ISR(void)
     usart_disable_tx_dma(UART_CFG.uart);
     DMA_disable_stream(USART_DMA);
 
-    if (USART_CR3(UART_CFG.uart) & USART_CR3_HDSEL)   // re-enable receiver if half-duplex
-      usart_set_mode(UART_CFG.uart, USART_MODE_TX_RX);
-    busy = 0;
+    USART_CR1(UART_CFG.uart) |= USART_CR1_TCIE;     // wait for last byte send complete
 }
 
 extern usart_callback_t *rx_callback;
 void __attribute__((__used__)) _UART_ISR(void)
 {
-    u8 status = USART_SR(UART_CFG.uart) & (USART_SR_RXNE | USART_SR_PE | USART_SR_FE | USART_SR_NE | USART_SR_ORE);
+    u8 status = USART_SR(UART_CFG.uart);
     u8 data = usart_recv(UART_CFG.uart);       // read unconditionally to reset interrupt and error flags
 
-//  if (status & (USART_SR_PE | USART_SR_FE | USART_SR_NE | USART_SR_ORE))
-//      return;
+    // handle transmit complete at end of DMA transfer
+    if (status & USART_SR_TC) {
+        busy = 0;
+        USART_CR1(UART_CFG.uart) &= ~USART_CR1_TCIE;
+        if (USART_CR3(UART_CFG.uart) & USART_CR3_HDSEL) {   // change to receiver if half-duplex
+            usart_set_mode(UART_CFG.uart, USART_MODE_RX);
+        }
+    }
+        
+    if (status & (USART_SR_PE | USART_SR_FE | USART_SR_NE | USART_SR_ORE))
+        return;
 
-    if (rx_callback) rx_callback(data, status);
+    if (!busy && (status & USART_SR_RXNE) && rx_callback) rx_callback(data, status);
 
     // interrupt cleared by reading data register
 }

--- a/src/target/drivers/serial/uart/uart_isr.c
+++ b/src/target/drivers/serial/uart/uart_isr.c
@@ -42,6 +42,9 @@ void __attribute__((__used__)) _UART_ISR(void)
     u8 status = USART_SR(UART_CFG.uart) & (USART_SR_RXNE | USART_SR_PE | USART_SR_FE | USART_SR_NE | USART_SR_ORE);
     u8 data = usart_recv(UART_CFG.uart);       // read unconditionally to reset interrupt and error flags
 
+//  if (status & (USART_SR_PE | USART_SR_FE | USART_SR_NE | USART_SR_ORE))
+//      return;
+
     if (rx_callback) rx_callback(data, status);
 
     // interrupt cleared by reading data register


### PR DESCRIPTION
Names of max length (16 including nul) or greater caused incorrect calculation of location of next parameter in receiver buffer.

Fixes issue in serial sending code where link was switched from tx to rx before last byte finished sending.

Fixes updating CRSF config page device list when new info message received from new device.