### PR TITLE
Fix broken multimod on Devo transmitters

### DIFF
--- a/src/target/drivers/mcu/stm32/power.c
+++ b/src/target/drivers/mcu/stm32/power.c
@@ -25,11 +25,6 @@ void PWR_Init(void)
 {
     _pwr_init();
 
-    /* Disable SWD and set SWD pins as I/O for programable switch */
-#if !defined(USE_JTAG) || !USE_JTAG
-    DisableJTAG();
-#endif
-
     if (HAS_PIN(PWR_ENABLE_PIN)) {
         rcc_periph_clock_enable(get_rcc_from_pin(PWR_SWITCH_PIN));
         rcc_periph_clock_enable(get_rcc_from_pin(PWR_ENABLE_PIN));
@@ -42,6 +37,12 @@ void PWR_Init(void)
         /* When Pin goes high, the user turned off the Tx */
         GPIO_setup_input(PWR_SWITCH_PIN, ITYPE_FLOAT);
     }
+
+    /* Disable SWD and set SWD pins as I/O for programable switch */
+#if !defined(USE_JTAG) || !USE_JTAG
+    // Disable JTAG needs to be done after rcc_periph_clock_enable
+    DisableJTAG();
+#endif
 }
 
 void PWR_Shutdown()

--- a/src/universaltx/include/common.h
+++ b/src/universaltx/include/common.h
@@ -62,6 +62,7 @@ enum {
     CC2500,
     NRF24L01,
     MULTIMOD,
+    R9M,
     TX_MODULE_LAST,
 };
 int SPI_ConfigSwitch(unsigned csn_high, unsigned csn_low);


### PR DESCRIPTION
The original multimodule (MultiMod) designed for Devo transmitters (not the Universal module) had been broken since early 2019.  The problem is caused by major code restructure at the time and JTAG isn't completely disabled and interfere with the MultiMod operation.  Without the fix, you'll get an error message "Missing Modules: MultiMod" every time powering up and the transmitter is basically non-functional.  I've tested this on Devo7e and it will probably affect all other Devo transmitters with MultiMod installed.