### PR TITLE
Fix crash when opening telemetry monitor for FrSky

### DIFF
--- a/src/pages/text/guiobj.h
+++ b/src/pages/text/guiobj.h
@@ -140,7 +140,7 @@ struct telemcfg_obj {
 struct telemtest_obj {
     guiLabel_t msg;
     guiLabel_t header[SCROLLABLE_ROWS];
-    guiLabel_t box[31];
+    guiLabel_t box[39];
     guiScrollable_t scrollable;
 };
 


### PR DESCRIPTION
Telemetry monitor did only show a single box centered and was crashing my F12e seconds later.