### PR TITLE
Limit range of fixed id in CRSF protocol

### DIFF
--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -312,7 +312,7 @@ static void processCrossfireTelemetryData() {
                     processCrossfireTelemetryFrame();     // Broadcast frame
 #if SUPPORT_CRSF_CONFIG
                     // wait for telemetry running before sending model id
-                    if (model_id_send && CRSF_send_model_id(Model.fixed_id < 64 ? Model.fixed_id : 0xff)) {
+                    if (model_id_send && CRSF_send_model_id(Model.fixed_id < 64 ? Model.fixed_id : 0)) {
                         model_id_send = 0;
                         return;
                     }


### PR DESCRIPTION
Sends model id of 0 to ELRS if the Deviation Fixed ID is greater than 63.   When sending a model id to the TX it should always be in the range 0-63. 