### PR TITLE
Adjust crsf telem limits and voice scaling

### DIFF
--- a/src/telemetry.c
+++ b/src/telemetry.c
@@ -477,10 +477,9 @@ void TELEMETRY_Alarm()
 #if HAS_EXTENDED_TELEMETRY
         if (TELEMETRY_Type() == TELEM_CRSF) {
             switch (alarm->src) {
-                case TELEM_CRSF_BATT_VOLTAGE:
-                    MUSIC_PlayValue(telem_music, telem_value,VOICE_UNIT_VOLT,2); break;
-                case TELEM_CRSF_BATT_CURRENT: MUSIC_PlayValue(telem_music, telem_value,VOICE_UNIT_AMPS,2); break;
-                case TELEM_CRSF_GPS_ALTITUDE: MUSIC_PlayValue(telem_music, telem_value,VOICE_UNIT_ALTITUDE,2); break;
+                case TELEM_CRSF_BATT_VOLTAGE: MUSIC_PlayValue(telem_music, telem_value,VOICE_UNIT_VOLT,1); break;
+                case TELEM_CRSF_BATT_CURRENT: MUSIC_PlayValue(telem_music, telem_value,VOICE_UNIT_AMPS,1); break;
+                case TELEM_CRSF_GPS_ALTITUDE: MUSIC_PlayValue(telem_music, telem_value,VOICE_UNIT_ALTITUDE,3); break;
                 case TELEM_CRSF_TX_SNR:
                 case TELEM_CRSF_TX_RSSI:
                 case TELEM_CRSF_RX_SNR:

--- a/src/telemetry/telem_crsf.c
+++ b/src/telemetry/telem_crsf.c
@@ -128,7 +128,7 @@ s32 _crsf_get_max_value(u8 telem)
     case TELEM_CRSF_RX_QUALITY: return 150; break;
     case TELEM_CRSF_TX_QUALITY: return 150; break;
     case TELEM_CRSF_BATT_VOLTAGE: return 500; break;
-    case TELEM_CRSF_BATT_CURRENT: return 100; break;
+    case TELEM_CRSF_BATT_CURRENT: return 1000; break;
     case TELEM_CRSF_BATT_CAPACITY: return 500000; break;
     case TELEM_CRSF_ATTITUDE_PITCH:
     case TELEM_CRSF_ATTITUDE_ROLL:

--- a/src/telemetry/telem_crsf.c
+++ b/src/telemetry/telem_crsf.c
@@ -127,7 +127,7 @@ s32 _crsf_get_max_value(u8 telem)
     case TELEM_CRSF_TX_POWER: return 1000; break;
     case TELEM_CRSF_RX_QUALITY: return 150; break;
     case TELEM_CRSF_TX_QUALITY: return 150; break;
-    case TELEM_CRSF_BATT_VOLTAGE: return 100; break;
+    case TELEM_CRSF_BATT_VOLTAGE: return 500; break;
     case TELEM_CRSF_BATT_CURRENT: return 100; break;
     case TELEM_CRSF_BATT_CAPACITY: return 500000; break;
     case TELEM_CRSF_ATTITUDE_PITCH:


### PR DESCRIPTION
Increase CRSF voltage telemetry alarm limit to 50 volts.
Increase CRSF current telemetry alarm limit to 100 amps.
Fix voice announcement of voltage and current.  Was off by factor of 10.

Tested by mooiweertje on deviationtx.com