### PR TITLE
CRSF configuration menu handling update

### DIFF
--- a/src/crsf.h
+++ b/src/crsf.h
@@ -127,7 +127,7 @@ typedef struct {
     u8 parent;            // Parent folder parameter number of the parent folder, 0 means root
     enum data_type type;  // (Parameter type definitions and hidden bit)
     u8 hidden:1;          // set if hidden
-    u8 loaded:1;          // clear to force reload
+    volatile u8 loaded:1;          // clear to force reload
     u8 lines_per_row:2;   // GUI optimization
     char *name;           // Null-terminated string
     void *value;          // size depending on data type

--- a/src/crsf.h
+++ b/src/crsf.h
@@ -150,6 +150,7 @@ typedef struct {
         char *info;
         char *unit;         // Unit ( Null-terminated string / not sent for type string and folder )
     } s;
+    u8 lines_per_row;     // GUI optimization
 } crsf_param_t;
 
 extern crsf_device_t crsf_devices[CRSF_MAX_DEVICES];

--- a/src/crsf.h
+++ b/src/crsf.h
@@ -128,7 +128,7 @@ typedef struct {
     enum data_type type;  // (Parameter type definitions and hidden bit)
     u8 hidden:1;          // set if hidden
     u8 loaded:1;          // clear to force reload
-    u8 name_size:6;       // initial size of name string - can't be resized
+    u8 lines_per_row:2;   // GUI optimization
     char *name;           // Null-terminated string
     void *value;          // size depending on data type
 
@@ -150,7 +150,6 @@ typedef struct {
         char *info;
         char *unit;         // Unit ( Null-terminated string / not sent for type string and folder )
     } s;
-    u8 lines_per_row;     // GUI optimization
 } crsf_param_t;
 
 extern crsf_device_t crsf_devices[CRSF_MAX_DEVICES];

--- a/src/crsf.h
+++ b/src/crsf.h
@@ -126,7 +126,9 @@ typedef struct {
     u8 id;                // Parameter number (starting from 1)
     u8 parent;            // Parent folder parameter number of the parent folder, 0 means root
     enum data_type type;  // (Parameter type definitions and hidden bit)
-    u8 hidden;            // set if hidden
+    u8 hidden:1;          // set if hidden
+    u8 loaded:1;          // clear to force reload
+    u8 name_size:6;       // initial size of name string - can't be resized
     char *name;           // Null-terminated string
     void *value;          // size depending on data type
 

--- a/src/crsf.h
+++ b/src/crsf.h
@@ -150,6 +150,8 @@ typedef struct {
         char *info;
         char *unit;         // Unit ( Null-terminated string / not sent for type string and folder )
     } s;
+    int parent_row_idx;   // GUI optimization
+    int child_row_idx;    // GUI optimization
 } crsf_param_t;
 
 extern crsf_device_t crsf_devices[CRSF_MAX_DEVICES];

--- a/src/pages/128x64x1/crsfdevice_page.c
+++ b/src/pages/128x64x1/crsfdevice_page.c
@@ -56,7 +56,7 @@ static int row_cb(int absrow, int relrow, int y, void *data) {
     switch (param->type) {
     case TEXT_SELECTION:
         LCD_GetStringDimensions((const u8 *)param->max_str, &width, &height);
-        if (param->max_value - param->min_value > 1) {
+        if (non_null_values(param) > 1 && (param->max_value - param->min_value > 1)) {
             GUI_CreateTextSelectPlate(&gui->value[relrow].ts,
                 LCD_WIDTH - width - 18, y,
                 width + 13, LINE_HEIGHT, &TEXTSEL_FONT,

--- a/src/pages/128x64x1/crsfdevice_page.c
+++ b/src/pages/128x64x1/crsfdevice_page.c
@@ -102,21 +102,30 @@ static int row_cb(int absrow, int relrow, int y, void *data) {
 static const char *hdr_str_cb(guiObject_t *obj, const void *data) {
     (void)obj;
     (void)data;
+    static u8 need_show_folder;
 
     if (count_params_loaded() != crsf_devices[device_idx].number_of_params) {
-        snprintf(tempstring, sizeof tempstring, "%s %s", crsf_devices[device_idx].name, _tr_noop("LOADING"));
-    } else if (protocol_module_is_elrs()) {
-        if (protocol_elrs_is_armed()) {
-            snprintf(tempstring, sizeof tempstring, "%s  ! Armed !", crsf_devices[device_idx].name);
-        } else if (elrs_info.flag_info[0]) {
-            snprintf(tempstring, sizeof tempstring, "%s", elrs_info.flag_info);
-        } else {
-            snprintf(tempstring, sizeof tempstring, "%s  %d/%d  %c",
-                     crsf_devices[device_idx].name, elrs_info.bad_pkts, elrs_info.good_pkts,
-                     (elrs_info.flags & 1) ? 'C' : '-');
+        need_show_folder = 1;
+        //snprintf(tempstring, sizeof tempstring, "%s %s", crsf_devices[device_idx].name, _tr_noop("LOADING"));
+        snprintf(tempstring, sizeof tempstring, "L %d N %d F %d", count_params_loaded(), crsf_devices[device_idx].number_of_params, current_folder);
+    } else {
+        if (need_show_folder) {
+            need_show_folder = 0;
+            show_page(current_folder);
         }
-    } else  {
-        return crsf_devices[device_idx].name;
+        if (protocol_module_is_elrs()) {
+            if (protocol_elrs_is_armed()) {
+                snprintf(tempstring, sizeof tempstring, "%s  ! Armed !", crsf_devices[device_idx].name);
+            } else if (elrs_info.flag_info[0]) {
+                snprintf(tempstring, sizeof tempstring, "%s", elrs_info.flag_info);
+            } else {
+                snprintf(tempstring, sizeof tempstring, "%s  %d/%d  %c",
+                         crsf_devices[device_idx].name, elrs_info.bad_pkts, elrs_info.good_pkts,
+                         (elrs_info.flags & 1) ? 'C' : '-');
+            }
+        } else {
+            return crsf_devices[device_idx].name;
+        }
     }
     return tempstring;
 }

--- a/src/pages/128x64x1/crsfdevice_page.c
+++ b/src/pages/128x64x1/crsfdevice_page.c
@@ -157,10 +157,6 @@ static const char *hdr_str_cb(guiObject_t *obj, const void *data) {
     if (params_loaded != crsf_devices[device_idx].number_of_params) {
         snprintf(tempstring, sizeof tempstring, "%s %s", crsf_devices[device_idx].name, _tr_noop("LOADING"));
     } else {
-        if (need_show_folder < 255) {
-            show_page(need_show_folder);
-            need_show_folder = 255;
-        }
         if (protocol_module_is_elrs()) {
             if (protocol_elrs_is_armed()) {
                 snprintf(tempstring, sizeof tempstring, "%s  ! Armed !", crsf_devices[device_idx].name);

--- a/src/pages/128x64x1/crsfdevice_page.c
+++ b/src/pages/128x64x1/crsfdevice_page.c
@@ -156,7 +156,9 @@ static const char *hdr_str_cb(guiObject_t *obj, const void *data) {
 
     int params_left = crsf_devices[device_idx].number_of_params - count_params_loaded();
     if (params_left != 0) {
-        snprintf(tempstring, sizeof tempstring, "%s %s %d", crsf_devices[device_idx].name, _tr_noop("LOADING"), params_left);
+        char short_name[10];
+        strlcpy(short_name, crsf_devices[device_idx].name, 10);
+        snprintf(tempstring, sizeof tempstring, "%s %s %d", short_name, _tr_noop("LOADING"), params_left);
     } else {
         if (protocol_module_is_elrs()) {
             if (protocol_elrs_is_armed()) {

--- a/src/pages/128x64x1/crsfdevice_page.c
+++ b/src/pages/128x64x1/crsfdevice_page.c
@@ -31,6 +31,7 @@ enum {
 #endif
 
 #if SUPPORT_CRSF_CONFIG
+static u8 need_show_folder;
 
 #include "../common/_crsfdevice_page.c"
 
@@ -102,12 +103,10 @@ static int row_cb(int absrow, int relrow, int y, void *data) {
 static const char *hdr_str_cb(guiObject_t *obj, const void *data) {
     (void)obj;
     (void)data;
-    static u8 need_show_folder;
 
-    if (count_params_loaded() != crsf_devices[device_idx].number_of_params) {
-        need_show_folder = 1;
+    if (params_loaded != crsf_devices[device_idx].number_of_params) {
         //snprintf(tempstring, sizeof tempstring, "%s %s", crsf_devices[device_idx].name, _tr_noop("LOADING"));
-        snprintf(tempstring, sizeof tempstring, "L %d N %d F %d", count_params_loaded(), crsf_devices[device_idx].number_of_params, current_folder);
+        snprintf(tempstring, sizeof tempstring, "L %d N %d F %d, X %d", count_params_loaded(), crsf_devices[device_idx].number_of_params, current_folder, next_param);
     } else {
         if (need_show_folder) {
             need_show_folder = 0;

--- a/src/pages/320x240x16/crsfdevice_page.c
+++ b/src/pages/320x240x16/crsfdevice_page.c
@@ -90,7 +90,7 @@ static int row_cb(int absrow, int relrow, int y, void *data) {
 
 static void show_header() {}
 
-void show_page(int folder) {
+static void show_page(u8 folder) {
     GUI_RemoveAllObjects();
     if (count_params_loaded() == crsf_devices[device_idx].number_of_params) {
         PAGE_ShowHeader(crsf_devices[device_idx].name);

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -810,7 +810,6 @@ static void add_param(u8 *buffer, u8 num_bytes) {
     parameter->id = buffer[3];
     parameter->parent = *recv_param_ptr++;
     parameter->type = *recv_param_ptr & 0x7f;
-    parameter->loaded = 1;
     parameter->hidden = *recv_param_ptr++ & 0x80;
 
     u8 name_size = strlen(recv_param_ptr) + 1;
@@ -923,6 +922,7 @@ static void add_param(u8 *buffer, u8 num_bytes) {
     default:
         break;
     }
+    parameter->loaded = 1;
 
     recv_param_ptr = recv_param_buffer;
 

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -24,8 +24,8 @@ static struct crsfdevice_page * const mp = &pagemem.u.crsfdevice_page;
 static struct crsfdevice_obj * const gui = &gui_objs.u.crsfdevice;
 
 static u32 read_timeout;
-static u8 current_folder = 255;
-static u8 need_show_folder = 255;
+static volatile u8 current_folder;
+static volatile u8 need_show_folder = 255;
 static volatile u8 params_loaded;     // if not zero, number received so far for current device
 static volatile u8 params_displayed;  // if not zero, number displayed so far for current device
 static u8 device_idx;   // current device index

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -800,11 +800,11 @@ static void add_param(u8 *buffer, u8 num_bytes) {
     parameter->type = *recv_param_ptr & 0x7f;
     parameter->loaded = 1;
     parameter->hidden = *recv_param_ptr++ & 0x80;
-    // reallocate name string
-    parameter->name_size = strlen(recv_param_ptr) + 1;
-    parameter->name = alloc_string(parameter->name_size);
-    strlcpy(parameter->name, (const char *)recv_param_ptr, parameter->name_size);
-    recv_param_ptr += parameter->name_size;
+
+    u8 name_size = strlen(recv_param_ptr) + 1;
+    parameter->name = alloc_string(name_size);
+    strlcpy(parameter->name, (const char *)recv_param_ptr, name_size);
+    recv_param_ptr += name_size;
 
     int count;
     switch (parameter->type) {

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -261,18 +261,18 @@ static void folder_load(u8 param_id) {
     // param_id of 0 indicates root folder
     if (param_id != 0) {
         crsf_params[param_id-1].loaded = 0;
-        params_loaded -= 1;
-        need_show_folder = param_id;
+        crsf_params[param_id-1].lines_per_row = 0;
     }
     if (param_id == 0 || crsf_params[param_id-1].type == FOLDER) {
         for (int i=0; i < crsf_devices[device_idx].number_of_params; i++) {
             if (crsf_params[i].parent == param_id) {
                 crsf_params[i].loaded = 0;
-                params_loaded -= 1;
-                need_show_folder = param_id;
+                crsf_params[i].lines_per_row = 0;
             }
         }
     }
+    need_show_folder = param_id;
+    params_loaded = count_params_loaded();
     next_string = mp->strings;      // re-allocate all strings
     next_param = param_next(param_id);
     next_chunk = 0;
@@ -375,13 +375,20 @@ void PAGE_CRSFDeviceEvent() {
     // until all parameters loaded
     static u8 armed_state;
     u8 params_count = count_params_loaded();
+
     if (params_displayed != params_count) {
         params_displayed = params_count;
         show_page(current_folder);
-    } else if (elrs_info.update > 0 || armed_state != protocol_elrs_is_armed()) {
-        elrs_info.update = 0;
-        armed_state = protocol_elrs_is_armed();
-        show_header();
+    } else {
+        if (need_show_folder < 255) {
+            show_page(need_show_folder);
+            need_show_folder = 255;
+        }
+        if (elrs_info.update > 0 || armed_state != protocol_elrs_is_armed()) {
+            elrs_info.update = 0;
+            armed_state = protocol_elrs_is_armed();
+            show_header();
+        }
     }
 
     // commands may require interaction through dialog

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -168,7 +168,7 @@ void protocol_set_param(u8 value) {
 static struct {
     volatile uint8_t    m_get_idx;
     volatile uint8_t    m_put_idx;
-    uint8_t             m_entry[512];  // must be power of 2
+    uint8_t             m_entry[1024];  // must be power of 2
 } receive_buf;
 
 static u8 telemetryRxBuffer[TELEMETRY_RX_PACKET_SIZE];

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -152,6 +152,7 @@ void protocol_read_param(u8 device_idx, crsf_param_t *param) {
     param->max_value = 2;        // not sent for string type
     param->changed = 0;           // flag if set needed when edit element is de-selected
     param->max_str = &((char*)param->value)[11];        // Longest choice length for text select
+    param->lines_per_row = 1;
     param->u.text_sel = Model.proto_opts[PROTO_OPTS_BITRATE];
 }
 

--- a/src/protocol/crsf_uart.c
+++ b/src/protocol/crsf_uart.c
@@ -144,6 +144,7 @@ void protocol_read_param(u8 device_idx, crsf_param_t *param) {
     param->parent = 0;            // Parent folder parameter number of the parent folder, 0 means root
     param->type = TEXT_SELECTION;  // (Parameter type definitions and hidden bit)
     param->hidden = 0;            // set if hidden
+    param->loaded = 1;
     param->name = (char*)crsf_opts[0];           // Null-terminated string
     param->value = "400K\0001.87M\0002.00M";    // must match crsf_opts
     param->default_value = 0;  // size depending on data type. Not present for COMMAND.


### PR DESCRIPTION
Fix bugs and improve usability in handling CRSF parameter menus.

1. When a parameter is changed, all elements of the current folder and the folder itself are reloaded.  This handles dynamic changes to parameter names and options caused by changes to other parameters.  For example, with ELRS changing the packet rate can cause the available switch mode options to change.  This can be a little slow at 400Kbps data rate so be sure to use 1.87Mbps(ELRS) or 2.00Mbps(TBS).
2. Parameters where the label + value lengths are wider than the screen are split into two rows.  This fixes an issue with values partially overwriting label strings in the display.
3. When navigating between folders the current selection in a folder is remembered.  If the folder is opened again the same row will be selected.
4. Add handling of null options in TEXT_SELECTION parameters.  These are used by ELRS.