### PR TITLE
Add handling for changes in CRSF COMMAND dialogs

### DIFF
--- a/src/pages/128x64x1/dialogs.c
+++ b/src/pages/128x64x1/dialogs.c
@@ -199,15 +199,21 @@ void PAGE_ShowModuleDialog(const char **missing)
 /*********************************/
 /*   CRSF configuration dialog   */
 /*********************************/
-void PAGE_CRSFdialog(int status, void *param) {
+void PAGE_CRSFdialog(void *param) {
+    enum DialogType dg_type = ((crsf_param_t *)param)->u.status == CONFIRMATION_NEEDED ? dtOkCancel : dtCancel;
+
+    guiDialog_t *dlg = (guiDialog_t *)dialog;
+
     if (dialog) {
-        GUI_Redraw(dialog);
-        return;
+        if (((dg_type == dtOkCancel) && (dlg->but2.header.box.x != 0))  // somewhat kludgy test to see if current dialog has two buttons
+         || ((dg_type != dtOkCancel) && (dlg->but2.header.box.x == 0))) {
+            GUI_Redraw(dialog);
+            return;
+        }
     }
 
     dialog = GUI_CreateDialog(&gui->dialog, DIALOG2_X, DIALOG2_Y, DIALOG2_WIDTH, DIALOG2_HEIGHT,
-                NULL, cmd_info_cb, crsf_confirm_cb,
-                status == CONFIRMATION_NEEDED ? dtOkCancel : dtCancel, param);
+                              NULL, cmd_info_cb, crsf_confirm_cb, dg_type, param);
 }
 
 void PAGE_CRSFdialogClose() {

--- a/src/pages/128x64x1/pages.h
+++ b/src/pages/128x64x1/pages.h
@@ -83,6 +83,6 @@ void PAGE_VideoSetupInit(int page);
 void PAGE_LayoutEditInit(int page);
 void PAGE_ExternalOSDInit(int page);
 
-void PAGE_CRSFdialog(int type, void *param);
+void PAGE_CRSFdialog(void *param);
 void PAGE_CRSFdialogClose();
 #endif

--- a/src/pages/320x240x16/dialogs.c
+++ b/src/pages/320x240x16/dialogs.c
@@ -162,7 +162,7 @@ void PAGE_ShowModuleDialog(const char **missing)
 /*********************************/
 /*   CRSF configuration dialog   */
 /*********************************/
-void PAGE_CRSFdialog(int status, void *param) {
+void PAGE_CRSFdialog(void *param) {
     if (dialog) {
         GUI_Redraw(dialog);
         return;
@@ -170,7 +170,7 @@ void PAGE_CRSFdialog(int status, void *param) {
 
     dialog = GUI_CreateDialog(&gui->dialog, 10 + DLG_XOFFSET, 42 + DLG_YOFFSET, 300, 188,
                 NULL, cmd_info_cb, crsf_confirm_cb,
-                status == CONFIRMATION_NEEDED ? dtOkCancel : dtCancel, param);
+                ((crsf_param_t *)param)->u.status == CONFIRMATION_NEEDED ? dtOkCancel : dtCancel, param);
 }
 
 void PAGE_CRSFdialogClose() {

--- a/src/pages/320x240x16/pages.h
+++ b/src/pages/320x240x16/pages.h
@@ -66,6 +66,6 @@ void PAGE_ModelMenuInit(int page);
 //Touch
 void PAGE_TouchInit(int page);
 void PAGE_TouchEvent();
-void PAGE_CRSFdialog(int type, void *param);
+void PAGE_CRSFdialog(void *param);
 void PAGE_CRSFdialogClose();
 #endif

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -324,7 +324,7 @@ void PAGE_CRSFDeviceEvent() {
     // commands may require interaction through dialog
     if (command.dialog == 1) {
         command.dialog = 0;
-        PAGE_CRSFdialog(command.param->u.status, (void *)command.param);
+        PAGE_CRSFdialog((void *)command.param);
     } else if (command.dialog == 2) {
         command.dialog = 0;
         PAGE_CRSFdialogClose();
@@ -798,8 +798,8 @@ static void add_param(u8 *buffer, u8 num_bytes) {
     case COMMAND:
         parse_bytes(UINT8, &recv_param_ptr, &parameter->u.status);
         parse_bytes(UINT8, &recv_param_ptr, &parameter->timeout);
-        if (!update) parameter->s.info = alloc_string(20);
-        strlcpy(parameter->s.info, (const char *)recv_param_ptr, 20);
+        if (!update) parameter->s.info = alloc_string(40);
+        strlcpy(parameter->s.info, (const char *)recv_param_ptr, 40);
 
         command.param = parameter;
         command.time = 0;

--- a/src/pages/common/_dialogs.c
+++ b/src/pages/common/_dialogs.c
@@ -146,7 +146,12 @@ static const char *cmd_info_cb(guiObject_t *obj, void *data) {
     (void)obj;
     crsf_param_t *param = (crsf_param_t *)data;
 
-    return (const char *)param->s.info;
+    // info max string length is 39
+    if (strlen(param->s.info) > 20)
+        snprintf(tempstring, sizeof(tempstring), "%20s\n%s", param->s.info, &param->s.info[20]);
+    else
+        snprintf(tempstring, sizeof(tempstring), "%s", param->s.info);
+    return tempstring;
 }
 
 static void crsf_confirm_cb(u8 state, void *data) {


### PR DESCRIPTION
Dialog type may change after creation, for example from PROGRESS to CONFIRMATION_NEEDED.  This requires changing the dialog from one button to two buttons.

Also handle longer COMMAND info strings - up to 39 characters.