### PR TITLE
Crsf hidden parameter fix

### DIFF
--- a/src/crsf.h
+++ b/src/crsf.h
@@ -126,8 +126,8 @@ typedef struct {
     u8 id;                // Parameter number (starting from 1)
     u8 parent;            // Parent folder parameter number of the parent folder, 0 means root
     enum data_type type;  // (Parameter type definitions and hidden bit)
-    u8 hidden:1;          // set if hidden
-    volatile u8 loaded:1;          // clear to force reload
+    volatile u8 hidden:1; // set if hidden
+    volatile u8 loaded:1; // clear to force reload
     u8 lines_per_row:2;   // GUI optimization
     char *name;           // Null-terminated string
     void *value;          // size depending on data type
@@ -156,6 +156,7 @@ typedef struct {
 
 extern crsf_device_t crsf_devices[CRSF_MAX_DEVICES];
 extern elrs_info_t elrs_info;
+extern u8 show_hidden;
 
 void CRSF_serial_rcv(u8 *buffer, u8 num_bytes);
 u8 CRSF_serial_txd(u8 *buffer);
@@ -170,8 +171,8 @@ void CRSF_send_command(crsf_param_t *param, enum cmd_status status);
 u8 CRSF_send_model_id(u8 fixed_id);
 u32 CRSF_read_timeout();
 void CRSF_get_elrs();
-void protocol_read_param(u8 device_idx, crsf_param_t *param);
-void protocol_set_param(u8 value);
+void protocol_read_params(u8 device_idx, crsf_param_t param[]);
+void protocol_set_param(crsf_param_t *param);
 void protocol_module_type(module_type_t type);
 u8 protocol_module_is_elrs();
 u8 protocol_elrs_is_armed();

--- a/src/pages/128x64x1/crsfdevice_page.c
+++ b/src/pages/128x64x1/crsfdevice_page.c
@@ -213,7 +213,7 @@ void PAGE_CrsfdeviceInit(int page)
     next_param = 1;
     if (crsf_devices[device_idx].number_of_params) {
         if (crsf_devices[device_idx].address == ADDR_RADIO)
-            protocol_read_param(device_idx, &crsf_params[0]);    // only one param now
+            protocol_read_params(device_idx, crsf_params);
         else 
             CRSF_read_param(device_idx, next_param, 0);
     }

--- a/src/pages/128x64x1/crsfdevice_page.c
+++ b/src/pages/128x64x1/crsfdevice_page.c
@@ -27,7 +27,7 @@ enum {
     EDIT_LABEL_WIDTH = 60,
     EDIT_VALUE_X     = 66,
     EDIT_VALUE_WIDTH = 56,
-    ROW_SPLIT_WIDTH  = 110,
+    ROW_SPLIT_WIDTH  = 105,
 };
 #endif
 

--- a/src/pages/common/_crsfconfig_page.c
+++ b/src/pages/common/_crsfconfig_page.c
@@ -21,7 +21,7 @@ crsf_device_t crsf_devices[CRSF_MAX_DEVICES];
 elrs_info_t elrs_info;
 crsf_device_t deviation = {
     .address = ADDR_RADIO,
-    .number_of_params = 1,
+    .number_of_params = 2,
     .params_version = 0,
     .serial_number = 1,
     .hardware_id = 0,

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -19,6 +19,7 @@
 #include "crsf.h"
 
 crsf_param_t crsf_params[CRSF_MAX_PARAMS];
+u8 show_hidden;
 
 static struct crsfdevice_page * const mp = &pagemem.u.crsfdevice_page;
 static struct crsfdevice_obj * const gui = &gui_objs.u.crsfdevice;
@@ -68,7 +69,7 @@ crsf_param_t *current_param(int absrow) {
 
     for (int i=0; i < crsf_devices[device_idx].number_of_params; i++) {
         if (!crsf_params[i].id) break;
-        if (crsf_params[i].parent != current_folder || crsf_params[i].hidden) continue;
+        if (crsf_params[i].parent != current_folder || (!show_hidden && crsf_params[i].hidden)) continue;
         if (idx++ == absrow) return &crsf_params[i];
     }
     return NULL;
@@ -158,7 +159,7 @@ static int folder_rows(int folder) {
     for (int i=0; i < crsf_devices[device_idx].number_of_params; i++)
         if (crsf_params[i].loaded
          && crsf_params[i].parent == folder
-         && !crsf_params[i].hidden)
+         && (show_hidden || !crsf_params[i].hidden))
             count += 1;
 
     return count;
@@ -562,7 +563,7 @@ static u8 param_len(crsf_param_t *param) {
 
 void CRSF_set_param(crsf_param_t *param) {
     if (crsf_devices[param->device].address == ADDR_RADIO) {
-        protocol_set_param((u8)param->u.text_sel);  // only one radio param so don't need id
+        protocol_set_param(param);
         return;
     }
 

--- a/src/pages/common/_crsfdevice_page.c
+++ b/src/pages/common/_crsfdevice_page.c
@@ -782,6 +782,9 @@ static void add_param(u8 *buffer, u8 num_bytes) {
         return;
     }
 
+    // ignore unsolicited update from TBS
+    if (next_param == 0) return;
+
     memcpy(recv_param_ptr, buffer+5, num_bytes-5);
     recv_param_ptr += num_bytes - 5;
 
@@ -810,7 +813,7 @@ static void add_param(u8 *buffer, u8 num_bytes) {
     parameter->id = buffer[3];
     parameter->parent = *recv_param_ptr++;
     parameter->type = *recv_param_ptr & 0x7f;
-    parameter->hidden = *recv_param_ptr++ & 0x80;
+    parameter->hidden = *recv_param_ptr++ >> 7;
 
     u8 name_size = strlen(recv_param_ptr) + 1;
     parameter->name = alloc_string(name_size);


### PR DESCRIPTION
- hidden flag was not set correctly
- TBS param echo caused page update problem
- Fix overlap by a few pixels
- Add Show Hidden protocol option to display CRSF config parameters even when they're marked hidden.

The only place I know hidden parameters are used is in the TBS Radio Settings folder.  Setting the Region to anything but Open changes the Region and Frequency parameters to hidden.  The Multi-Bind option is hidden unless the tx is registered with TBS.
The Show Hidden option can be used to change the Region even if was previously changed to something other than Open.  Changing the Multi-Bind option has no effect - the display will change back to Disabled after the change is sent to the tx.  It can only be Enabled if the tx is registered.  Changes to the Frequency when the Region is not Open appear to be accepted by the tx but did not test if the changes have any effect. 