### PR TITLE
Update HonTai protocol with format to support WlToys XKK170 heli

### DIFF
--- a/src/protocol/hontai_nrf24l01.c
+++ b/src/protocol/hontai_nrf24l01.c
@@ -176,7 +176,6 @@ static s8 scale_channel_s8(u8 ch, s8 start, s8 end)
     return (range * (chanval - CHAN_MIN_VALUE + round)) / CHAN_RANGE + start;
 }
 
-// k170 uses unsigned channel values
 static u8 scale_channel_u8(u8 ch, u8 start, u8 end)
 {
     s32 range = end - start;
@@ -209,6 +208,9 @@ static void send_packet(u8 bind)
             packet[4] = scale_channel_u8(CHANNEL1, 0x28, 0xd8); // aileron
             packet[5] = scale_channel_u8(CHANNEL2, 0x28, 0xd8); // elevator
             packet[6] = scale_channel_u8(CHANNEL4, 0xd8, 0x28); // rudder
+            // drive trims for extra control throw
+            packet[7] = scale_channel_s8(CHANNEL1,  32, -32); // aileron trim
+            packet[9] = scale_channel_s8(CHANNEL2, -32,  32); // elevator trim
         }
         
         // feature flags

--- a/src/protocol/hontai_nrf24l01.c
+++ b/src/protocol/hontai_nrf24l01.c
@@ -189,14 +189,15 @@ static void send_packet(u8 bind)
             packet[4] = scale_channel(CHANNEL1, 0x3f, 0x01); // aileron   
             packet[5] = scale_channel(CHANNEL2, 0x01, 0x3f); // elevator
             packet[6] = scale_channel(CHANNEL4, 0x3f, 0x01); // rudder  
+            // drive trims for extra control throw
+            packet[7] = scale_channel(CHANNEL1, -16, 16); // aileron trim
+            packet[8] = scale_channel(CHANNEL4, -16, 16); // rudder trim
+            packet[9] = scale_channel(CHANNEL2, -16, 16); // elevator trim
         } else {
             packet[4] = scale_channel(CHANNEL1, 0x28, 0xd8); // aileron   
-            packet[5] = scale_channel(CHANNEL2, 0xd8, 0x28); // elevator
-            packet[6] = scale_channel(CHANNEL4, 0x28, 0xd8); // rudder  
+            packet[5] = scale_channel(CHANNEL2, 0x28, 0xd8); // elevator
+            packet[6] = scale_channel(CHANNEL4, 0xd8, 0x28); // rudder  
         }
-        packet[7] = scale_channel(CHANNEL1, -16, 16); // aileron trim
-        packet[8] = scale_channel(CHANNEL4, -16, 16); // rudder trim
-        packet[9] = scale_channel(CHANNEL2, -16, 16); // elevator trim
         
         // feature flags
         switch(Model.proto_opts[PROTOOPTS_FORMAT]) {

--- a/src/protocol/hontai_nrf24l01.c
+++ b/src/protocol/hontai_nrf24l01.c
@@ -176,6 +176,18 @@ static s8 scale_channel(u8 ch, s8 start, s8 end)
     return (range * (chanval - CHAN_MIN_VALUE + round)) / CHAN_RANGE + start;
 }
 
+// k170 uses unsigned channel values
+static u8 scale_chan_k170(u8 ch, u8 start, u8 end)
+{
+    s32 range = end - start;
+    s32 chanval = Channels[ch];
+
+    if      (chanval < CHAN_MIN_VALUE) chanval = CHAN_MIN_VALUE;
+    else if (chanval > CHAN_MAX_VALUE) chanval = CHAN_MAX_VALUE;
+
+    return (range * (chanval - CHAN_MIN_VALUE)) / CHAN_RANGE + start;
+}
+
 #define GET_FLAG(ch, mask) (Channels[ch] > 0 ? mask : 0)
 static void send_packet(u8 bind)
 {
@@ -184,8 +196,8 @@ static void send_packet(u8 bind)
         memset(&packet[5], 0, 3);
     } else {
         memset(packet,0,PACKET_SIZE);
-        packet[3] = scale_channel(CHANNEL3, 0x00, 0x7f) << 1; // throttle
         if (Model.proto_opts[PROTOOPTS_FORMAT] != FORMAT_XKK170) {
+            packet[3] = scale_channel(CHANNEL3, 0x00, 0x7f) << 1; // throttle
             packet[4] = scale_channel(CHANNEL1, 0x3f, 0x01); // aileron   
             packet[5] = scale_channel(CHANNEL2, 0x01, 0x3f); // elevator
             packet[6] = scale_channel(CHANNEL4, 0x3f, 0x01); // rudder  
@@ -194,9 +206,10 @@ static void send_packet(u8 bind)
             packet[8] = scale_channel(CHANNEL4, -16, 16); // rudder trim
             packet[9] = scale_channel(CHANNEL2, -16, 16); // elevator trim
         } else {
-            packet[4] = scale_channel(CHANNEL1, 0x28, 0xd8); // aileron   
-            packet[5] = scale_channel(CHANNEL2, 0x28, 0xd8); // elevator
-            packet[6] = scale_channel(CHANNEL4, 0xd8, 0x28); // rudder  
+            packet[3] = scale_chan_k170(CHANNEL3, 0x00, 0xff); // throttle
+            packet[4] = scale_chan_k170(CHANNEL1, 0x28, 0xd8); // aileron
+            packet[5] = scale_chan_k170(CHANNEL2, 0x28, 0xd8); // elevator
+            packet[6] = scale_chan_k170(CHANNEL4, 0xd8, 0x28); // rudder
         }
         
         // feature flags


### PR DESCRIPTION
The HonTai protocol has a new format option XKK170.
Channels 1-4 are AETR respectively.
Channel 5 is gyro calibration. This is a "momentary" switch.  Set value greater than zero to initiate calibration, then back to less than zero.
Channel 6 is takeoff/landing. Also momentary.
Channel 7 is emergency. Also momentary.

Deviation doesn't implement rate selection in these protocols. The rate is fixed at high and the mixers should be used to tone down the flight controls as needed.  The protocol aileron and elevator trim channels are used to extend control throw.  Use deviation trims to get level flight with controls at neutral.