### PR TITLE
Set default value for number selection step value in _crsfdevice_page.c

### DIFF
--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -201,6 +201,8 @@ static const char *value_numsel(guiObject_t *obj, int dir, void *data)
     crsf_param_t *param = (crsf_param_t *)data;
     u8 changed = 0;
 
+    if(param->step == 0) param->step = 1;
+ 
     param->value = (void *)(intptr_t)GUI_TextSelectHelper((intptr_t)param->value,
                                         param->min_value, param->max_value,
                                         dir, param->step, 10*param->step, &changed);


### PR DESCRIPTION
If number selection step is not defined, then set step to 1. Fixes an issue with not being able to change VTX channel over the radio. VTX channel is an uint8 in ELRS version 3.4.0+