### PR TITLE
Bug fix for missing shutdown voice

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -228,9 +228,11 @@ void EventLoop()
 #if HAS_EXTENDED_AUDIO
         if(AUDIO_VoiceAvailable()) {
             MUSIC_Play(MUSIC_SHUTDOWN);
+            AUDIO_CheckQueue();
             while (CLOCK_getms() < audio_queue_time) {
                 // Wait for voice to finished
                 CLOCK_ResetWatchdog();
+                AUDIO_CheckQueue();
             }
         } else {
 #else


### PR DESCRIPTION
This is a simple bug fix for the missing shutdown voice in extended audio support.  