### PR TITLE
Allow hex notation for fixed_id

### DIFF
--- a/src/config/model.c
+++ b/src/config/model.c
@@ -630,7 +630,7 @@ static const struct struct_map _secppm[] = {
 };
 static int ini_handler(void* user, const char* section, const char* name, const char* value)
 {
-    int value_int = atoi(value);
+    u32 value_int = strtoul(value, NULL, 0);
     struct Model *m = (struct Model *)user;
 int assign_int(void* ptr, const struct struct_map *map, int map_size)
 {

--- a/src/protocol/radiolink_cc2500.c
+++ b/src/protocol/radiolink_cc2500.c
@@ -173,7 +173,7 @@ static void RLINK_TXID_init()
         //air T8FB
         //memcpy(rx_tx_addr,"\xFC\x11\x0D\x20",RLINK_TX_ID_LEN);
         // hexfet's am-x12
-        // memcpy(rx_tx_addr,"\x8a\xda\xf5\xcc\x02",RLINK_TX_ID_LEN+1);
+        // memcpy(rx_tx_addr,"\x8a\xda\xf5\xcc",RLINK_TX_ID_LEN);
     #endif
 
     // channels order depend on ID

--- a/src/target/drivers/mcu/emu/stubs.c
+++ b/src/target/drivers/mcu/emu/stubs.c
@@ -159,17 +159,18 @@ void SSER_Stop() {}
 
 void MCU_SerialNumber(u8 *var, int len)
 {
-    int l = len > 12 ? 12 : len;
     if(Transmitter.txid) {
+        int l = len > 16 ? 16 : len;
         u32 id[4];
         u32 seed = 0x4d3ab5d0ul;
         for(int i = 0; i < 4; i++)
             rand32_r(&seed, Transmitter.txid >> (8*i));
         for(int i = 0; i < 4; i++)
             id[i] = rand32_r(&seed, 0x00);
-        memcpy(var, &id[1], len);
+        memcpy(var, &id[0], l);
         return;
     }
+    int l = len > 12 ? 12 : len;
     const char data[] = {0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
                          0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
     memcpy(var, data, l);


### PR DESCRIPTION
Allows hex notation and large positive numbers for model configuration file numbers.